### PR TITLE
PR: Complete ACP protocol implementation, sandbox hardening, and acpws proxy support

### DIFF
--- a/acp/client.go
+++ b/acp/client.go
@@ -292,9 +292,9 @@ func (s *Session) LoadSession(ctx context.Context, req LoadSessionRequest) (*Loa
 	}
 
 	_, err := s.conn.ResumeSession(ctx, acpsdk.ResumeSessionRequest{
-		SessionId:            acpsdk.SessionId(req.SessionID),
-		Cwd:                  req.Cwd,
-		McpServers:           mcpServers,
+		SessionId:             acpsdk.SessionId(req.SessionID),
+		Cwd:                   req.Cwd,
+		McpServers:            mcpServers,
 		AdditionalDirectories: req.AdditionalDirectories,
 	})
 	if err != nil {
@@ -503,6 +503,11 @@ func (b *sessionBridge) SessionUpdate(ctx context.Context, params acpsdk.Session
 				Size: update.UsageUpdate.Size,
 			})
 		}
+
+	case update.ConfigOptionUpdate != nil:
+		if coh, ok := h.(ConfigOptionHandler); ok {
+			coh.OnConfigOptionUpdate(fromSDKConfigOptions(update.ConfigOptionUpdate.ConfigOptions))
+		}
 	}
 
 	return nil
@@ -510,11 +515,50 @@ func (b *sessionBridge) SessionUpdate(ctx context.Context, params acpsdk.Session
 
 // Other Client methods — return "not supported".
 func (b *sessionBridge) RequestPermission(ctx context.Context, params acpsdk.RequestPermissionRequest) (acpsdk.RequestPermissionResponse, error) {
+	h := b.getHandler()
+	if h == nil {
+		return cancelledPermissionResponse(), nil
+	}
+	ph, ok := h.(PermissionHandler)
+	if !ok {
+		return cancelledPermissionResponse(), nil
+	}
+
+	options := make([]PermissionOption, len(params.Options))
+	for i, o := range params.Options {
+		options[i] = PermissionOption{
+			Kind:     string(o.Kind),
+			Name:     o.Name,
+			OptionID: string(o.OptionId),
+		}
+	}
+
+	tc := ToolCallEvent{ID: string(params.ToolCall.ToolCallId)}
+	if params.ToolCall.Title != nil {
+		tc.Title = *params.ToolCall.Title
+	}
+	tc.RawInput = params.ToolCall.RawInput
+
+	outcome := ph.OnRequestPermission(options, tc)
+	if outcome.Cancelled {
+		return cancelledPermissionResponse(), nil
+	}
+	return acpsdk.RequestPermissionResponse{
+		Outcome: acpsdk.RequestPermissionOutcome{
+			Selected: &acpsdk.RequestPermissionOutcomeSelected{
+				Outcome:  "selected",
+				OptionId: acpsdk.PermissionOptionId(outcome.OptionID),
+			},
+		},
+	}, nil
+}
+
+func cancelledPermissionResponse() acpsdk.RequestPermissionResponse {
 	return acpsdk.RequestPermissionResponse{
 		Outcome: acpsdk.RequestPermissionOutcome{
 			Cancelled: &acpsdk.RequestPermissionOutcomeCancelled{Outcome: "cancelled"},
 		},
-	}, nil
+	}
 }
 
 func (b *sessionBridge) ReadTextFile(ctx context.Context, params acpsdk.ReadTextFileRequest) (acpsdk.ReadTextFileResponse, error) {

--- a/acp/client.go
+++ b/acp/client.go
@@ -308,6 +308,50 @@ func (s *Session) LoadSession(ctx context.Context, req LoadSessionRequest) (*Loa
 	return &LoadSessionResponse{}, nil
 }
 
+// SetSessionConfigOption sends a config option change to the agent.
+func (s *Session) SetSessionConfigOption(ctx context.Context, sessionID string, opt SetConfigOption) error {
+	var req acpsdk.SetSessionConfigOptionRequest
+	switch opt.Value.(type) {
+	case bool:
+		v := opt.Value.(bool)
+		req.Boolean = &acpsdk.SetSessionConfigOptionBoolean{
+			SessionId: acpsdk.SessionId(sessionID),
+			ConfigId:  acpsdk.SessionConfigId(opt.ID),
+			Value:     v,
+			Type:      "boolean",
+		}
+	default:
+		v, _ := opt.Value.(string)
+		req.ValueId = &acpsdk.SetSessionConfigOptionValueId{
+			SessionId: acpsdk.SessionId(sessionID),
+			ConfigId:  acpsdk.SessionConfigId(opt.ID),
+			Value:     acpsdk.SessionConfigValueId(v),
+		}
+	}
+	_, err := s.conn.SetSessionConfigOption(ctx, req)
+	return err
+}
+
+// SetSessionMode changes the session mode on the agent.
+func (s *Session) SetSessionMode(ctx context.Context, sessionID string, modeID string) error {
+	_, err := s.conn.SetSessionMode(ctx, acpsdk.SetSessionModeRequest{
+		SessionId: acpsdk.SessionId(sessionID),
+		ModeId:    acpsdk.SessionModeId(modeID),
+	})
+	return err
+}
+
+// ForkSession creates a new session by forking an existing one on the agent.
+func (s *Session) ForkSession(ctx context.Context, sessionID string) (*ForkSessionResponse, error) {
+	resp, err := s.conn.UnstableForkSession(ctx, acpsdk.UnstableForkSessionRequest{
+		SessionId: acpsdk.SessionId(sessionID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("acp fork session: %w", err)
+	}
+	return &ForkSessionResponse{SessionID: string(resp.SessionId)}, nil
+}
+
 // Close terminates the ACP connection and cleans up the subprocess.
 //
 // It first closes stdin to signal EOF to the process, allowing it to exit
@@ -419,6 +463,46 @@ func (b *sessionBridge) SessionUpdate(ctx context.Context, params acpsdk.Session
 			Status:    status,
 			RawOutput: tu.RawOutput,
 		})
+
+	case update.Plan != nil:
+		if ph, ok := h.(PlanHandler); ok {
+			entries := make([]PlanEntry, len(update.Plan.Entries))
+			for i, e := range update.Plan.Entries {
+				entries[i] = PlanEntry{
+					Title:    e.Content,
+					Priority: string(e.Priority),
+					Status:   string(e.Status),
+				}
+			}
+			ph.OnPlan(entries)
+		}
+
+	case update.AvailableCommandsUpdate != nil:
+		if ch, ok := h.(CommandHandler); ok {
+			cmds := make([]AvailableCommand, len(update.AvailableCommandsUpdate.AvailableCommands))
+			for i, c := range update.AvailableCommandsUpdate.AvailableCommands {
+				cmds[i] = AvailableCommand{Name: c.Name, Description: c.Description}
+			}
+			ch.OnAvailableCommands(cmds)
+		}
+
+	case update.CurrentModeUpdate != nil:
+		if mh, ok := h.(ModeHandler); ok {
+			mh.OnCurrentMode(string(update.CurrentModeUpdate.CurrentModeId))
+		}
+
+	case update.UserMessageChunk != nil:
+		if mh, ok := h.(ModeHandler); ok {
+			mh.OnUserMessage(contentBlockTextSDK(update.UserMessageChunk.Content))
+		}
+
+	case update.UsageUpdate != nil:
+		if uh, ok := h.(UsageHandler); ok {
+			uh.OnUsage(UsageInfo{
+				Used: update.UsageUpdate.Used,
+				Size: update.UsageUpdate.Size,
+			})
+		}
 	}
 
 	return nil

--- a/acp/compat.go
+++ b/acp/compat.go
@@ -1,0 +1,156 @@
+package acp
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log"
+)
+
+type acpCompatReader struct {
+	raw        io.Reader
+	writer     io.Writer
+	rawBuf     []byte
+	out        bytes.Buffer
+	defaultCwd string
+}
+
+func newACPCompatReader(rawReader io.Reader, writer io.Writer) *acpCompatReader {
+	return &acpCompatReader{
+		raw:        rawReader,
+		writer:     writer,
+		defaultCwd: "/",
+	}
+}
+
+func (r *acpCompatReader) Read(p []byte) (int, error) {
+	if r.out.Len() > 0 {
+		return r.out.Read(p)
+	}
+
+	for {
+		line, err := r.readLine()
+		if err != nil {
+			return 0, err
+		}
+		if len(line) == 0 {
+			continue
+		}
+
+		result := r.processLine(line)
+		if result == nil {
+			continue
+		}
+
+		r.out.Write(result)
+		r.out.WriteByte('\n')
+		return r.out.Read(p)
+	}
+}
+
+func (r *acpCompatReader) readLine() ([]byte, error) {
+	for {
+		if idx := bytes.IndexByte(r.rawBuf, '\n'); idx != -1 {
+			line := r.rawBuf[:idx]
+			r.rawBuf = r.rawBuf[idx+1:]
+			return line, nil
+		}
+		tmp := make([]byte, 4096)
+		n, err := r.raw.Read(tmp)
+		if n > 0 {
+			r.rawBuf = append(r.rawBuf, tmp[:n]...)
+		}
+		if err != nil {
+			if len(r.rawBuf) > 0 {
+				line := r.rawBuf
+				r.rawBuf = nil
+				return line, nil
+			}
+			return nil, err
+		}
+	}
+}
+
+func (r *acpCompatReader) processLine(line []byte) []byte {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(line, &raw); err != nil {
+		return line
+	}
+
+	methodRaw, hasMethod := raw["method"]
+	if !hasMethod {
+		return line
+	}
+
+	var method string
+	json.Unmarshal(methodRaw, &method)
+
+	switch method {
+	case "session/setup":
+		r.handleSessionSetup(raw)
+		return nil
+
+	case "session/resume", "session/load":
+		return r.injectCwd(raw, line)
+	}
+
+	return line
+}
+
+func (r *acpCompatReader) handleSessionSetup(raw map[string]json.RawMessage) {
+	idRaw, hasID := raw["id"]
+	if !hasID {
+		return
+	}
+
+	resp := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      json.RawMessage(idRaw),
+		"result": map[string]interface{}{
+			"configOptions": []interface{}{},
+		},
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		log.Printf("acp compat: marshal session/setup response: %v", err)
+		return
+	}
+	if _, err := r.writer.Write(append(data, '\n')); err != nil {
+		log.Printf("acp compat: write session/setup response: %v", err)
+	}
+}
+
+func (r *acpCompatReader) injectCwd(raw map[string]json.RawMessage, originalLine []byte) []byte {
+	paramsRaw, hasParams := raw["params"]
+	if !hasParams {
+		return originalLine
+	}
+
+	var params map[string]interface{}
+	if err := json.Unmarshal(paramsRaw, &params); err != nil {
+		return originalLine
+	}
+
+	cwd, exists := params["cwd"]
+	if exists {
+		if cwdStr, ok := cwd.(string); ok && cwdStr != "" {
+			return originalLine
+		}
+	}
+	params["cwd"] = r.defaultCwd
+
+	newParams, err := json.Marshal(params)
+	if err != nil {
+		return originalLine
+	}
+	raw["params"] = newParams
+
+	newLine, err := json.Marshal(raw)
+	if err != nil {
+		return originalLine
+	}
+	return newLine
+}
+
+// Compile-time check.
+var _ io.Reader = (*acpCompatReader)(nil)

--- a/acp/server.go
+++ b/acp/server.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"log/slog"
 	"os"
 	"sync"
+	"time"
 
 	acpsdk "github.com/coder/acp-go-sdk"
 )
@@ -52,7 +54,7 @@ type AgentHandler interface {
 // ConfigHandler is an optional extension of [AgentHandler]. Implement it
 // to support session/config_set and session/mode changes.
 type ConfigHandler interface {
-	OnSetSessionConfigOption(ctx context.Context, sessionID string, opt SetConfigOption) error
+	OnSetSessionConfigOption(ctx context.Context, sessionID string, opt SetConfigOption) ([]SessionConfigOption, error)
 	OnSetSessionMode(ctx context.Context, sessionID string, modeID string) error
 }
 
@@ -94,6 +96,10 @@ type SessionEventSender interface {
 
 	// SendUsage reports token counts and context window size.
 	SendUsage(info UsageInfo) error
+
+	// SendConfigOptionUpdate pushes the full set of config options and
+	// their current values to the client.
+	SendConfigOptionUpdate(opts []SessionConfigOption) error
 }
 
 // ── Server ──
@@ -279,6 +285,7 @@ func (b *agentBridge) NewSession(ctx context.Context, params acpsdk.NewSessionRe
 
 func (b *agentBridge) Prompt(ctx context.Context, params acpsdk.PromptRequest) (acpsdk.PromptResponse, error) {
 	sessionID := string(params.SessionId)
+	log.Printf("acp bridge Prompt: session=%s", sessionID)
 
 	sender := &agentSender{
 		sessionID: sessionID,
@@ -288,6 +295,11 @@ func (b *agentBridge) Prompt(ctx context.Context, params acpsdk.PromptRequest) (
 
 	b.setSender(sessionID, sender)
 	defer b.deleteSender(sessionID)
+
+	if pr, ok := b.handler.(PermissionRegistrar); ok {
+		pr.RegisterPermissionRequester(sessionID, sender)
+		defer pr.UnregisterPermissionRequester(sessionID)
+	}
 
 	blocks := make([]ContentBlock, len(params.Prompt))
 	for i, pb := range params.Prompt {
@@ -301,9 +313,11 @@ func (b *agentBridge) Prompt(ctx context.Context, params acpsdk.PromptRequest) (
 		Blocks:    blocks,
 	}, sender)
 	if err != nil {
+		log.Printf("acp bridge Prompt: OnPrompt error: %v", err)
 		return acpsdk.PromptResponse{}, err
 	}
 
+	log.Printf("acp bridge Prompt: done, stopReason=%s", resp.StopReason)
 	return acpsdk.PromptResponse{
 		StopReason: acpsdk.StopReason(resp.StopReason),
 	}, nil
@@ -367,9 +381,9 @@ func (b *agentBridge) ResumeSession(ctx context.Context, params acpsdk.ResumeSes
 	sessionID := string(params.SessionId)
 	sender := &agentSender{sessionID: sessionID, bridge: b, conn: b.conn}
 	_, err := b.handler.OnLoadSession(ctx, LoadSessionRequest{
-		SessionID:            sessionID,
-		Cwd:                  params.Cwd,
-		McpServers:           mcpServers,
+		SessionID:             sessionID,
+		Cwd:                   params.Cwd,
+		McpServers:            mcpServers,
 		AdditionalDirectories: params.AdditionalDirectories,
 	}, sender)
 	if err != nil {
@@ -390,9 +404,9 @@ func (b *agentBridge) LoadSession(ctx context.Context, params acpsdk.LoadSession
 	sessionID := string(params.SessionId)
 	sender := &agentSender{sessionID: sessionID, bridge: b, conn: b.conn}
 	_, err := b.handler.OnLoadSession(ctx, LoadSessionRequest{
-		SessionID:            sessionID,
-		Cwd:                  params.Cwd,
-		McpServers:           mcpServers,
+		SessionID:             sessionID,
+		Cwd:                   params.Cwd,
+		McpServers:            mcpServers,
 		AdditionalDirectories: params.AdditionalDirectories,
 	}, sender)
 	if err != nil {
@@ -421,8 +435,12 @@ func (b *agentBridge) SetSessionConfigOption(ctx context.Context, params acpsdk.
 		opt.Value = string(params.ValueId.Value)
 	}
 
-	if err := ch.OnSetSessionConfigOption(ctx, sessionID, opt); err != nil {
+	if updatedOpts, err := ch.OnSetSessionConfigOption(ctx, sessionID, opt); err != nil {
 		return acpsdk.SetSessionConfigOptionResponse{}, err
+	} else if len(updatedOpts) > 0 {
+		if sender := b.getSender(sessionID); sender != nil {
+			sender.SendConfigOptionUpdate(updatedOpts)
+		}
 	}
 	return acpsdk.SetSessionConfigOptionResponse{}, nil
 }
@@ -477,13 +495,18 @@ type agentSender struct {
 
 func (s *agentSender) SendAgentMessage(text string) error {
 	if s.conn == nil {
+		log.Printf("acp SendAgentMessage: conn is nil, text=%q", text[:min(len(text), 100)])
 		return nil
 	}
 	content := acpsdk.ContentBlock{Text: &acpsdk.ContentBlockText{Text: text}}
-	return s.conn.SessionUpdate(context.Background(), acpsdk.SessionNotification{
+	err := s.conn.SessionUpdate(context.Background(), acpsdk.SessionNotification{
 		SessionId: acpsdk.SessionId(s.sessionID),
 		Update:    acpsdk.UpdateAgentMessage(content),
 	})
+	if err != nil {
+		log.Printf("acp SendAgentMessage: SessionUpdate error: %v", err)
+	}
+	return err
 }
 
 func (s *agentSender) SendAgentThought(text string) error {
@@ -623,22 +646,83 @@ func (s *agentSender) SendUsage(info UsageInfo) error {
 	})
 }
 
+func (s *agentSender) SendConfigOptionUpdate(opts []SessionConfigOption) error {
+	if s.conn == nil {
+		return nil
+	}
+	return s.conn.SessionUpdate(context.Background(), acpsdk.SessionNotification{
+		SessionId: acpsdk.SessionId(s.sessionID),
+		Update: acpsdk.SessionUpdate{
+			ConfigOptionUpdate: &acpsdk.SessionConfigOptionUpdate{
+				ConfigOptions: convertConfigOptions(opts),
+				SessionUpdate: "configOptionUpdate",
+			},
+		},
+	})
+}
+
+func (s *agentSender) RequestPermission(ctx context.Context, toolCall ToolCallEvent, options []PermissionOption) (PermissionOutcome, error) {
+	if s.conn == nil {
+		return PermissionOutcome{Cancelled: true}, nil
+	}
+	sdkOpts := make([]acpsdk.PermissionOption, len(options))
+	for i, o := range options {
+		sdkOpts[i] = acpsdk.PermissionOption{
+			Kind:     acpsdk.PermissionOptionKind(o.Kind),
+			Name:     o.Name,
+			OptionId: acpsdk.PermissionOptionId(o.OptionID),
+		}
+	}
+	title := toolCall.Title
+	status := acpsdk.ToolCallStatusInProgress
+	reqCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	resp, err := s.conn.RequestPermission(reqCtx, acpsdk.RequestPermissionRequest{
+		Options:   sdkOpts,
+		SessionId: acpsdk.SessionId(s.sessionID),
+		ToolCall: acpsdk.ToolCallUpdate{
+			ToolCallId: acpsdk.ToolCallId(toolCall.ID),
+			Title:      &title,
+			RawInput:   toolCall.RawInput,
+			Status:     &status,
+		},
+	})
+	if err != nil {
+		return PermissionOutcome{Cancelled: true}, err
+	}
+	if resp.Outcome.Cancelled != nil {
+		return PermissionOutcome{Cancelled: true}, nil
+	}
+	if resp.Outcome.Selected != nil {
+		return PermissionOutcome{OptionID: string(resp.Outcome.Selected.OptionId)}, nil
+	}
+	return PermissionOutcome{Cancelled: true}, nil
+}
+
 // ── Helpers ──
 
 func sessionListCapPtr(ok bool) *acpsdk.SessionListCapabilities {
-	if !ok { return nil }
+	if !ok {
+		return nil
+	}
 	return &acpsdk.SessionListCapabilities{}
 }
 func sessionResumeCapPtr(ok bool) *acpsdk.SessionResumeCapabilities {
-	if !ok { return nil }
+	if !ok {
+		return nil
+	}
 	return &acpsdk.SessionResumeCapabilities{}
 }
 func sessionDeleteCapPtr(ok bool) *acpsdk.SessionDeleteCapabilities {
-	if !ok { return nil }
+	if !ok {
+		return nil
+	}
 	return &acpsdk.SessionDeleteCapabilities{}
 }
 func sessionCloseCapPtr(ok bool) *acpsdk.SessionCloseCapabilities {
-	if !ok { return nil }
+	if !ok {
+		return nil
+	}
 	return &acpsdk.SessionCloseCapabilities{}
 }
 

--- a/acp/server.go
+++ b/acp/server.go
@@ -142,9 +142,8 @@ func (s *Server) SetLogger(l *slog.Logger) { s.logger = l }
 //
 // For custom transports, use [Server.RunTransport].
 func (s *Server) Run(ctx context.Context) error {
-	// For a subprocess agent: we read ACP requests from stdin,
-	// and write ACP responses/notifications to stdout.
-	return s.RunTransport(ctx, os.Stdout, os.Stdin)
+	compatReader := newACPCompatReader(os.Stdin, os.Stdout)
+	return s.RunTransport(ctx, os.Stdout, compatReader)
 }
 
 // RunTransport starts the ACP server on custom I/O streams.

--- a/acp/server.go
+++ b/acp/server.go
@@ -481,7 +481,8 @@ func (s *agentSender) SendAgentMessage(text string) error {
 	}
 	content := acpsdk.ContentBlock{Text: &acpsdk.ContentBlockText{Text: text}}
 	return s.conn.SessionUpdate(context.Background(), acpsdk.SessionNotification{
-		Update: acpsdk.UpdateAgentMessage(content),
+		SessionId: acpsdk.SessionId(s.sessionID),
+		Update:    acpsdk.UpdateAgentMessage(content),
 	})
 }
 
@@ -491,7 +492,8 @@ func (s *agentSender) SendAgentThought(text string) error {
 	}
 	content := acpsdk.ContentBlock{Text: &acpsdk.ContentBlockText{Text: text}}
 	return s.conn.SessionUpdate(context.Background(), acpsdk.SessionNotification{
-		Update: acpsdk.UpdateAgentThought(content),
+		SessionId: acpsdk.SessionId(s.sessionID),
+		Update:    acpsdk.UpdateAgentThought(content),
 	})
 }
 
@@ -515,7 +517,8 @@ func (s *agentSender) SendToolCall(tc ToolCallEvent) error {
 			acpsdk.WithStartRawInput(tc.RawInput))
 	}
 	return s.conn.SessionUpdate(context.Background(), acpsdk.SessionNotification{
-		Update: update,
+		SessionId: acpsdk.SessionId(s.sessionID),
+		Update:    update,
 	})
 }
 

--- a/acp/server.go
+++ b/acp/server.go
@@ -34,9 +34,9 @@ type AgentHandler interface {
 	OnCancel(ctx context.Context, sessionID string) error
 
 	// OnLoadSession is called when the client requests to resume an existing
-	// session. The handler should restore the session state and return the
-	// session ID if successful.
-	OnLoadSession(ctx context.Context, req LoadSessionRequest) (*LoadSessionResponse, error)
+	// session. The handler should restore the session state and use sender
+	// to replay conversation history to the client.
+	OnLoadSession(ctx context.Context, req LoadSessionRequest, sender SessionEventSender) (*LoadSessionResponse, error)
 
 	// OnListSessions returns the sessions available for loading via OnLoadSession.
 	OnListSessions(ctx context.Context, req ListSessionsRequest) (*ListSessionsResponse, error)
@@ -47,6 +47,19 @@ type AgentHandler interface {
 
 	// OnCloseSession is called when the client closes a session.
 	OnCloseSession(ctx context.Context, sessionID string) error
+}
+
+// ConfigHandler is an optional extension of [AgentHandler]. Implement it
+// to support session/config_set and session/mode changes.
+type ConfigHandler interface {
+	OnSetSessionConfigOption(ctx context.Context, sessionID string, opt SetConfigOption) error
+	OnSetSessionMode(ctx context.Context, sessionID string, modeID string) error
+}
+
+// SessionAdminHandler is an optional extension of [AgentHandler]. Implement
+// it to support session/fork.
+type SessionAdminHandler interface {
+	OnForkSession(ctx context.Context, req ForkSessionRequest) (*ForkSessionResponse, error)
 }
 
 // SessionEventSender sends streaming events from the agent back to the
@@ -63,6 +76,24 @@ type SessionEventSender interface {
 
 	// SendSessionInfo updates session metadata (title, timestamps).
 	SendSessionInfo(title string, metadata map[string]any) error
+
+	// SendUserMessage sends a chunk of the user's message (e.g. textified
+	// image descriptions). Use this to echo back interpreted user input.
+	SendUserMessage(text string) error
+
+	// SendPlan sends or updates the agent's execution plan. Pass nil or
+	// empty slice to clear the plan.
+	SendPlan(entries []PlanEntry) error
+
+	// SendAvailableCommands declares the commands the agent supports
+	// (e.g. /help, /clear). Clients may render these as slash-commands.
+	SendAvailableCommands(commands []AvailableCommand) error
+
+	// SendCurrentMode notifies the client about the current session mode.
+	SendCurrentMode(modeID string) error
+
+	// SendUsage reports token counts and context window size.
+	SendUsage(info UsageInfo) error
 }
 
 // ── Server ──
@@ -333,22 +364,76 @@ func (b *agentBridge) ResumeSession(ctx context.Context, params acpsdk.ResumeSes
 		mcpServers = append(mcpServers, fromSDKMcpServer(m))
 	}
 
+	sessionID := string(params.SessionId)
+	sender := &agentSender{sessionID: sessionID, bridge: b, conn: b.conn}
 	_, err := b.handler.OnLoadSession(ctx, LoadSessionRequest{
-		SessionID:            string(params.SessionId),
+		SessionID:            sessionID,
 		Cwd:                  params.Cwd,
 		McpServers:           mcpServers,
 		AdditionalDirectories: params.AdditionalDirectories,
-	})
+	}, sender)
 	if err != nil {
 		return acpsdk.ResumeSessionResponse{}, err
 	}
 
 	return acpsdk.ResumeSessionResponse{}, nil
 }
+
+// LoadSession implements acpsdk.AgentLoader so clients can restore a
+// previously saved session via session/load.
+func (b *agentBridge) LoadSession(ctx context.Context, params acpsdk.LoadSessionRequest) (acpsdk.LoadSessionResponse, error) {
+	mcpServers := make([]McpServer, 0, len(params.McpServers))
+	for _, m := range params.McpServers {
+		mcpServers = append(mcpServers, fromSDKMcpServer(m))
+	}
+
+	sessionID := string(params.SessionId)
+	sender := &agentSender{sessionID: sessionID, bridge: b, conn: b.conn}
+	_, err := b.handler.OnLoadSession(ctx, LoadSessionRequest{
+		SessionID:            sessionID,
+		Cwd:                  params.Cwd,
+		McpServers:           mcpServers,
+		AdditionalDirectories: params.AdditionalDirectories,
+	}, sender)
+	if err != nil {
+		return acpsdk.LoadSessionResponse{}, err
+	}
+
+	return acpsdk.LoadSessionResponse{}, nil
+}
+
 func (b *agentBridge) SetSessionConfigOption(ctx context.Context, params acpsdk.SetSessionConfigOptionRequest) (acpsdk.SetSessionConfigOptionResponse, error) {
+	ch, ok := b.handler.(ConfigHandler)
+	if !ok {
+		return acpsdk.SetSessionConfigOptionResponse{}, nil
+	}
+
+	var sessionID string
+	var opt SetConfigOption
+
+	if params.Boolean != nil {
+		sessionID = string(params.Boolean.SessionId)
+		opt.ID = string(params.Boolean.ConfigId)
+		opt.Value = params.Boolean.Value
+	} else if params.ValueId != nil {
+		sessionID = string(params.ValueId.SessionId)
+		opt.ID = string(params.ValueId.ConfigId)
+		opt.Value = string(params.ValueId.Value)
+	}
+
+	if err := ch.OnSetSessionConfigOption(ctx, sessionID, opt); err != nil {
+		return acpsdk.SetSessionConfigOptionResponse{}, err
+	}
 	return acpsdk.SetSessionConfigOptionResponse{}, nil
 }
 func (b *agentBridge) SetSessionMode(ctx context.Context, params acpsdk.SetSessionModeRequest) (acpsdk.SetSessionModeResponse, error) {
+	ch, ok := b.handler.(ConfigHandler)
+	if !ok {
+		return acpsdk.SetSessionModeResponse{}, nil
+	}
+	if err := ch.OnSetSessionMode(ctx, string(params.SessionId), string(params.ModeId)); err != nil {
+		return acpsdk.SetSessionModeResponse{}, err
+	}
 	return acpsdk.SetSessionModeResponse{}, nil
 }
 
@@ -361,6 +446,23 @@ func (b *agentBridge) UnstableDeleteSession(ctx context.Context, params acpsdk.U
 		return acpsdk.UnstableDeleteSessionResponse{}, err
 	}
 	return acpsdk.UnstableDeleteSessionResponse{}, nil
+}
+
+// UnstableForkSession implements the SDK's optional session/fork interface.
+func (b *agentBridge) UnstableForkSession(ctx context.Context, params acpsdk.UnstableForkSessionRequest) (acpsdk.UnstableForkSessionResponse, error) {
+	sh, ok := b.handler.(SessionAdminHandler)
+	if !ok {
+		return acpsdk.UnstableForkSessionResponse{}, fmt.Errorf("not supported")
+	}
+	resp, err := sh.OnForkSession(ctx, ForkSessionRequest{
+		SessionID: string(params.SessionId),
+	})
+	if err != nil {
+		return acpsdk.UnstableForkSessionResponse{}, err
+	}
+	return acpsdk.UnstableForkSessionResponse{
+		SessionId: acpsdk.SessionId(resp.SessionID),
+	}, nil
 }
 
 // ── agentSender ──
@@ -432,6 +534,87 @@ func (s *agentSender) SendSessionInfo(title string, metadata map[string]any) err
 				SessionUpdate: "sessionInfoUpdate",
 				Title:         titlePtr,
 				Meta:          metadata,
+			},
+		},
+	})
+}
+
+func (s *agentSender) SendUserMessage(text string) error {
+	if s.conn == nil {
+		return nil
+	}
+	return s.conn.SessionUpdate(context.Background(), acpsdk.SessionNotification{
+		SessionId: acpsdk.SessionId(s.sessionID),
+		Update:    acpsdk.UpdateUserMessageText(text),
+	})
+}
+
+func (s *agentSender) SendPlan(entries []PlanEntry) error {
+	if s.conn == nil {
+		return nil
+	}
+	sdkEntries := make([]acpsdk.PlanEntry, len(entries))
+	for i, e := range entries {
+		sdkEntries[i] = acpsdk.PlanEntry{
+			Content:  e.Title,
+			Priority: stringToPlanPriority(e.Priority),
+			Status:   stringToPlanStatus(e.Status),
+		}
+	}
+	return s.conn.SessionUpdate(context.Background(), acpsdk.SessionNotification{
+		SessionId: acpsdk.SessionId(s.sessionID),
+		Update:    acpsdk.UpdatePlan(sdkEntries...),
+	})
+}
+
+func (s *agentSender) SendAvailableCommands(commands []AvailableCommand) error {
+	if s.conn == nil {
+		return nil
+	}
+	sdkCmds := make([]acpsdk.AvailableCommand, len(commands))
+	for i, c := range commands {
+		sdkCmds[i] = acpsdk.AvailableCommand{
+			Name:        c.Name,
+			Description: c.Description,
+		}
+	}
+	return s.conn.SessionUpdate(context.Background(), acpsdk.SessionNotification{
+		SessionId: acpsdk.SessionId(s.sessionID),
+		Update: acpsdk.SessionUpdate{
+			AvailableCommandsUpdate: &acpsdk.SessionAvailableCommandsUpdate{
+				AvailableCommands: sdkCmds,
+				SessionUpdate:     "availableCommandsUpdate",
+			},
+		},
+	})
+}
+
+func (s *agentSender) SendCurrentMode(modeID string) error {
+	if s.conn == nil {
+		return nil
+	}
+	return s.conn.SessionUpdate(context.Background(), acpsdk.SessionNotification{
+		SessionId: acpsdk.SessionId(s.sessionID),
+		Update: acpsdk.SessionUpdate{
+			CurrentModeUpdate: &acpsdk.SessionCurrentModeUpdate{
+				CurrentModeId: acpsdk.SessionModeId(modeID),
+				SessionUpdate: "currentModeUpdate",
+			},
+		},
+	})
+}
+
+func (s *agentSender) SendUsage(info UsageInfo) error {
+	if s.conn == nil {
+		return nil
+	}
+	return s.conn.SessionUpdate(context.Background(), acpsdk.SessionNotification{
+		SessionId: acpsdk.SessionId(s.sessionID),
+		Update: acpsdk.SessionUpdate{
+			UsageUpdate: &acpsdk.SessionUsageUpdate{
+				Used:          info.Used,
+				Size:          info.Size,
+				SessionUpdate: "usageUpdate",
 			},
 		},
 	})
@@ -516,3 +699,30 @@ func clientInfoVersion(info *acpsdk.Implementation) string {
 
 // Compile-time interface checks.
 var _ acpsdk.Agent = (*agentBridge)(nil)
+var _ acpsdk.AgentLoader = (*agentBridge)(nil)
+
+func stringToPlanPriority(p string) acpsdk.PlanEntryPriority {
+	switch p {
+	case "high":
+		return acpsdk.PlanEntryPriorityHigh
+	case "medium":
+		return acpsdk.PlanEntryPriorityMedium
+	case "low":
+		return acpsdk.PlanEntryPriorityLow
+	default:
+		return acpsdk.PlanEntryPriorityMedium
+	}
+}
+
+func stringToPlanStatus(s string) acpsdk.PlanEntryStatus {
+	switch s {
+	case "pending":
+		return acpsdk.PlanEntryStatusPending
+	case "in_progress":
+		return acpsdk.PlanEntryStatusInProgress
+	case "completed":
+		return acpsdk.PlanEntryStatusCompleted
+	default:
+		return acpsdk.PlanEntryStatusPending
+	}
+}

--- a/acp/types.go
+++ b/acp/types.go
@@ -176,6 +176,27 @@ type InitializeResponse struct {
 	Capabilities    AgentCapabilities
 }
 
+// ── Plan / Usage / Commands ──
+
+// PlanEntry represents a single task in the agent's execution plan.
+type PlanEntry struct {
+	Title    string // human-readable task description
+	Priority string // "high", "medium", "low"
+	Status   string // "pending", "in_progress", "completed", "cancelled"
+}
+
+// UsageInfo reports token and context window usage for a session.
+type UsageInfo struct {
+	Used int // tokens currently in context
+	Size int // total context window size in tokens
+}
+
+// AvailableCommand describes a command the agent can execute (e.g. /help, /clear).
+type AvailableCommand struct {
+	Name        string
+	Description string
+}
+
 // ── Event handler ──
 
 // EventHandler receives streaming events from the agent during Prompt.
@@ -187,6 +208,31 @@ type EventHandler interface {
 	OnToolCall(tc ToolCallEvent)
 }
 
+// PlanHandler is an optional extension of [EventHandler]. Implement it
+// to receive plan updates from the agent.
+type PlanHandler interface {
+	OnPlan(entries []PlanEntry)
+}
+
+// UsageHandler is an optional extension of [EventHandler]. Implement it
+// to receive token usage information.
+type UsageHandler interface {
+	OnUsage(info UsageInfo)
+}
+
+// CommandHandler is an optional extension of [EventHandler]. Implement it
+// to receive available command listings from the agent.
+type CommandHandler interface {
+	OnAvailableCommands(commands []AvailableCommand)
+}
+
+// ModeHandler is an optional extension of [EventHandler]. Implement it
+// to receive mode changes and user message echoes.
+type ModeHandler interface {
+	OnCurrentMode(modeID string)
+	OnUserMessage(text string)
+}
+
 // ToolCallEvent represents a tool invocation by the agent.
 type ToolCallEvent struct {
 	ID        string
@@ -194,4 +240,22 @@ type ToolCallEvent struct {
 	RawInput  any    // parameters sent to the tool
 	Status    string // "in_progress", "completed", "failed"
 	RawOutput any    // tool result (when Status == "completed")
+}
+
+// ── Config / Fork ──
+
+// SetConfigOption describes a session configuration option change.
+type SetConfigOption struct {
+	ID    string // config option ID
+	Value any    // bool for boolean options, string for select valueID
+}
+
+// ForkSessionRequest requests forking an existing session.
+type ForkSessionRequest struct {
+	SessionID string
+}
+
+// ForkSessionResponse is the result of forking a session.
+type ForkSessionResponse struct {
+	SessionID string
 }

--- a/acp/types.go
+++ b/acp/types.go
@@ -10,6 +10,8 @@
 //	openacp "github.com/yusheng-g/openagent-go/acp"
 package acp
 
+import "context"
+
 // ── Content / Prompt ──
 
 // ContentBlock represents a piece of content in a prompt.
@@ -33,16 +35,16 @@ type PromptResponse struct {
 // NewSessionRequest configures a new ACP session.
 // See: https://agentclientprotocol.com/protocol/session-setup#creating-a-session
 type NewSessionRequest struct {
-	Cwd                  string      // working directory (required)
-	McpServers           []McpServer // MCP servers the agent should connect to
-	AdditionalDirectories []string   // additional workspace roots
+	Cwd                   string      // working directory (required)
+	McpServers            []McpServer // MCP servers the agent should connect to
+	AdditionalDirectories []string    // additional workspace roots
 }
 
 // NewSessionResponse is the result of creating a session.
 type NewSessionResponse struct {
-	SessionID     string                 // unique session identifier
-	ConfigOptions []SessionConfigOption  // initial config options (if supported)
-	Modes         *SessionModeState      // initial mode state (if supported)
+	SessionID     string                // unique session identifier
+	ConfigOptions []SessionConfigOption // initial config options (if supported)
+	Modes         *SessionModeState     // initial mode state (if supported)
 }
 
 // LoadSessionRequest requests resuming an existing ACP session.
@@ -77,7 +79,7 @@ type SessionInfo struct {
 
 // ListSessionsResponse is the result of listing available sessions.
 type ListSessionsResponse struct {
-	NextCursor *string        // present if there are more results
+	NextCursor *string // present if there are more results
 	Sessions   []SessionInfo
 }
 
@@ -93,11 +95,11 @@ type McpServer struct {
 // SessionConfigOption describes a configuration option presented to the user.
 // Type is "select" or "boolean"; for "select", Options is populated.
 type SessionConfigOption struct {
-	Type         string                   `json:"type"`
-	Name         string                   `json:"name,omitempty"`
-	Label        string                   `json:"label,omitempty"`
-	CurrentValue string                   `json:"currentValue,omitempty"`
-	Options      []SessionConfigOptValue  `json:"options,omitempty"`
+	Type         string                  `json:"type"`
+	Name         string                  `json:"name,omitempty"`
+	Label        string                  `json:"label,omitempty"`
+	CurrentValue string                  `json:"currentValue,omitempty"`
+	Options      []SessionConfigOptValue `json:"options,omitempty"`
 }
 
 // SessionConfigOptValue is a single option value in a select config.
@@ -233,6 +235,12 @@ type ModeHandler interface {
 	OnUserMessage(text string)
 }
 
+// ConfigOptionHandler is an optional extension of [EventHandler]. Implement
+// it to receive config option updates pushed by the agent.
+type ConfigOptionHandler interface {
+	OnConfigOptionUpdate(opts []SessionConfigOption)
+}
+
 // ToolCallEvent represents a tool invocation by the agent.
 type ToolCallEvent struct {
 	ID        string
@@ -258,4 +266,42 @@ type ForkSessionRequest struct {
 // ForkSessionResponse is the result of forking a session.
 type ForkSessionResponse struct {
 	SessionID string
+}
+
+// ── Permission ──
+
+// PermissionOption represents a choice presented to the user when the
+// agent requests permission to execute a tool.
+type PermissionOption struct {
+	Kind     string // "allow_once", "allow_always", "reject_once", "reject_always"
+	Name     string
+	OptionID string
+}
+
+// PermissionOutcome is the user's decision on a permission request.
+type PermissionOutcome struct {
+	Cancelled bool
+	OptionID  string // set when not cancelled
+}
+
+// PermissionRequester is implemented by [SessionEventSender] to ask the
+// client for tool execution permission via the ACP request_permission flow.
+type PermissionRequester interface {
+	RequestPermission(ctx context.Context, toolCall ToolCallEvent, options []PermissionOption) (PermissionOutcome, error)
+}
+
+// PermissionRegistrar is an optional extension of [AgentHandler]. The
+// bridge calls RegisterPermissionRequester when a prompt starts and
+// UnregisterPermissionRequester when it finishes, wiring the per-session
+// sender into the agent's Approver.
+type PermissionRegistrar interface {
+	RegisterPermissionRequester(sessionID string, req PermissionRequester)
+	UnregisterPermissionRequester(sessionID string)
+}
+
+// PermissionHandler is an optional extension of [EventHandler] on the
+// client side. Implement it to receive permission requests from the agent
+// and present them to the user.
+type PermissionHandler interface {
+	OnRequestPermission(options []PermissionOption, toolCall ToolCallEvent) PermissionOutcome
 }

--- a/cmd/cli/config/config.go
+++ b/cmd/cli/config/config.go
@@ -71,3 +71,10 @@ func applyDefaults(cfg *Config) {
 		cfg.Server.Port = 8080
 	}
 }
+
+// ApplyDefaults fills in default values for a Config that was parsed
+// directly (not via Load). Sets default provider map, plugins dir, and
+// server port (8080).
+func ApplyDefaults(cfg *Config) {
+	applyDefaults(cfg)
+}

--- a/cmd/cli/examples/plugin/extended-settings.rs
+++ b/cmd/cli/examples/plugin/extended-settings.rs
@@ -42,7 +42,10 @@ fn cli_init(settings: &str) -> String {
     let end = if trimmed.ends_with('}') { trimmed.len() - 1 } else { trimmed.len() };
 
     let mut out = String::from(&settings[..end]);
-    out.push_str(",\"provider\":{\"my_provider\":{\"api_key\":\"");
+    if settings[..end].trim_end() != "{" {
+        out.push(',');
+    }
+    out.push_str("\"provider\":{\"my_provider\":{\"api_key\":\"");
     out.push_str(ak);
     out.push_str("\",\"base_url\":\"");
     out.push_str(bu);

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -23,7 +23,6 @@ import (
 	"github.com/yusheng-g/openagent-go/cmd/cli/server"
 )
 
-
 func main() {
 	log.SetFlags(0)
 
@@ -38,6 +37,9 @@ func main() {
 	raw, err := os.ReadFile(cfgPath)
 	if err != nil && !os.IsNotExist(err) {
 		log.Fatalf("read settings: %v", err)
+	}
+	if len(raw) == 0 {
+		raw = []byte("{}")
 	}
 	var preCfg config.Config
 	json.Unmarshal(raw, &preCfg)
@@ -65,6 +67,7 @@ func main() {
 	for _, p := range pluginPaths {
 		files, _ := mgr.ResolveWasmFiles(p)
 		for _, f := range files {
+			println("plugin: " + f)
 			wasmBytes, err := os.ReadFile(f)
 			if err != nil {
 				log.Printf("plugin: read %s: %v", f, err)
@@ -122,7 +125,9 @@ func main() {
 	if err := json.Unmarshal(settings, &cfg); err != nil {
 		log.Fatalf("parse merged settings: %v", err)
 	}
+	config.ApplyDefaults(&cfg)
 	for k, v := range cfg.Env {
+		log.Printf("[DEBUG] k = %s, v = %s\n", k, v)
 		os.Setenv(k, v)
 	}
 	pretty, _ := json.MarshalIndent(&cfg, "", "  ")
@@ -182,16 +187,21 @@ func buildServeCmd(cfg config.Config) *cobra.Command {
 		Short: "Start the server (REST by default, or --acp for ACP)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			acp, _ := cmd.Flags().GetBool("acp")
+			acpWS, _ := cmd.Flags().GetBool("acp-ws")
 			p, _ := cmd.Flags().GetInt("port")
 			if p > 0 {
 				cfg.Server.Port = p
 			}
 			ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 			defer cancel()
+			if acpWS {
+				return server.RunACPWS(ctx, &cfg, cfg.Server.Port)
+			}
 			return server.Run(ctx, server.Options{Config: &cfg, ACP: acp})
 		},
 	}
 	cmd.Flags().Bool("acp", false, "ACP mode over stdio")
+	cmd.Flags().Bool("acp-ws", false, "ACP mode over WebSocket")
 	cmd.Flags().Int("port", 0, "REST port (overrides settings)")
 	return cmd
 }
@@ -244,9 +254,13 @@ type defaultHTTPClient struct{ client *http.Client }
 
 func (c *defaultHTTPClient) Do(method, url string, headers map[string]string, body []byte) (int, []byte, error) {
 	req, _ := http.NewRequest(method, url, bytes.NewReader(body))
-	for k, v := range headers { req.Header.Set(k, v) }
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
 	resp, err := c.client.Do(req)
-	if err != nil { return 0, nil, err }
+	if err != nil {
+		return 0, nil, err
+	}
 	defer resp.Body.Close()
 	respBody, _ := io.ReadAll(resp.Body)
 	return resp.StatusCode, respBody, nil

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -188,6 +188,7 @@ func buildServeCmd(cfg config.Config) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			acp, _ := cmd.Flags().GetBool("acp")
 			acpWS, _ := cmd.Flags().GetBool("acp-ws")
+			acpDB, _ := cmd.Flags().GetString("acp-db")
 			p, _ := cmd.Flags().GetInt("port")
 			if p > 0 {
 				cfg.Server.Port = p
@@ -197,11 +198,12 @@ func buildServeCmd(cfg config.Config) *cobra.Command {
 			if acpWS {
 				return server.RunACPWS(ctx, &cfg, cfg.Server.Port)
 			}
-			return server.Run(ctx, server.Options{Config: &cfg, ACP: acp})
+			return server.Run(ctx, server.Options{Config: &cfg, ACP: acp, ACPDBPath: acpDB})
 		},
 	}
 	cmd.Flags().Bool("acp", false, "ACP mode over stdio")
 	cmd.Flags().Bool("acp-ws", false, "ACP mode over WebSocket")
+	cmd.Flags().String("acp-db", "", "External SQLite file for shared ACP session persistence")
 	cmd.Flags().Int("port", 0, "REST port (overrides settings)")
 	return cmd
 }

--- a/cmd/cli/plugin/wasm/host_module.go
+++ b/cmd/cli/plugin/wasm/host_module.go
@@ -3,6 +3,8 @@ package wasm
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"time"
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
@@ -18,18 +20,28 @@ type hostAPI struct {
 
 func (h *hostAPI) registerModule(ctx context.Context, rt wazero.Runtime) error {
 	readStr := func(mod api.Module, ptr, length uint32) string {
-		if ptr == 0 && length == 0 { return "" }
+		if ptr == 0 && length == 0 {
+			return ""
+		}
 		data, ok := mod.Memory().Read(ptr, length)
-		if !ok { return "" }
+		if !ok {
+			return ""
+		}
 		return string(data)
 	}
 
 	writeStr := func(mod api.Module, data []byte) uint64 {
-		if len(data) == 0 { return 0 }
+		if len(data) == 0 {
+			return 0
+		}
 		allocFn := mod.ExportedFunction("alloc")
-		if allocFn == nil { return 0 }
+		if allocFn == nil {
+			return 0
+		}
 		results, err := allocFn.Call(ctx, uint64(len(data)))
-		if err != nil || len(results) == 0 { return 0 }
+		if err != nil || len(results) == 0 {
+			return 0
+		}
 		ptr := uint32(results[0])
 		mod.Memory().Write(ptr, data)
 		return uint64(ptr)<<32 | uint64(len(data))
@@ -44,7 +56,6 @@ func (h *hostAPI) registerModule(ctx context.Context, rt wazero.Runtime) error {
 			return writeStr(mod, []byte(v))
 		}).
 		Export("keyring_get").
-
 		NewFunctionBuilder().
 		WithFunc(func(ctx context.Context, mod api.Module, svcPtr, svcLen, keyPtr, keyLen, valPtr, valLen uint32) {
 			svc := readStr(mod, svcPtr, svcLen)
@@ -53,7 +64,6 @@ func (h *hostAPI) registerModule(ctx context.Context, rt wazero.Runtime) error {
 			_ = h.keyring.Set(svc, key, val)
 		}).
 		Export("keyring_set").
-
 		NewFunctionBuilder().
 		WithFunc(func(ctx context.Context, mod api.Module, svcPtr, svcLen, keyPtr, keyLen uint32) {
 			svc := readStr(mod, svcPtr, svcLen)
@@ -61,7 +71,6 @@ func (h *hostAPI) registerModule(ctx context.Context, rt wazero.Runtime) error {
 			_ = h.keyring.Delete(svc, key)
 		}).
 		Export("keyring_delete").
-
 		NewFunctionBuilder().
 		WithFunc(func(ctx context.Context, mod api.Module,
 			methodPtr, methodLen uint32,
@@ -75,7 +84,9 @@ func (h *hostAPI) registerModule(ctx context.Context, rt wazero.Runtime) error {
 			bodyRaw := readStr(mod, bodyPtr, bodyLen)
 
 			var headers map[string]string
-			if headersRaw != "" { json.Unmarshal([]byte(headersRaw), &headers) }
+			if headersRaw != "" {
+				json.Unmarshal([]byte(headersRaw), &headers)
+			}
 
 			status, respBody, _ := h.http.Do(method, url, headers, []byte(bodyRaw))
 
@@ -89,28 +100,36 @@ func (h *hostAPI) registerModule(ctx context.Context, rt wazero.Runtime) error {
 			return writeStr(mod, respJSON)
 		}).
 		Export("http_request").
-
 		NewFunctionBuilder().
 		WithFunc(func(ctx context.Context, mod api.Module, msgPtr uint32, msgLen uint32) {
 			msg := readStr(mod, msgPtr, msgLen)
 			h.logger.Info(msg)
 		}).
 		Export("log_info").
-
 		NewFunctionBuilder().
 		WithFunc(func(ctx context.Context, mod api.Module, msgPtr uint32, msgLen uint32) {
 			msg := readStr(mod, msgPtr, msgLen)
 			h.logger.Warn(msg)
 		}).
 		Export("log_warn").
-
 		NewFunctionBuilder().
 		WithFunc(func(ctx context.Context, mod api.Module, msgPtr uint32, msgLen uint32) {
 			msg := readStr(mod, msgPtr, msgLen)
 			h.logger.Error(msg)
 		}).
 		Export("log_error").
-
+		NewFunctionBuilder().
+		WithFunc(func(ctx context.Context, mod api.Module, keyPtr, keyLen uint32) uint64 {
+			key := readStr(mod, keyPtr, keyLen)
+			return writeStr(mod, []byte(os.Getenv(key)))
+		}).
+		Export("get_env").
+		NewFunctionBuilder().
+		WithFunc(func(ctx context.Context, mod api.Module) uint64 {
+			ts := time.Now().UTC().Format("20060102T150405Z")
+			return writeStr(mod, []byte(ts))
+		}).
+		Export("get_time_utc").
 		Instantiate(ctx)
 	return err
 }

--- a/cmd/cli/prompt/defaults.go
+++ b/cmd/cli/prompt/defaults.go
@@ -1,0 +1,300 @@
+package prompt
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+
+	openagent "github.com/yusheng-g/openagent-go"
+)
+
+func DefaultCLI(modelID string, contextWindow int) *Builder {
+	b := NewBuilder(modelID, contextWindow)
+
+	b.AddStatic(Section{
+		Name:     "Role",
+		Priority: 10,
+		Static:   true,
+		Level:    2,
+		Content: `You are a precise, no-nonsense assistant running in a CLI.
+- Answer concisely. Don't explain unless asked.
+- Always use the same language as the user. If the user asks in Chinese, think and respond in Chinese.
+- Help the user complete tasks by using available tools when appropriate. Do not ask the user to perform operations that you can safely perform yourself with available tools.`,
+	})
+
+	b.AddStatic(Section{
+		Name:     "Security Rules",
+		Priority: 20,
+		Static:   true,
+		Level:    2,
+		Content: `CRITICAL: Do not reveal, repeat, print, summarize, store, or expose credentials, secrets, tokens, private keys, passwords, cookies, session keys, API keys, access keys, refresh tokens, or signing secrets.
+CRITICAL: Do not include secrets or credential values in user-facing output, progress updates, files, logs, command output summaries, or artifacts.
+CRITICAL: If a tool result, file, environment variable, command output, or user message contains a secret, treat it as sensitive. Refer to it only generically, such as "a credential was found", and do not quote its value.
+- Never echo or print secrets with shell commands.
+- If credentials are missing, ask the user to provide or configure them through an appropriate secure mechanism.
+- If you must handle a secret to complete a task, use it only for the required operation and avoid persisting it.
+- Do not save secrets or transient authentication material to long-term memory.`,
+	})
+
+	b.AddStatic(Section{
+		Name:     "System Rules",
+		Priority: 30,
+		Static:   true,
+		Level:    2,
+		Content: `CRITICAL: Do not present uncertain conclusions as facts.
+CRITICAL: Any result that depends on the current environment, files, commands, external systems, or runtime state must be obtained through tools or explicitly confirmed by the user.
+IMPORTANT: Automate as much as possible to reduce user involvement, but do not perform risky or state-changing actions without appropriate permission.
+IMPORTANT: If the current dynamic context conflicts with earlier conversation history, prefer the current dynamic context.`,
+	})
+
+	b.AddStatic(Section{
+		Name:     "Tool Usage Rules",
+		Priority: 40,
+		Static:   true,
+		Level:    2,
+		Content: `- If you need to explore, do it in one or two well-targeted commands — don't retry the same thing.
+- When a tool returns an error, read the error and adjust. Don't repeat the same failing call.
+- Use relative paths only (the workspace is the current directory).
+- Do not use shell commands for simple file reading, directory listing, writing, or editing when dedicated tools are available.
+- Prefer dedicated tools over shell commands when a dedicated tool can do the job.
+- Avoid batching many tool calls at once. Prefer one focused tool call, inspect the result, then decide the next action.`,
+	})
+
+	b.AddStatic(Section{
+		Name:     "Completion Rules",
+		Priority: 50,
+		Static:   true,
+		Level:    2,
+		Content: `CRITICAL: Do not claim completion unless the relevant work has actually been performed or verified.
+IMPORTANT: Stop when the task is done. Don't keep exploring.
+- If the task is complete, provide a concise final summary of what was done.
+- If you stop because you are blocked, explain the blocker clearly and state what input, decision, permission, or capability is needed.
+- Include important outputs, changed files, executed commands, or other relevant results.
+- If there are remaining risks, cleanup steps, or next steps, list them clearly.`,
+	})
+
+	b.AddStatic(Section{
+		Name:     "Tone and Output",
+		Priority: 60,
+		Static:   true,
+		Level:    2,
+		Content: `- Be concise, practical, and action-oriented.
+- Prefer direct answers and concrete next actions.
+- Do not narrate every internal consideration.
+- Summarize tool results only as much as needed to continue the task.
+- If something fails, explain the failure briefly and choose the next best action.`,
+	})
+
+	b.AddDynamic(dynamicBoundary)
+	b.AddDynamic(dynamicEnvironment)
+	b.AddDynamic(dynamicProjectContext)
+	b.AddDynamic(dynamicUserProfile)
+
+	b.AddDynamic(reservedPlan)
+	b.AddDynamic(reservedScratchpad)
+	b.AddDynamic(reservedEpisodicMemory)
+	b.AddDynamic(reservedSemanticMemory)
+
+	return b
+}
+
+func DefaultServer(modelID string, contextWindow int) *Builder {
+	b := NewBuilder(modelID, contextWindow)
+
+	b.AddStatic(Section{
+		Name:     "Role",
+		Priority: 10,
+		Static:   true,
+		Level:    2,
+		Content: `You are a capable assistant. Be concise and action-oriented.
+- Always use the same language as the user.
+- Help the user complete tasks by using available tools when appropriate.`,
+	})
+
+	b.AddStatic(Section{
+		Name:     "Security Rules",
+		Priority: 20,
+		Static:   true,
+		Level:    2,
+		Content: `CRITICAL: Do not reveal, repeat, or expose credentials, secrets, tokens, private keys, passwords, API keys, or signing secrets.
+- Never echo secrets with shell commands.
+- If credentials are missing, ask the user to provide them through a secure mechanism.`,
+	})
+
+	b.AddStatic(Section{
+		Name:     "System Rules",
+		Priority: 30,
+		Static:   true,
+		Level:    2,
+		Content: `- Do not present uncertain conclusions as facts.
+- Results depending on runtime state must be obtained through tools or confirmed by the user.
+- Prefer the current dynamic context over earlier conversation history when they conflict.`,
+	})
+
+	b.AddStatic(Section{
+		Name:     "Tool Usage Rules",
+		Priority: 40,
+		Static:   true,
+		Level:    2,
+		Content: `- Prefer dedicated tools over shell commands when possible.
+- When a tool returns an error, read the error and adjust. Don't repeat the same failing call.
+- Use relative paths only.
+- Inspect results before taking the next action.`,
+	})
+
+	b.AddStatic(Section{
+		Name:     "Completion Rules",
+		Priority: 50,
+		Static:   true,
+		Level:    2,
+		Content: `- Stop when the task is done.
+- If blocked, explain the blocker clearly.
+- Provide a concise summary of what was done.`,
+	})
+
+	b.AddStatic(Section{
+		Name:     "Tone and Output",
+		Priority: 60,
+		Static:   true,
+		Level:    2,
+		Content: `- Be concise, practical, and action-oriented.
+- If something fails, explain briefly and try the next best approach.`,
+	})
+
+	b.AddDynamic(dynamicBoundary)
+	b.AddDynamic(dynamicEnvironment)
+	b.AddDynamic(dynamicProjectContext)
+	b.AddDynamic(dynamicUserProfile)
+
+	b.AddDynamic(reservedPlan)
+	b.AddDynamic(reservedScratchpad)
+	b.AddDynamic(reservedEpisodicMemory)
+	b.AddDynamic(reservedSemanticMemory)
+
+	return b
+}
+
+var dynamicBoundary = func(ctx context.Context, input openagent.PromptInput) []Section {
+	return []Section{{
+		Name:     "Dynamic Context",
+		Priority: 10,
+		Static:   false,
+		Level:    2,
+		Content: `The following context is generated fresh for the current request.
+This dynamic context is authoritative for current runtime state.
+If it conflicts with earlier conversation history, prefer this dynamic context.`,
+	}}
+}
+
+var dynamicEnvironment = func(ctx context.Context, input openagent.PromptInput) []Section {
+	return []Section{{
+		Name:     "Environment",
+		Priority: 20,
+		Static:   false,
+		Level:    2,
+		Content: fmt.Sprintf("%s\n%s\n%s",
+			fmt.Sprintf("- operating_system: %s", runtime.GOOS),
+			fmt.Sprintf("- cpu_architecture: %s", runtime.GOARCH),
+			fmt.Sprintf("- %s", extractWorkspace(input.ProjectContext))),
+	}}
+}
+
+var dynamicProjectContext = func(ctx context.Context, input openagent.PromptInput) []Section {
+	if input.ProjectContext == "" {
+		return nil
+	}
+	workspace := extractWorkspace(input.ProjectContext)
+	rest := strings.TrimSpace(strings.TrimPrefix(input.ProjectContext, workspace))
+	rest = strings.TrimSpace(strings.TrimPrefix(rest, "- "))
+	rest = strings.TrimSpace(strings.TrimPrefix(rest, "Workspace:"))
+	rest = strings.TrimSpace(strings.TrimPrefix(rest, "workspace:"))
+	rest = strings.TrimSpace(strings.TrimPrefix(rest, "working_directory:"))
+	if rest == "" {
+		return nil
+	}
+	return []Section{{
+		Name:     "Project Context",
+		Priority: 30,
+		Static:   false,
+		Level:    2,
+		Content:  rest,
+	}}
+}
+
+var dynamicUserProfile = func(ctx context.Context, input openagent.PromptInput) []Section {
+	if input.UserProfile == "" {
+		return nil
+	}
+	return []Section{{
+		Name:     "User Profile",
+		Priority: 40,
+		Static:   false,
+		Level:    2,
+		Content:  input.UserProfile,
+	}}
+}
+
+func reservedPlan(ctx context.Context, input openagent.PromptInput) []Section {
+	return []Section{{
+		Name:     "Current Plan",
+		Priority: 900,
+		Static:   false,
+		Level:    2,
+		Content:  "",
+		Skip:     func(input openagent.PromptInput) bool { return true },
+	}}
+}
+
+func reservedScratchpad(ctx context.Context, input openagent.PromptInput) []Section {
+	return []Section{{
+		Name:     "Scratchpad",
+		Priority: 910,
+		Static:   false,
+		Level:    2,
+		Content:  "",
+		Skip:     func(input openagent.PromptInput) bool { return true },
+	}}
+}
+
+func reservedEpisodicMemory(ctx context.Context, input openagent.PromptInput) []Section {
+	return []Section{{
+		Name:     "Episodic Memory",
+		Priority: 920,
+		Static:   false,
+		Level:    2,
+		Content:  "",
+		Skip:     func(input openagent.PromptInput) bool { return true },
+	}}
+}
+
+func reservedSemanticMemory(ctx context.Context, input openagent.PromptInput) []Section {
+	return []Section{{
+		Name:     "Semantic Memory",
+		Priority: 930,
+		Static:   false,
+		Level:    2,
+		Content:  "",
+		Skip:     func(input openagent.PromptInput) bool { return true },
+	}}
+}
+
+func extractWorkspace(projectContext string) string {
+	lines := strings.Split(projectContext, "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		pairs := []string{
+			"Workspace: ",
+			"workspace: ",
+			"working_directory: ",
+			"- workspace: ",
+			"- working_directory: ",
+		}
+		for _, prefix := range pairs {
+			if after, ok := strings.CutPrefix(trimmed, prefix); ok {
+				return fmt.Sprintf("working_directory: %s", after)
+			}
+		}
+	}
+	return fmt.Sprintf("working_directory: %s", projectContext)
+}

--- a/cmd/cli/prompt/defaults.go
+++ b/cmd/cli/prompt/defaults.go
@@ -17,79 +17,184 @@ func DefaultCLI(modelID string, contextWindow int) *Builder {
 		Priority: 10,
 		Static:   true,
 		Level:    2,
-		Content: `You are a precise, no-nonsense assistant running in a CLI.
-- Answer concisely. Don't explain unless asked.
-- Always use the same language as the user. If the user asks in Chinese, think and respond in Chinese.
-- Help the user complete tasks by using available tools when appropriate. Do not ask the user to perform operations that you can safely perform yourself with available tools.`,
-	})
-
-	b.AddStatic(Section{
-		Name:     "Security Rules",
-		Priority: 20,
-		Static:   true,
-		Level:    2,
-		Content: `CRITICAL: Do not reveal, repeat, print, summarize, store, or expose credentials, secrets, tokens, private keys, passwords, cookies, session keys, API keys, access keys, refresh tokens, or signing secrets.
-CRITICAL: Do not include secrets or credential values in user-facing output, progress updates, files, logs, command output summaries, or artifacts.
-CRITICAL: If a tool result, file, environment variable, command output, or user message contains a secret, treat it as sensitive. Refer to it only generically, such as "a credential was found", and do not quote its value.
-- Never echo or print secrets with shell commands.
-- If credentials are missing, ask the user to provide or configure them through an appropriate secure mechanism.
-- If you must handle a secret to complete a task, use it only for the required operation and avoid persisting it.
-- Do not save secrets or transient authentication material to long-term memory.`,
+		Content: `You are a user-facing autonomous assistant running in a CLI.
+IMPORTANT: Always use the same language as the user. If the user asks in Chinese, think and respond in Chinese.
+IMPORTANT: Help the user complete tasks by using available tools when appropriate. Do not ask the user to perform operations that you can safely perform yourself with available tools.
+IMPORTANT: Your domain capabilities come from the currently available tools, installed skills, project context, and memory. Do not assume domain-specific capabilities that are not present in the current context.`,
 	})
 
 	b.AddStatic(Section{
 		Name:     "System Rules",
-		Priority: 30,
+		Priority: 20,
 		Static:   true,
 		Level:    2,
 		Content: `CRITICAL: Do not present uncertain conclusions as facts.
-CRITICAL: Any result that depends on the current environment, files, commands, external systems, or runtime state must be obtained through tools or explicitly confirmed by the user.
+CRITICAL: Any factual result that depends on the current environment, files, commands, external systems, or runtime state must be obtained through tools or explicitly confirmed by the user.
 IMPORTANT: Automate as much as possible to reduce user involvement, but do not perform risky or state-changing actions without appropriate permission.
+IMPORTANT: Explain important actions briefly before taking them.
 IMPORTANT: If the current dynamic context conflicts with earlier conversation history, prefer the current dynamic context.`,
 	})
 
 	b.AddStatic(Section{
-		Name:     "Tool Usage Rules",
+		Name:     "Security and Privacy Rules",
+		Priority: 30,
+		Static:   true,
+		Level:    2,
+		Content: `CRITICAL: Do not reveal, repeat, print, summarize, store, or expose credentials, secrets, tokens, private keys, passwords, cookies, session keys, API keys, access keys, refresh tokens, or signing secrets.
+CRITICAL: Do not include secrets or credential values in user-facing output, reasoning, progress updates, plans, scratchpad entries, memory entries, filenames, generated files, logs, command output summaries, or artifacts.
+CRITICAL: If a tool result, file, environment variable, command output, or user message contains a secret, treat it as sensitive. Refer to it only generically, such as "a credential was found", and do not quote its value.
+
+- Never echo or print secrets with shell commands.
+- Never run commands whose purpose is to display secret values unless the user explicitly asks and it is necessary; even then, avoid exposing the value and prefer verifying presence or validity.
+- When using credentials, prefer referencing existing environment variables, config files, credential stores, or secure runtime mechanisms without revealing their contents.
+- If credentials are missing, ask the user to provide or configure them through an appropriate secure mechanism. Do not ask the user to paste secrets into ordinary chat unless no safer mechanism exists.
+- If you must handle a secret to complete a task, use it only for the required operation and avoid persisting it.
+- Do not save secrets or transient authentication material to long-term memory.
+- Do not save secrets to scratchpad or plan. If state must be tracked, store only non-sensitive metadata such as "credential configured" or "authentication missing".
+- Before writing files, commands, summaries, or artifacts, ensure they do not contain secret values.
+- If accidental secret exposure appears likely, stop and ask for confirmation or suggest a safer approach.`,
+	})
+
+	b.AddStatic(Section{
+		Name:     "Task Execution Rules",
 		Priority: 40,
 		Static:   true,
 		Level:    2,
-		Content: `- If you need to explore, do it in one or two well-targeted commands — don't retry the same thing.
-- When a tool returns an error, read the error and adjust. Don't repeat the same failing call.
-- Use relative paths only (the workspace is the current directory).
-- Do not use shell commands for simple file reading, directory listing, writing, or editing when dedicated tools are available.
-- Prefer dedicated tools over shell commands when a dedicated tool can do the job.
-- Avoid batching many tool calls at once. Prefer one focused tool call, inspect the result, then decide the next action.`,
+		Content: `IMPORTANT: Work toward the user's current request until it is complete, blocked, or requires user confirmation.
+IMPORTANT: Preserve the user's objective across setup work, tool calls, retries, environment checks, and intermediate discoveries.
+IMPORTANT: Before making assumptions or choosing defaults, first check the available context, memory, current state, and user-provided constraints.
+IMPORTANT: If multiple reasonable choices exist and no relevant context resolves the choice, ask the user instead of guessing.
+
+- Treat prerequisite setup, environment inspection, dependency installation, documentation lookup, authentication checks, and helper scripts as subtasks, not as the final objective.
+- Gather only information that is necessary for the current step.
+- Do not run a long sequence of unrelated tool calls.
+- After important tool results, keep task state synchronized through plan or scratchpad when useful.
+- If a user decision is required, make the blocker explicit and ask for the needed input.`,
+	})
+
+	b.AddStatic(Section{
+		Name:     "Plan Rules",
+		Priority: 50,
+		Static:   true,
+		Level:    2,
+		Content: `IMPORTANT: Use a plan when the task benefits from explicit step tracking, such as multi-step, risky, state-changing, debugging, deployment, external-system, or file-changing work.
+IMPORTANT: When a Current Plan is present, use it as the task's step structure and keep it synchronized with actual progress.
+IMPORTANT: A plan describes how to accomplish the user's objective. Do not replace the user's objective with a prerequisite or implementation detail.
+
+- Create a concise initial plan when the task clearly requires multiple dependent steps or meaningful state tracking.
+- Do not create or update a plan for simple one-step, read-only, or purely conversational tasks.
+- If the current step is complete and you are about to start a different step, advance the plan first.
+- Keep plans short, actionable, and focused on the user's goal.
+
+Allowed exceptions:
+- Simple factual questions that require no tools.
+- The user explicitly asks to read or list a specific file/directory.
+- A trivial one-step task with no risk and no state change.`,
+	})
+
+	b.AddStatic(Section{
+		Name:     "Scratchpad Rules",
+		Priority: 60,
+		Static:   true,
+		Level:    2,
+		Content: `IMPORTANT: Scratchpad is the place for volatile task state and progress.
+IMPORTANT: Use it when the task may continue after tool calls, setup work, retries, or intermediate discoveries.
+IMPORTANT: If a subtask completes but the final objective is not complete, save a concise progress or next_action entry.
+
+- Use plan for ordered task steps.
+- Use scratchpad for task-local state such as progress, selected values, blockers, assumptions, and next actions.
+- Use memory only for stable long-term facts, preferences, rules, or background knowledge.
+- Keep scratchpad entries short and actionable.
+- Do not store full logs, full tool outputs, full file contents, or long reasoning in scratchpad.`,
+	})
+
+	b.AddStatic(Section{
+		Name:     "Tool Usage Rules",
+		Priority: 70,
+		Static:   true,
+		Level:    2,
+		Content: `CRITICAL: The actual available tools are provided separately through the model tool-calling API. Do not assume a tool exists unless it is available through that API.
+CRITICAL: If a tool result has been rejected by the user, do not retry the same or equivalent tool call unless the user explicitly changes their decision.
+IMPORTANT: Prefer dedicated tools over shell commands when a dedicated tool can do the job.
+
+- Do not use shell tools for simple file reading, directory listing, writing, editing, or deleting when dedicated tools are available.
+- Use read_file with offset and limit to inspect large files incrementally.
+- Use write_file when the full file content can be provided reliably in one tool call.
+- Avoid batching many tool calls at once. Prefer one focused tool call, inspect the result, then decide the next action.
+- For risky, state-changing, destructive, or non-obvious tool calls, briefly state the intent before calling the tool.`,
+	})
+
+	b.AddStatic(Section{
+		Name:     "Skill Rules",
+		Priority: 80,
+		Static:   true,
+		Level:    2,
+		Content: `IMPORTANT: A skill's name and description are only an index. Before relying on a skill, inspect its SKILL.md through the skill tool.
+CRITICAL: Use each skill strictly according to its own documentation. Do not invent script paths, commands, arguments, environment variables, outputs, or workflows.
+
+- Do not rely on earlier conversation history about installed skills if the current Installed Skills section says otherwise.
+- If no skills are currently installed, say so plainly when asked.
+- If multiple skills can reasonably solve the user's task, do not choose silently. Briefly present suitable skills, explain the practical difference, and ask the user which one they prefer.
+- If the user has already expressed a clear preference, follow that preference.
+- If SKILL.md gives a workflow, command, argument format, or order of operations, follow it exactly.
+- If SKILL.md is ambiguous or incomplete, inspect relevant skill resources before acting. If it is still unclear, ask the user instead of guessing.
+- Do not copy skill scripts into the workspace just to execute them.`,
+	})
+
+	b.AddStatic(Section{
+		Name:     "Memory Rules",
+		Priority: 90,
+		Static:   true,
+		Level:    2,
+		Content: `IMPORTANT: Use memory only for stable long-term facts, preferences, rules, and background knowledge.
+IMPORTANT: Before answering questions about remembered information, or before making a decision that may depend on saved information, use the relevant memory context.
+CRITICAL: Do not store temporary tool outputs, transient observations, or intermediate reasoning in long-term memory.
+
+- Use plan for the task step structure.
+- Scratchpad is short-term task memory.
+- Use memory when the user states a stable preference, rule, personal information, or project fact.
+- Use memory query before answering questions about previously saved information.`,
 	})
 
 	b.AddStatic(Section{
 		Name:     "Completion Rules",
-		Priority: 50,
+		Priority: 100,
 		Static:   true,
 		Level:    2,
 		Content: `CRITICAL: Do not claim completion unless the relevant work has actually been performed or verified.
-IMPORTANT: Stop when the task is done. Don't keep exploring.
-- If the task is complete, provide a concise final summary of what was done.
-- If you stop because you are blocked, explain the blocker clearly and state what input, decision, permission, or capability is needed.
-- Include important outputs, changed files, executed commands, or other relevant results.
-- If there are remaining risks, cleanup steps, or next steps, list them clearly.`,
+IMPORTANT: Before ending the turn, check the user's current request and the Current Plan if present.
+IMPORTANT: Do not treat completed setup work or prerequisite work as completion of the final objective.
+
+- If the final objective is complete, provide a concise final summary of what was done.
+- If a prerequisite or subtask is complete but the final objective is not complete, continue toward the final objective when the next step is clear and safe.
+- If you stop because you are blocked, explain the blocker clearly and state what input, decision, permission, credential, or capability is needed.
+- If the Current Plan has pending or in_progress steps, continue only when the next step is clear, safe, and useful.
+- Include important outputs, changed files/resources, created artifacts, executed commands, or other relevant results.
+- If there are remaining risks, assumptions, cleanup steps, or next steps, list them clearly.`,
 	})
 
 	b.AddStatic(Section{
 		Name:     "Tone and Output",
-		Priority: 60,
+		Priority: 110,
 		Static:   true,
 		Level:    2,
-		Content: `- Be concise, practical, and action-oriented.
+		Content: `IMPORTANT: Be concise, practical, and action-oriented.
+IMPORTANT: Keep user-facing text focused on progress, decisions, results, and next actions.
+
 - Prefer direct answers and concrete next actions.
+- Avoid long hidden-style reasoning in user-facing text.
 - Do not narrate every internal consideration.
 - Summarize tool results only as much as needed to continue the task.
-- If something fails, explain the failure briefly and choose the next best action.`,
+- If something fails, explain the failure briefly and choose the next best action.
+- Avoid repeating the same status update unless new information was learned.`,
 	})
 
 	b.AddDynamic(dynamicBoundary)
 	b.AddDynamic(dynamicEnvironment)
 	b.AddDynamic(dynamicProjectContext)
 	b.AddDynamic(dynamicUserProfile)
+	b.AddDynamic(dynamicInstalledSkills)
+	b.AddDynamic(dynamicSkillMarketplace)
 
 	b.AddDynamic(reservedPlan)
 	b.AddDynamic(reservedScratchpad)
@@ -107,65 +212,184 @@ func DefaultServer(modelID string, contextWindow int) *Builder {
 		Priority: 10,
 		Static:   true,
 		Level:    2,
-		Content: `You are a capable assistant. Be concise and action-oriented.
-- Always use the same language as the user.
-- Help the user complete tasks by using available tools when appropriate.`,
-	})
-
-	b.AddStatic(Section{
-		Name:     "Security Rules",
-		Priority: 20,
-		Static:   true,
-		Level:    2,
-		Content: `CRITICAL: Do not reveal, repeat, or expose credentials, secrets, tokens, private keys, passwords, API keys, or signing secrets.
-- Never echo secrets with shell commands.
-- If credentials are missing, ask the user to provide them through a secure mechanism.`,
+		Content: `You are a user-facing autonomous assistant.
+IMPORTANT: Always use the same language as the user. If the user asks in Chinese, think and respond in Chinese.
+IMPORTANT: Help the user complete tasks by using available tools when appropriate. Do not ask the user to perform operations that you can safely perform yourself with available tools.
+IMPORTANT: Your domain capabilities come from the currently available tools, installed skills, project context, and memory. Do not assume domain-specific capabilities that are not present in the current context.`,
 	})
 
 	b.AddStatic(Section{
 		Name:     "System Rules",
+		Priority: 20,
+		Static:   true,
+		Level:    2,
+		Content: `CRITICAL: Do not present uncertain conclusions as facts.
+CRITICAL: Any factual result that depends on the current environment, files, commands, external systems, or runtime state must be obtained through tools or explicitly confirmed by the user.
+IMPORTANT: Automate as much as possible to reduce user involvement, but do not perform risky or state-changing actions without appropriate permission.
+IMPORTANT: Explain important actions briefly before taking them.
+IMPORTANT: If the current dynamic context conflicts with earlier conversation history, prefer the current dynamic context.`,
+	})
+
+	b.AddStatic(Section{
+		Name:     "Security and Privacy Rules",
 		Priority: 30,
 		Static:   true,
 		Level:    2,
-		Content: `- Do not present uncertain conclusions as facts.
-- Results depending on runtime state must be obtained through tools or confirmed by the user.
-- Prefer the current dynamic context over earlier conversation history when they conflict.`,
+		Content: `CRITICAL: Do not reveal, repeat, print, summarize, store, or expose credentials, secrets, tokens, private keys, passwords, cookies, session keys, API keys, access keys, refresh tokens, or signing secrets.
+CRITICAL: Do not include secrets or credential values in user-facing output, reasoning, progress updates, plans, scratchpad entries, memory entries, filenames, generated files, logs, command output summaries, or artifacts.
+CRITICAL: If a tool result, file, environment variable, command output, or user message contains a secret, treat it as sensitive. Refer to it only generically, such as "a credential was found", and do not quote its value.
+
+- Never echo or print secrets with shell commands.
+- Never run commands whose purpose is to display secret values unless the user explicitly asks and it is necessary; even then, avoid exposing the value and prefer verifying presence or validity.
+- When using credentials, prefer referencing existing environment variables, config files, credential stores, or secure runtime mechanisms without revealing their contents.
+- If credentials are missing, ask the user to provide or configure them through an appropriate secure mechanism. Do not ask the user to paste secrets into ordinary chat unless no safer mechanism exists.
+- If you must handle a secret to complete a task, use it only for the required operation and avoid persisting it.
+- Do not save secrets or transient authentication material to long-term memory.
+- Do not save secrets to scratchpad or plan. If state must be tracked, store only non-sensitive metadata such as "credential configured" or "authentication missing".
+- Before writing files, commands, summaries, or artifacts, ensure they do not contain secret values.
+- If accidental secret exposure appears likely, stop and ask for confirmation or suggest a safer approach.`,
+	})
+
+	b.AddStatic(Section{
+		Name:     "Task Execution Rules",
+		Priority: 40,
+		Static:   true,
+		Level:    2,
+		Content: `IMPORTANT: Work toward the user's current request until it is complete, blocked, or requires user confirmation.
+IMPORTANT: Preserve the user's objective across setup work, tool calls, retries, environment checks, and intermediate discoveries.
+IMPORTANT: Before making assumptions or choosing defaults, first check the available context, memory, current state, and user-provided constraints.
+IMPORTANT: If multiple reasonable choices exist and no relevant context resolves the choice, ask the user instead of guessing.
+
+- Treat prerequisite setup, environment inspection, dependency installation, documentation lookup, authentication checks, and helper scripts as subtasks, not as the final objective.
+- Gather only information that is necessary for the current step.
+- Do not run a long sequence of unrelated tool calls.
+- After important tool results, keep task state synchronized through plan or scratchpad when useful.
+- If a user decision is required, make the blocker explicit and ask for the needed input.`,
+	})
+
+	b.AddStatic(Section{
+		Name:     "Plan Rules",
+		Priority: 50,
+		Static:   true,
+		Level:    2,
+		Content: `IMPORTANT: Use a plan when the task benefits from explicit step tracking, such as multi-step, risky, state-changing, debugging, deployment, external-system, or file-changing work.
+IMPORTANT: When a Current Plan is present, use it as the task's step structure and keep it synchronized with actual progress.
+IMPORTANT: A plan describes how to accomplish the user's objective. Do not replace the user's objective with a prerequisite or implementation detail.
+
+- Create a concise initial plan when the task clearly requires multiple dependent steps or meaningful state tracking.
+- Do not create or update a plan for simple one-step, read-only, or purely conversational tasks.
+- If the current step is complete and you are about to start a different step, advance the plan first.
+- Keep plans short, actionable, and focused on the user's goal.
+
+Allowed exceptions:
+- Simple factual questions that require no tools.
+- The user explicitly asks to read or list a specific file/directory.
+- A trivial one-step task with no risk and no state change.`,
+	})
+
+	b.AddStatic(Section{
+		Name:     "Scratchpad Rules",
+		Priority: 60,
+		Static:   true,
+		Level:    2,
+		Content: `IMPORTANT: Scratchpad is the place for volatile task state and progress.
+IMPORTANT: Use it when the task may continue after tool calls, setup work, retries, or intermediate discoveries.
+IMPORTANT: If a subtask completes but the final objective is not complete, save a concise progress or next_action entry.
+
+- Use plan for ordered task steps.
+- Use scratchpad for task-local state such as progress, selected values, blockers, assumptions, and next actions.
+- Use memory only for stable long-term facts, preferences, rules, or background knowledge.
+- Keep scratchpad entries short and actionable.
+- Do not store full logs, full tool outputs, full file contents, or long reasoning in scratchpad.`,
 	})
 
 	b.AddStatic(Section{
 		Name:     "Tool Usage Rules",
-		Priority: 40,
+		Priority: 70,
 		Static:   true,
 		Level:    2,
-		Content: `- Prefer dedicated tools over shell commands when possible.
-- When a tool returns an error, read the error and adjust. Don't repeat the same failing call.
-- Use relative paths only.
-- Inspect results before taking the next action.`,
+		Content: `CRITICAL: The actual available tools are provided separately through the model tool-calling API. Do not assume a tool exists unless it is available through that API.
+CRITICAL: If a tool result has been rejected by the user, do not retry the same or equivalent tool call unless the user explicitly changes their decision.
+IMPORTANT: Prefer dedicated tools over shell commands when a dedicated tool can do the job.
+
+- Do not use shell tools for simple file reading, directory listing, writing, editing, or deleting when dedicated tools are available.
+- Use read_file with offset and limit to inspect large files incrementally.
+- Use write_file when the full file content can be provided reliably in one tool call.
+- Avoid batching many tool calls at once. Prefer one focused tool call, inspect the result, then decide the next action.
+- For risky, state-changing, destructive, or non-obvious tool calls, briefly state the intent before calling the tool.`,
+	})
+
+	b.AddStatic(Section{
+		Name:     "Skill Rules",
+		Priority: 80,
+		Static:   true,
+		Level:    2,
+		Content: `IMPORTANT: A skill's name and description are only an index. Before relying on a skill, inspect its SKILL.md through the skill tool.
+CRITICAL: Use each skill strictly according to its own documentation. Do not invent script paths, commands, arguments, environment variables, outputs, or workflows.
+
+- Do not rely on earlier conversation history about installed skills if the current Installed Skills section says otherwise.
+- If no skills are currently installed, say so plainly when asked.
+- If multiple skills can reasonably solve the user's task, do not choose silently. Briefly present suitable skills, explain the practical difference, and ask the user which one they prefer.
+- If the user has already expressed a clear preference, follow that preference.
+- If SKILL.md gives a workflow, command, argument format, or order of operations, follow it exactly.
+- If SKILL.md is ambiguous or incomplete, inspect relevant skill resources before acting. If it is still unclear, ask the user instead of guessing.
+- Do not copy skill scripts into the workspace just to execute them.`,
+	})
+
+	b.AddStatic(Section{
+		Name:     "Memory Rules",
+		Priority: 90,
+		Static:   true,
+		Level:    2,
+		Content: `IMPORTANT: Use memory only for stable long-term facts, preferences, rules, and background knowledge.
+IMPORTANT: Before answering questions about remembered information, or before making a decision that may depend on saved information, use the relevant memory context.
+CRITICAL: Do not store temporary tool outputs, transient observations, or intermediate reasoning in long-term memory.
+
+- Use plan for the task step structure.
+- Scratchpad is short-term task memory.
+- Use memory when the user states a stable preference, rule, personal information, or project fact.
+- Use memory query before answering questions about previously saved information.`,
 	})
 
 	b.AddStatic(Section{
 		Name:     "Completion Rules",
-		Priority: 50,
+		Priority: 100,
 		Static:   true,
 		Level:    2,
-		Content: `- Stop when the task is done.
-- If blocked, explain the blocker clearly.
-- Provide a concise summary of what was done.`,
+		Content: `CRITICAL: Do not claim completion unless the relevant work has actually been performed or verified.
+IMPORTANT: Before ending the turn, check the user's current request and the Current Plan if present.
+IMPORTANT: Do not treat completed setup work or prerequisite work as completion of the final objective.
+
+- If the final objective is complete, provide a concise final summary of what was done.
+- If a prerequisite or subtask is complete but the final objective is not complete, continue toward the final objective when the next step is clear and safe.
+- If you stop because you are blocked, explain the blocker clearly and state what input, decision, permission, credential, or capability is needed.
+- If the Current Plan has pending or in_progress steps, continue only when the next step is clear, safe, and useful.
+- Include important outputs, changed files/resources, created artifacts, executed commands, or other relevant results.
+- If there are remaining risks, assumptions, cleanup steps, or next steps, list them clearly.`,
 	})
 
 	b.AddStatic(Section{
 		Name:     "Tone and Output",
-		Priority: 60,
+		Priority: 110,
 		Static:   true,
 		Level:    2,
-		Content: `- Be concise, practical, and action-oriented.
-- If something fails, explain briefly and try the next best approach.`,
+		Content: `IMPORTANT: Be concise, practical, and action-oriented.
+IMPORTANT: Keep user-facing text focused on progress, decisions, results, and next actions.
+
+- Prefer direct answers and concrete next actions.
+- Avoid long hidden-style reasoning in user-facing text.
+- Do not narrate every internal consideration.
+- Summarize tool results only as much as needed to continue the task.
+- If something fails, explain the failure briefly and choose the next best action.
+- Avoid repeating the same status update unless new information was learned.`,
 	})
 
 	b.AddDynamic(dynamicBoundary)
 	b.AddDynamic(dynamicEnvironment)
 	b.AddDynamic(dynamicProjectContext)
 	b.AddDynamic(dynamicUserProfile)
+	b.AddDynamic(dynamicInstalledSkills)
+	b.AddDynamic(dynamicSkillMarketplace)
 
 	b.AddDynamic(reservedPlan)
 	b.AddDynamic(reservedScratchpad)
@@ -181,9 +405,11 @@ var dynamicBoundary = func(ctx context.Context, input openagent.PromptInput) []S
 		Priority: 10,
 		Static:   false,
 		Level:    2,
-		Content: `The following context is generated fresh for the current request.
-This dynamic context is authoritative for current runtime state.
-If it conflicts with earlier conversation history, prefer this dynamic context.`,
+		Content: `CRITICAL: The following context is generated fresh for the current request.
+IMPORTANT: This dynamic context is authoritative for current runtime state when present.
+
+It may include the current user request, environment, installed skills, current plan, scratchpad, retrieved memory, and other runtime state.
+If this dynamic context conflicts with earlier conversation history, prefer this dynamic context. Earlier assistant statements about installed skills, files, environment, plan state, or memory may be outdated.`,
 	}}
 }
 
@@ -193,10 +419,10 @@ var dynamicEnvironment = func(ctx context.Context, input openagent.PromptInput) 
 		Priority: 20,
 		Static:   false,
 		Level:    2,
-		Content: fmt.Sprintf("%s\n%s\n%s",
-			fmt.Sprintf("- operating_system: %s", runtime.GOOS),
-			fmt.Sprintf("- cpu_architecture: %s", runtime.GOARCH),
-			fmt.Sprintf("- %s", extractWorkspace(input.ProjectContext))),
+		Content: fmt.Sprintf("- operating_system: %s\n- cpu_architecture: %s\n- %s",
+			runtime.GOOS,
+			runtime.GOARCH,
+			extractWorkspace(input.ProjectContext)),
 	}}
 }
 
@@ -232,6 +458,48 @@ var dynamicUserProfile = func(ctx context.Context, input openagent.PromptInput) 
 		Static:   false,
 		Level:    2,
 		Content:  input.UserProfile,
+	}}
+}
+
+var dynamicInstalledSkills = func(ctx context.Context, input openagent.PromptInput) []Section {
+	if len(input.AvailableSkills) == 0 {
+		return []Section{{
+			Name:     "Installed Skills",
+			Priority: 50,
+			Static:   false,
+			Level:    2,
+			Content:  "No skills are currently installed.\nCRITICAL: Do not rely on earlier conversation history that mentioned installed skills. The current runtime has no installed skills available.",
+		}}
+	}
+	var catalog string
+	for _, s := range input.AvailableSkills {
+		catalog += "\n- **" + s.Name + "**: " + s.Description
+	}
+	return []Section{{
+		Name:     "Installed Skills",
+		Priority: 50,
+		Static:   false,
+		Level:    2,
+		Content:  "The following skills are currently installed.\nCRITICAL: This list is generated fresh for the current request. If it conflicts with earlier conversation history, this list is authoritative.\nIMPORTANT: Do not assume full skill contents from name or description alone. Use the skill tool to inspect SKILL.md before relying on a skill.\n" + catalog,
+	}}
+}
+
+var dynamicSkillMarketplace = func(ctx context.Context, input openagent.PromptInput) []Section {
+	return []Section{{
+		Name:     "Skill Marketplace",
+		Priority: 60,
+		Static:   false,
+		Level:    2,
+		Content: `You have access to a Skill Marketplace.
+
+IMPORTANT: Use this workflow when solving tasks:
+1. First, try to solve the task with the currently available tools and installed skills.
+2. If you are blocked, uncertain, or do not know how to handle the task, quickly look for relevant skills. Candidate skills may include already installed skills and installable but not yet installed skills.
+3. If an installed skill matches the task, use it.
+4. If a relevant skill is found but is not installed, do NOT install it automatically. Ask the user for confirmation.
+5. After installation, use the newly installed skill to continue the task.
+6. If multiple relevant skills are found, present the best 2-3 candidates and ask the user which one to install.
+7. If no relevant skill is found, say that no matching skill was found and continue with the best available approach.`,
 	}}
 }
 

--- a/cmd/cli/prompt/prompt.go
+++ b/cmd/cli/prompt/prompt.go
@@ -92,10 +92,6 @@ func (b *Builder) assemble(ctx context.Context, input openagent.PromptInput) []o
 		msgs = append(msgs, b.buildCompressedMsg(input.Compressed))
 	}
 
-	if len(input.AvailableSkills) > 0 {
-		msgs = append(msgs, b.buildSkillsMsg(input.AvailableSkills))
-	}
-
 	for name, body := range input.LoadedSkills {
 		msgs = append(msgs, openagent.Message{
 			Role:    openagent.RoleSystem,
@@ -155,20 +151,6 @@ func (b *Builder) buildCompressedMsg(cc *openagent.CompressedContext) openagent.
 	return openagent.Message{Role: openagent.RoleSystem, Content: content}
 }
 
-func (b *Builder) buildSkillsMsg(skills []openagent.SkillInfo) openagent.Message {
-	var catalog string
-	for _, s := range skills {
-		catalog += "\n### " + s.Name + "\n"
-		for k, v := range s.Frontmatter {
-			catalog += fmt.Sprintf("%s: %v\n", k, v)
-		}
-	}
-	return openagent.Message{
-		Role:    openagent.RoleSystem,
-		Content: "## Available Skills\n" + catalog,
-	}
-}
-
 func (b *Builder) applyBudget(msgs []openagent.Message) []openagent.Message {
 	if b.contextWindow <= 0 || len(msgs) == 0 {
 		return msgs
@@ -180,7 +162,7 @@ func (b *Builder) applyBudget(msgs []openagent.Message) []openagent.Message {
 
 	var result []openagent.Message
 	var workingMsgs []openagent.Message
-	var staticIdx, dynamicIdx, compressedIdx, loadedSkillStart int = -1, -1, -1, -1
+	var staticIdx, dynamicIdx, compressedIdx int = -1, -1, -1
 
 	for i, m := range msgs {
 		if m.Role != openagent.RoleSystem {
@@ -195,11 +177,8 @@ func (b *Builder) applyBudget(msgs []openagent.Message) []openagent.Message {
 			continue
 		}
 
-		if strings.HasPrefix(m.Content, "## Available Skills") ||
-			strings.HasPrefix(m.Content, "## Loaded Skill:") {
-			if loadedSkillStart < 0 {
-				loadedSkillStart = i
-			}
+		if strings.HasPrefix(m.Content, "## Loaded Skill:") {
+			result = append(result, m)
 			continue
 		}
 
@@ -221,19 +200,6 @@ func (b *Builder) applyBudget(msgs []openagent.Message) []openagent.Message {
 	if compressedIdx >= 0 {
 		content := b.trimContent(msgs[compressedIdx].Content, summaryBudget)
 		result = append(result, openagent.Message{Role: openagent.RoleSystem, Content: content})
-	}
-
-	if loadedSkillStart >= 0 {
-		for i := loadedSkillStart; i < len(msgs); i++ {
-			m := msgs[i]
-			if m.Role != openagent.RoleSystem {
-				break
-			}
-			if strings.HasPrefix(m.Content, "## Conversation Summary") {
-				continue
-			}
-			result = append(result, m)
-		}
 	}
 
 	result = append(result, workingMsgs...)

--- a/cmd/cli/prompt/prompt.go
+++ b/cmd/cli/prompt/prompt.go
@@ -1,0 +1,339 @@
+package prompt
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	openagent "github.com/yusheng-g/openagent-go"
+	"github.com/yusheng-g/openagent-go/tokenizer"
+)
+
+type Section struct {
+	Name     string
+	Content  string
+	Priority int
+	Static   bool
+	Level    int
+	Skip     func(input openagent.PromptInput) bool
+}
+
+type DynamicFn func(ctx context.Context, input openagent.PromptInput) []Section
+
+type BudgetConfig struct {
+	StaticRatio  float64
+	DynamicRatio float64
+	SummaryRatio float64
+}
+
+type Builder struct {
+	staticSections []Section
+	dynamicFns     []DynamicFn
+	budget         BudgetConfig
+	modelID        string
+	contextWindow  int
+}
+
+func NewBuilder(modelID string, contextWindow int) *Builder {
+	return &Builder{
+		modelID:       modelID,
+		contextWindow: contextWindow,
+		budget: BudgetConfig{
+			StaticRatio:  0.12,
+			DynamicRatio: 0.08,
+			SummaryRatio: 0.05,
+		},
+	}
+}
+
+func (b *Builder) AddStatic(s Section) *Builder {
+	b.staticSections = append(b.staticSections, s)
+	return b
+}
+
+func (b *Builder) AddDynamic(fn DynamicFn) *Builder {
+	b.dynamicFns = append(b.dynamicFns, fn)
+	return b
+}
+
+func (b *Builder) Build() openagent.PromptBuilder {
+	return func(ctx context.Context, input openagent.PromptInput) ([]openagent.Message, error) {
+		return b.assemble(ctx, input), nil
+	}
+}
+
+func (b *Builder) assemble(ctx context.Context, input openagent.PromptInput) []openagent.Message {
+	var msgs []openagent.Message
+
+	static := b.collectStatic(input)
+	if len(static) > 0 {
+		content := renderSections(static)
+		if content != "" {
+			msgs = append(msgs, openagent.Message{
+				Role:    openagent.RoleSystem,
+				Content: content,
+			})
+		}
+	}
+
+	dynamic := b.collectDynamic(ctx, input)
+	if len(dynamic) > 0 {
+		content := renderSections(dynamic)
+		if content != "" {
+			msgs = append(msgs, openagent.Message{
+				Role:    openagent.RoleSystem,
+				Content: content,
+			})
+		}
+	}
+
+	if input.Compressed != nil && input.Compressed.Summary != "" {
+		msgs = append(msgs, b.buildCompressedMsg(input.Compressed))
+	}
+
+	if len(input.AvailableSkills) > 0 {
+		msgs = append(msgs, b.buildSkillsMsg(input.AvailableSkills))
+	}
+
+	for name, body := range input.LoadedSkills {
+		msgs = append(msgs, openagent.Message{
+			Role:    openagent.RoleSystem,
+			Content: "## Loaded Skill: " + name + "\n\n" + body,
+		})
+	}
+
+	msgs = append(msgs, input.WorkingMessages...)
+
+	return b.applyBudget(msgs)
+}
+
+func (b *Builder) collectStatic(input openagent.PromptInput) []Section {
+	var sections []Section
+	for _, s := range b.staticSections {
+		if s.Skip != nil && s.Skip(input) {
+			continue
+		}
+		if s.Content == "" {
+			continue
+		}
+		sections = append(sections, s)
+	}
+	sort.Slice(sections, func(i, j int) bool {
+		return sections[i].Priority < sections[j].Priority
+	})
+	return sections
+}
+
+func (b *Builder) collectDynamic(ctx context.Context, input openagent.PromptInput) []Section {
+	var sections []Section
+	for _, fn := range b.dynamicFns {
+		for _, s := range fn(ctx, input) {
+			if s.Skip != nil && s.Skip(input) {
+				continue
+			}
+			if s.Content == "" {
+				continue
+			}
+			sections = append(sections, s)
+		}
+	}
+	sort.Slice(sections, func(i, j int) bool {
+		return sections[i].Priority < sections[j].Priority
+	})
+	return sections
+}
+
+func (b *Builder) buildCompressedMsg(cc *openagent.CompressedContext) openagent.Message {
+	content := "## Conversation Summary\n" + cc.Summary
+	if len(cc.Hints) > 0 {
+		content += "\n\n### Retrieval Hints\n"
+		for i, h := range cc.Hints {
+			content += fmt.Sprintf("%d. %s (query: %s)\n", i+1, h.Description, h.Query)
+		}
+	}
+	return openagent.Message{Role: openagent.RoleSystem, Content: content}
+}
+
+func (b *Builder) buildSkillsMsg(skills []openagent.SkillInfo) openagent.Message {
+	var catalog string
+	for _, s := range skills {
+		catalog += "\n### " + s.Name + "\n"
+		for k, v := range s.Frontmatter {
+			catalog += fmt.Sprintf("%s: %v\n", k, v)
+		}
+	}
+	return openagent.Message{
+		Role:    openagent.RoleSystem,
+		Content: "## Available Skills\n" + catalog,
+	}
+}
+
+func (b *Builder) applyBudget(msgs []openagent.Message) []openagent.Message {
+	if b.contextWindow <= 0 || len(msgs) == 0 {
+		return msgs
+	}
+
+	staticBudget := int(float64(b.contextWindow) * 0.95 * b.budget.StaticRatio)
+	dynamicBudget := int(float64(b.contextWindow) * 0.95 * b.budget.DynamicRatio)
+	summaryBudget := int(float64(b.contextWindow) * 0.95 * b.budget.SummaryRatio)
+
+	var result []openagent.Message
+	var workingMsgs []openagent.Message
+	var staticIdx, dynamicIdx, compressedIdx, loadedSkillStart int = -1, -1, -1, -1
+
+	for i, m := range msgs {
+		if m.Role != openagent.RoleSystem {
+			workingMsgs = append(workingMsgs, m)
+			continue
+		}
+
+		if strings.HasPrefix(m.Content, "## Conversation Summary") {
+			if compressedIdx < 0 {
+				compressedIdx = i
+			}
+			continue
+		}
+
+		if strings.HasPrefix(m.Content, "## Available Skills") ||
+			strings.HasPrefix(m.Content, "## Loaded Skill:") {
+			if loadedSkillStart < 0 {
+				loadedSkillStart = i
+			}
+			continue
+		}
+
+		if staticIdx < 0 {
+			staticIdx = i
+		} else if dynamicIdx < 0 {
+			dynamicIdx = i
+		}
+	}
+
+	if staticIdx >= 0 {
+		content := b.trimContent(msgs[staticIdx].Content, staticBudget)
+		result = append(result, openagent.Message{Role: openagent.RoleSystem, Content: content})
+	}
+	if dynamicIdx >= 0 {
+		content := b.trimContent(msgs[dynamicIdx].Content, dynamicBudget)
+		result = append(result, openagent.Message{Role: openagent.RoleSystem, Content: content})
+	}
+	if compressedIdx >= 0 {
+		content := b.trimContent(msgs[compressedIdx].Content, summaryBudget)
+		result = append(result, openagent.Message{Role: openagent.RoleSystem, Content: content})
+	}
+
+	if loadedSkillStart >= 0 {
+		for i := loadedSkillStart; i < len(msgs); i++ {
+			m := msgs[i]
+			if m.Role != openagent.RoleSystem {
+				break
+			}
+			if strings.HasPrefix(m.Content, "## Conversation Summary") {
+				continue
+			}
+			result = append(result, m)
+		}
+	}
+
+	result = append(result, workingMsgs...)
+	return result
+}
+
+func (b *Builder) trimContent(content string, budget int) string {
+	if budget <= 0 {
+		return content
+	}
+	tokens := b.countTokens(content)
+	if tokens <= budget {
+		return content
+	}
+
+	lines := strings.Split(content, "\n")
+	sections := splitByHeadings(lines)
+
+	for len(sections) > 1 {
+		sections = sections[:len(sections)-1]
+		newContent := strings.Join(sections, "\n")
+		if b.countTokens(newContent) <= budget {
+			return newContent
+		}
+	}
+
+	if len(sections) == 1 {
+		return b.trimText(sections[0], budget)
+	}
+	return ""
+}
+
+func splitByHeadings(lines []string) []string {
+	var sections []string
+	var current []string
+	for _, line := range lines {
+		if strings.HasPrefix(line, "#") {
+			if len(current) > 0 {
+				sections = append(sections, strings.Join(current, "\n"))
+			}
+			current = []string{line}
+		} else {
+			current = append(current, line)
+		}
+	}
+	if len(current) > 0 {
+		sections = append(sections, strings.Join(current, "\n"))
+	}
+	return sections
+}
+
+func (b *Builder) trimText(text string, budget int) string {
+	if b.countTokens(text) <= budget {
+		return text
+	}
+
+	runes := []rune(text)
+	target := budget * 4
+	if target > len(runes) {
+		target = len(runes)
+	}
+	for target > 0 {
+		candidate := string(runes[:target]) + "\n\n[truncated]"
+		if b.countTokens(candidate) <= budget {
+			return candidate
+		}
+		target -= target / 10
+		if target < 10 {
+			target = target - 1
+		}
+	}
+	return text[:len(text)/2] + "\n\n[truncated]"
+}
+
+func (b *Builder) countTokens(text string) int {
+	if text == "" {
+		return 0
+	}
+	modelID := b.modelID
+	if modelID == "" {
+		modelID = "gpt-4o"
+	}
+	return tokenizer.Count(modelID, text)
+}
+
+func renderSections(sections []Section) string {
+	var buf strings.Builder
+	for i, s := range sections {
+		if i > 0 {
+			buf.WriteString("\n\n")
+		}
+		level := s.Level
+		if level <= 0 {
+			level = 2
+		}
+		buf.WriteString(strings.Repeat("#", level))
+		buf.WriteString(" ")
+		buf.WriteString(s.Name)
+		buf.WriteString("\n\n")
+		buf.WriteString(strings.TrimSpace(s.Content))
+	}
+	return buf.String()
+}

--- a/cmd/cli/prompt/prompt_test.go
+++ b/cmd/cli/prompt/prompt_test.go
@@ -1,0 +1,376 @@
+package prompt
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+
+	openagent "github.com/yusheng-g/openagent-go"
+)
+
+func TestDefaultCLI_Build(t *testing.T) {
+	b := DefaultCLI("gpt-4o", 128000)
+	pb := b.Build()
+
+	input := openagent.PromptInput{
+		ProjectContext: "Workspace: /home/test",
+		WorkingMessages: []openagent.Message{
+			openagent.UserMessage("hello"),
+		},
+	}
+
+	msgs, err := pb(context.Background(), input)
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+	if len(msgs) < 3 {
+		t.Fatalf("expected at least 3 messages (static + dynamic + working), got %d", len(msgs))
+	}
+
+	sysMsgs := 0
+	for _, m := range msgs {
+		if m.Role == openagent.RoleSystem {
+			sysMsgs++
+		}
+	}
+	if sysMsgs < 2 {
+		t.Fatalf("expected at least 2 system messages (static + dynamic), got %d", sysMsgs)
+	}
+
+	foundEnv := false
+	for _, m := range msgs {
+		if strings.Contains(m.Content, runtime.GOOS) && strings.Contains(m.Content, runtime.GOARCH) {
+			foundEnv = true
+			break
+		}
+	}
+	if !foundEnv {
+		t.Error("dynamic system message should contain OS and architecture")
+	}
+
+	lastMsg := msgs[len(msgs)-1]
+	if lastMsg.Role != openagent.RoleUser || lastMsg.Content != "hello" {
+		t.Errorf("last message should be the working user message, got role=%s content=%q", lastMsg.Role, lastMsg.Content)
+	}
+}
+
+func TestDefaultServer_Build(t *testing.T) {
+	b := DefaultServer("gpt-4o", 128000)
+	pb := b.Build()
+
+	input := openagent.PromptInput{
+		WorkingMessages: []openagent.Message{
+			openagent.UserMessage("hello"),
+		},
+	}
+
+	msgs, err := pb(context.Background(), input)
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+	if len(msgs) < 3 {
+		t.Fatalf("expected at least 3 messages, got %d", len(msgs))
+	}
+}
+
+func TestBuilder_SectionSorting(t *testing.T) {
+	b := NewBuilder("gpt-4o", 128000)
+
+	b.AddStatic(Section{Name: "C", Priority: 30, Static: true, Level: 2, Content: "c"})
+	b.AddStatic(Section{Name: "A", Priority: 10, Static: true, Level: 2, Content: "a"})
+	b.AddStatic(Section{Name: "B", Priority: 20, Static: true, Level: 2, Content: "b"})
+
+	pb := b.Build()
+	msgs, err := pb(context.Background(), openagent.PromptInput{})
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+	if len(msgs) == 0 {
+		t.Fatal("expected at least 1 system message")
+	}
+
+	idxA := strings.Index(msgs[0].Content, "## A")
+	idxB := strings.Index(msgs[0].Content, "## B")
+	idxC := strings.Index(msgs[0].Content, "## C")
+	if idxA < 0 || idxB < 0 || idxC < 0 {
+		t.Fatal("missing sections in output")
+	}
+	if !(idxA < idxB && idxB < idxC) {
+		t.Error("sections not sorted by priority")
+	}
+}
+
+func TestBuilder_SkipSection(t *testing.T) {
+	b := NewBuilder("gpt-4o", 128000)
+
+	skipCalled := false
+	b.AddStatic(Section{
+		Name:     "SkipMe",
+		Priority: 10,
+		Static:   true,
+		Level:    2,
+		Content:  "should not appear",
+		Skip: func(input openagent.PromptInput) bool {
+			skipCalled = true
+			return true
+		},
+	})
+	b.AddStatic(Section{
+		Name:     "Visible",
+		Priority: 20,
+		Static:   true,
+		Level:    2,
+		Content:  "visible content",
+	})
+
+	pb := b.Build()
+	msgs, err := pb(context.Background(), openagent.PromptInput{})
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+	if !skipCalled {
+		t.Error("Skip function was not called")
+	}
+	if strings.Contains(msgs[0].Content, "SkipMe") {
+		t.Error("skipped section should not appear in output")
+	}
+	if !strings.Contains(msgs[0].Content, "Visible") {
+		t.Error("visible section should appear in output")
+	}
+}
+
+func TestBuilder_EmptySection(t *testing.T) {
+	b := NewBuilder("gpt-4o", 128000)
+	b.AddStatic(Section{Name: "Empty", Priority: 10, Static: true, Level: 2, Content: ""})
+
+	pb := b.Build()
+	msgs, err := pb(context.Background(), openagent.PromptInput{})
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Error("empty section should not produce output")
+	}
+}
+
+func TestBuilder_CompressedSummary(t *testing.T) {
+	b := NewBuilder("gpt-4o", 128000)
+
+	pb := b.Build()
+	input := openagent.PromptInput{
+		Compressed: &openagent.CompressedContext{
+			Summary: "This is a summary of earlier conversation.",
+			Hints: []openagent.RetrievalHint{
+				{Description: "discussion about auth", Query: "auth"},
+			},
+		},
+	}
+
+	msgs, err := pb(context.Background(), input)
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	found := false
+	for _, m := range msgs {
+		if strings.Contains(m.Content, "Conversation Summary") &&
+			strings.Contains(m.Content, "earlier conversation") &&
+			strings.Contains(m.Content, "Retrieval Hints") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("compressed summary message not found in output")
+	}
+}
+
+func TestBuilder_AvailableSkills(t *testing.T) {
+	b := NewBuilder("gpt-4o", 128000)
+
+	pb := b.Build()
+	input := openagent.PromptInput{
+		AvailableSkills: []openagent.SkillInfo{
+			{Name: "web-dev", Frontmatter: map[string]any{"description": "web development helpers"}},
+		},
+	}
+
+	msgs, err := pb(context.Background(), input)
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	found := false
+	for _, m := range msgs {
+		if strings.Contains(m.Content, "Available Skills") && strings.Contains(m.Content, "web-dev") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("available skills message not found in output")
+	}
+}
+
+func TestBuilder_LoadedSkills(t *testing.T) {
+	b := NewBuilder("gpt-4o", 128000)
+
+	pb := b.Build()
+	input := openagent.PromptInput{
+		LoadedSkills: map[string]string{
+			"my-skill": "skill body content",
+		},
+	}
+
+	msgs, err := pb(context.Background(), input)
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	found := false
+	for _, m := range msgs {
+		if strings.Contains(m.Content, "Loaded Skill: my-skill") && strings.Contains(m.Content, "skill body content") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("loaded skill message not found in output")
+	}
+}
+
+func TestBuilder_BudgetTrimsContent(t *testing.T) {
+	b := NewBuilder("gpt-4o", 1000)
+
+	longContent := strings.Repeat("very long text that will consume many tokens. ", 200)
+	b.AddStatic(Section{Name: "Long", Priority: 10, Static: true, Level: 2, Content: longContent})
+
+	pb := b.Build()
+	msgs, err := pb(context.Background(), openagent.PromptInput{
+		WorkingMessages: []openagent.Message{
+			openagent.UserMessage("hello"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	staticTokens := b.countTokens(longContent)
+	budget := int(float64(1000) * 0.95 * 0.12)
+
+	if staticTokens <= budget {
+		t.Skip("content doesn't exceed budget — trimming not triggered")
+	}
+
+	trimmedTokens := b.countTokens(msgs[0].Content)
+	if trimmedTokens > budget {
+		t.Errorf("trimmed content tokens (%d) should be <= budget (%d)", trimmedTokens, budget)
+	}
+	if !strings.Contains(msgs[0].Content, "[truncated]") {
+		t.Error("trimmed content should contain [truncated] marker")
+	}
+}
+
+func TestDefaultCLI_ReservedSectionsAreSkipped(t *testing.T) {
+	b := DefaultCLI("gpt-4o", 128000)
+	pb := b.Build()
+
+	msgs, err := pb(context.Background(), openagent.PromptInput{})
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	for _, m := range msgs {
+		if strings.Contains(m.Content, "Current Plan") ||
+			strings.Contains(m.Content, "## Scratchpad") ||
+			strings.Contains(m.Content, "Episodic Memory") ||
+			strings.Contains(m.Content, "Semantic Memory") {
+			t.Errorf("reserved section should not appear: %s", m.Content[:200])
+		}
+	}
+}
+
+func TestDefaultCLI_UserProfile(t *testing.T) {
+	b := DefaultCLI("gpt-4o", 128000)
+	pb := b.Build()
+
+	msgs, err := pb(context.Background(), openagent.PromptInput{
+		UserProfile: "Expert Go developer",
+	})
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	found := false
+	for _, m := range msgs {
+		if strings.Contains(m.Content, "User Profile") && strings.Contains(m.Content, "Expert Go") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("user profile section not found in output")
+	}
+}
+
+func TestDefaultCLI_AgentDescription(t *testing.T) {
+	b := DefaultCLI("gpt-4o", 128000)
+	pb := b.Build()
+
+	msgs, err := pb(context.Background(), openagent.PromptInput{
+		AgentDescription: "A specialized billing agent.",
+	})
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+	if len(msgs) < 2 {
+		t.Fatal("expected at least 2 messages")
+	}
+}
+
+func TestDynamicEnvironment_ContainsOSInfo(t *testing.T) {
+	b := DefaultCLI("gpt-4o", 128000)
+	pb := b.Build()
+
+	msgs, err := pb(context.Background(), openagent.PromptInput{
+		ProjectContext: "Workspace: /tmp/test",
+	})
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	found := false
+	for _, m := range msgs {
+		if strings.Contains(m.Content, fmt.Sprintf("operating_system: %s", runtime.GOOS)) &&
+			strings.Contains(m.Content, fmt.Sprintf("cpu_architecture: %s", runtime.GOARCH)) &&
+			strings.Contains(m.Content, "working_directory: /tmp/test") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("environment section missing OS/arch/workspace info")
+	}
+}
+
+func TestEmptyProjectContext(t *testing.T) {
+	b := DefaultCLI("gpt-4o", 128000)
+	pb := b.Build()
+
+	msgs, err := pb(context.Background(), openagent.PromptInput{})
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+
+	sysCount := 0
+	for _, m := range msgs {
+		if m.Role == openagent.RoleSystem {
+			sysCount++
+		}
+	}
+	if sysCount < 2 {
+		t.Errorf("expected at least 2 system messages, got %d", sysCount)
+	}
+}

--- a/cmd/cli/prompt/prompt_test.go
+++ b/cmd/cli/prompt/prompt_test.go
@@ -188,7 +188,7 @@ func TestBuilder_CompressedSummary(t *testing.T) {
 }
 
 func TestBuilder_AvailableSkills(t *testing.T) {
-	b := NewBuilder("gpt-4o", 128000)
+	b := DefaultServer("gpt-4o", 128000)
 
 	pb := b.Build()
 	input := openagent.PromptInput{
@@ -204,13 +204,13 @@ func TestBuilder_AvailableSkills(t *testing.T) {
 
 	found := false
 	for _, m := range msgs {
-		if strings.Contains(m.Content, "Available Skills") && strings.Contains(m.Content, "web-dev") {
+		if strings.Contains(m.Content, "Installed Skills") && strings.Contains(m.Content, "web-dev") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Error("available skills message not found in output")
+		t.Error("installed skills message not found in output")
 	}
 }
 
@@ -283,10 +283,10 @@ func TestDefaultCLI_ReservedSectionsAreSkipped(t *testing.T) {
 	}
 
 	for _, m := range msgs {
-		if strings.Contains(m.Content, "Current Plan") ||
-			strings.Contains(m.Content, "## Scratchpad") ||
-			strings.Contains(m.Content, "Episodic Memory") ||
-			strings.Contains(m.Content, "Semantic Memory") {
+		if strings.HasPrefix(m.Content, "## Current Plan") ||
+			strings.HasPrefix(m.Content, "## Scratchpad") ||
+			strings.HasPrefix(m.Content, "## Episodic Memory") ||
+			strings.HasPrefix(m.Content, "## Semantic Memory") {
 			t.Errorf("reserved section should not appear: %s", m.Content[:200])
 		}
 	}

--- a/cmd/cli/sdk/rust/src/host.rs
+++ b/cmd/cli/sdk/rust/src/host.rs
@@ -13,6 +13,8 @@ mod ffi {
         pub fn log_info(mp: u32, ml: u32);
         pub fn log_warn(mp: u32, ml: u32);
         pub fn log_error(mp: u32, ml: u32);
+        pub fn get_env(kp: u32, kl: u32) -> u64;
+        pub fn get_time_utc() -> u64;
     }
 }
 
@@ -69,6 +71,16 @@ fn find_u32(d: &[u8], k: &[u8]) -> u32 {
 pub fn log_info(msg: &str) { unsafe { ffi::log_info(msg.as_ptr() as u32, msg.len() as u32) } }
 pub fn log_warn(msg: &str) { unsafe { ffi::log_warn(msg.as_ptr() as u32, msg.len() as u32) } }
 pub fn log_error(msg: &str) { unsafe { ffi::log_error(msg.as_ptr() as u32, msg.len() as u32) } }
+
+pub fn get_env(key: &str) -> Option<&'static str> {
+    let (p, l) = up(unsafe { ffi::get_env(key.as_ptr() as u32, key.len() as u32) });
+    if p == 0 && l == 0 { None } else { Some(unsafe { wasm_str(p, l) }) }
+}
+
+pub fn get_time_utc() -> Option<&'static str> {
+    let (p, l) = up(unsafe { ffi::get_time_utc() });
+    if p == 0 && l == 0 { None } else { Some(unsafe { wasm_str(p, l) }) }
+}
 
 fn find_body(d: &[u8]) -> usize {
     let pat = b"\"body\":\"";

--- a/cmd/cli/sdk/rust/src/lib.rs
+++ b/cmd/cli/sdk/rust/src/lib.rs
@@ -24,10 +24,10 @@ unsafe impl GlobalAlloc for BumpAlloc {
     unsafe fn alloc(&self, layout: core::alloc::Layout) -> *mut u8 {
         let size = layout.size();
         let align = layout.align();
-        let ptr = HEAP.as_ptr() as *mut u8;
+        let ptr = core::ptr::addr_of_mut!(HEAP).cast::<u8>();
         let offset = OFF;
         let aligned = (offset + align - 1) & !(align - 1);
-        if aligned + size <= HEAP.len() {
+        if aligned + size <= HEAP_SIZE {
             OFF = aligned + size;
             ptr.add(aligned)
         } else {
@@ -40,7 +40,8 @@ unsafe impl GlobalAlloc for BumpAlloc {
 #[global_allocator]
 static ALLOC: BumpAlloc = BumpAlloc;
 
-const HEAP: [u8; 131072] = [0; 131072]; // 128 KB
+const HEAP_SIZE: usize = 131072; // 128 KB
+static mut HEAP: [u8; HEAP_SIZE] = [0; HEAP_SIZE];
 static mut OFF: usize = 0;
 
 // ── panic ──

--- a/cmd/cli/server/agent.go
+++ b/cmd/cli/server/agent.go
@@ -122,7 +122,7 @@ func Run(ctx context.Context, opts Options) error {
 	}
 
 	if opts.ACP {
-		return runACP(ac)
+		return runACP(ctx, ac)
 	}
 	return runREST(ctx, opts.Config, ac.Agent, ac.ModelInfos, ac.Mem, ac.SessionStore)
 }
@@ -551,7 +551,7 @@ func (s *sqliteACPStore) Close() error { return nil }
 
 // ── handler ──
 
-func runACP(ac *agentContext) error {
+func runACP(ctx context.Context, ac *agentContext) error {
 	store := newACPStore(ac.Mem)
 	srv := &acpHandler{
 		agent:          ac.Agent,
@@ -562,7 +562,10 @@ func runACP(ac *agentContext) error {
 	}
 	server := openacp.NewServer("openagent-acp", "1.0.0", srv)
 	log.Println("ACP server starting on stdio")
-	return server.Run(context.Background())
+	if err := server.Run(ctx); err != nil && err != context.Canceled {
+		return err
+	}
+	return nil
 }
 
 func newACPStore(mem openagent.Memory) ACPSessionStore {

--- a/cmd/cli/server/agent.go
+++ b/cmd/cli/server/agent.go
@@ -32,8 +32,9 @@ import (
 )
 
 type Options struct {
-	Config *config.Config
-	ACP    bool
+	Config    *config.Config
+	ACP       bool
+	ACPDBPath string
 }
 
 type agentContext struct {
@@ -122,7 +123,7 @@ func Run(ctx context.Context, opts Options) error {
 	}
 
 	if opts.ACP {
-		return runACP(ctx, ac)
+		return runACP(ctx, ac, opts.ACPDBPath)
 	}
 	return runREST(ctx, opts.Config, ac.Agent, ac.ModelInfos, ac.Mem, ac.SessionStore)
 }
@@ -410,7 +411,8 @@ func (s *memoryACPStore) Close() error { return nil }
 // ── sqlite store ──
 
 type sqliteACPStore struct {
-	db *sql.DB
+	db      *sql.DB
+	ownedDB bool
 }
 
 func newSQLiteACPStore(db *sql.DB) (*sqliteACPStore, error) {
@@ -547,12 +549,51 @@ func (s *sqliteACPStore) EnsureSession(ctx context.Context, id, cwd string) erro
 	return err
 }
 
-func (s *sqliteACPStore) Close() error { return nil }
+func (s *sqliteACPStore) Close() error {
+	if s.ownedDB {
+		return s.db.Close()
+	}
+	return nil
+}
+
+func newExternalACPStore(dbPath string) (ACPSessionStore, error) {
+	dsn := dbPath + "?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("acp external db: open: %w", err)
+	}
+	if err := migrateACPStore(db); err != nil {
+		db.Close()
+		return nil, err
+	}
+	if _, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS messages (
+			id         INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_id TEXT NOT NULL,
+			role       TEXT NOT NULL,
+			content    TEXT NOT NULL DEFAULT ''
+		);
+		CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, id);
+	`); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("acp external db: migrate messages: %w", err)
+	}
+	return &sqliteACPStore{db: db, ownedDB: true}, nil
+}
 
 // ── handler ──
 
-func runACP(ctx context.Context, ac *agentContext) error {
-	store := newACPStore(ac.Mem)
+func runACP(ctx context.Context, ac *agentContext, externalDBPath string) error {
+	var store ACPSessionStore
+	if externalDBPath != "" {
+		var err error
+		store, err = newExternalACPStore(externalDBPath)
+		if err != nil {
+			return err
+		}
+	} else {
+		store = newACPStore(ac.Mem)
+	}
 	srv := &acpHandler{
 		agent:          ac.Agent,
 		approver:       ac.Approver,

--- a/cmd/cli/server/agent.go
+++ b/cmd/cli/server/agent.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -37,6 +38,7 @@ type Options struct {
 
 type agentContext struct {
 	Agent        *openagent.Agent
+	Approver     *acpApprover
 	ModelInfos   []modelReg
 	Mem          openagent.Memory
 	SessionStore rest.SessionStore
@@ -91,17 +93,21 @@ func buildAgentContext(cfg *config.Config) (*agentContext, error) {
 
 	skillLoader := skillfs.New(skillRoot)
 
+	approver := &acpApprover{reqs: make(map[string]openacp.PermissionRequester)}
+
 	agent := openagent.NewAgent("assistant",
 		openagent.WithModel(primaryModel),
 		openagent.WithMemory(mem),
 		openagent.WithPrompt(promptBuilder),
 		openagent.WithSkillLoader(skillLoader),
 		openagent.WithTools(agentTools...),
+		openagent.WithApprover(approver),
 		openagent.WithMaxTurns(100),
 	)
 
 	return &agentContext{
 		Agent:        agent,
+		Approver:     approver,
 		ModelInfos:   modelInfos,
 		Mem:          mem,
 		SessionStore: sessionStore,
@@ -551,9 +557,10 @@ func (s *sqliteACPStore) Close() error { return nil }
 func runACP(ac *agentContext) error {
 	store := newACPStore(ac.Mem)
 	srv := &acpHandler{
-		agent:      ac.Agent,
-		store:      store,
-		modelInfos: ac.ModelInfos,
+		agent:          ac.Agent,
+		approver:       ac.Approver,
+		store:          store,
+		modelInfos:     ac.ModelInfos,
 		defaultModelID: firstModelID(ac.ModelInfos),
 	}
 	server := openacp.NewServer("openagent-acp", "1.0.0", srv)
@@ -573,6 +580,7 @@ func newACPStore(mem openagent.Memory) ACPSessionStore {
 
 type acpHandler struct {
 	agent          *openagent.Agent
+	approver       *acpApprover
 	store          ACPSessionStore
 	modelInfos     []modelReg
 	defaultModelID string
@@ -589,6 +597,27 @@ func (h *acpHandler) findModel(modelID string) openagent.Model {
 		}
 	}
 	return nil
+}
+
+func (h *acpHandler) buildConfigOptions(currentModelID string) []openacp.SessionConfigOption {
+	if len(h.modelInfos) == 0 {
+		return nil
+	}
+	opts := make([]openacp.SessionConfigOptValue, len(h.modelInfos))
+	for i, mi := range h.modelInfos {
+		id := mi.ID
+		if mi.Provider != "" {
+			id = mi.Provider + "/" + mi.ID
+		}
+		opts[i] = openacp.SessionConfigOptValue{Value: id, Label: id}
+	}
+	return []openacp.SessionConfigOption{{
+		Type:         "select",
+		Name:         "model",
+		Label:        "Model",
+		CurrentValue: currentModelID,
+		Options:      opts,
+	}}
 }
 
 func (h *acpHandler) OnInitialize(ctx context.Context, req openacp.InitializeRequest) (*openacp.InitializeResponse, error) {
@@ -614,7 +643,11 @@ func (h *acpHandler) OnNewSession(ctx context.Context, req openacp.NewSessionReq
 		return nil, fmt.Errorf("acp create session: %w", err)
 	}
 	h.store.SetModel(ctx, id, h.defaultModelID)
-	return &openacp.NewSessionResponse{SessionID: id}, nil
+	log.Printf("acp OnNewSession: id=%s cwd=%s model=%s", id, req.Cwd, h.defaultModelID)
+	return &openacp.NewSessionResponse{
+		SessionID:     id,
+		ConfigOptions: h.buildConfigOptions(h.defaultModelID),
+	}, nil
 }
 
 func (h *acpHandler) OnLoadSession(ctx context.Context, req openacp.LoadSessionRequest, sender openacp.SessionEventSender) (*openacp.LoadSessionResponse, error) {
@@ -638,7 +671,13 @@ func (h *acpHandler) OnLoadSession(ctx context.Context, req openacp.LoadSessionR
 	if si.Title != "" {
 		sender.SendSessionInfo(si.Title, nil)
 	}
-	return &openacp.LoadSessionResponse{}, nil
+	modelID, _ := h.store.GetModel(ctx, req.SessionID)
+	if modelID == "" {
+		modelID = h.defaultModelID
+	}
+	return &openacp.LoadSessionResponse{
+		ConfigOptions: h.buildConfigOptions(modelID),
+	}, nil
 }
 
 func (h *acpHandler) OnListSessions(ctx context.Context, req openacp.ListSessionsRequest) (*openacp.ListSessionsResponse, error) {
@@ -670,6 +709,8 @@ func (h *acpHandler) OnPrompt(ctx context.Context, req openacp.PromptRequest, se
 		return nil, fmt.Errorf("no text in prompt")
 	}
 
+	log.Printf("acp OnPrompt: session=%s input=%q", req.SessionID, input)
+
 	h.store.AppendMessage(ctx, req.SessionID, "user", input)
 
 	var responseText strings.Builder
@@ -677,27 +718,62 @@ func (h *acpHandler) OnPrompt(ctx context.Context, req openacp.PromptRequest, se
 	if mID, ok := h.store.GetModel(ctx, req.SessionID); ok {
 		if m := h.findModel(mID); m != nil {
 			session.Model = m
+			log.Printf("acp OnPrompt: using model=%s", mID)
 		}
+	} else {
+		log.Printf("acp OnPrompt: no model found for session, using default")
 	}
+
+	var planEntries []openacp.PlanEntry
+
+	log.Printf("acp OnPrompt: starting RunStream")
 	ch := h.agent.RunStream(ctx, session, openagent.UserMessage(input))
+	eventCount := 0
 	for evt := range ch {
+		eventCount++
+		log.Printf("acp OnPrompt: event #%d type=%s", eventCount, evt.Type)
 		switch evt.Type {
 		case openagent.StreamTextDelta:
 			responseText.WriteString(evt.Text)
-			sender.SendAgentMessage(evt.Text)
+			if err := sender.SendAgentMessage(evt.Text); err != nil {
+				log.Printf("acp OnPrompt: SendAgentMessage error: %v", err)
+			}
 		case openagent.StreamToolCall:
 			if len(evt.Message.ToolCalls) > 0 {
 				tc := evt.Message.ToolCalls[0]
-				sender.SendToolCall(openacp.ToolCallEvent{ID: tc.ID, Title: tc.Function.Name, Status: "in_progress", RawInput: map[string]any{"args": tc.Function.Arguments}})
+				log.Printf("acp OnPrompt: tool_call=%s", tc.Function.Name)
+				if err := sender.SendToolCall(openacp.ToolCallEvent{ID: tc.ID, Title: tc.Function.Name, Status: "in_progress", RawInput: map[string]any{"args": tc.Function.Arguments}}); err != nil {
+					log.Printf("acp OnPrompt: SendToolCall error: %v", err)
+				}
+				planEntries = append(planEntries, openacp.PlanEntry{
+					Title:    tc.Function.Name,
+					Priority: "medium",
+					Status:   "in_progress",
+				})
+				sender.SendPlan(planEntries)
 			}
 		case openagent.StreamToolResult:
-			sender.SendToolCall(openacp.ToolCallEvent{ID: evt.Message.ToolCallID, Status: "completed", RawOutput: map[string]any{"result": evt.Message.Content}})
+			log.Printf("acp OnPrompt: tool_result id=%s", evt.Message.ToolCallID)
+			if err := sender.SendToolCall(openacp.ToolCallEvent{ID: evt.Message.ToolCallID, Status: "completed", RawOutput: map[string]any{"result": evt.Message.Content}}); err != nil {
+				log.Printf("acp OnPrompt: SendToolCall result error: %v", err)
+			}
+			for i := range planEntries {
+				if planEntries[i].Status == "in_progress" {
+					planEntries[i].Status = "completed"
+					break
+				}
+			}
+			sender.SendPlan(planEntries)
 		case openagent.StreamError:
+			log.Printf("acp OnPrompt: stream error: %v", evt.Error)
 			return nil, evt.Error
 		case openagent.StreamAborted:
+			log.Printf("acp OnPrompt: stream aborted")
 			return &openacp.PromptResponse{StopReason: "cancelled"}, nil
 		}
 	}
+
+	log.Printf("acp OnPrompt: stream ended, total events=%d, response len=%d", eventCount, responseText.Len())
 
 	finalText := responseText.String()
 	h.store.AppendMessage(ctx, req.SessionID, "assistant", finalText)
@@ -708,6 +784,7 @@ func (h *acpHandler) OnPrompt(ctx context.Context, req openacp.PromptRequest, se
 	}
 	h.store.SetTitle(ctx, req.SessionID, title)
 
+	log.Printf("acp OnPrompt: done, returning end_turn, response=%q", finalText[:min(len(finalText), 200)])
 	return &openacp.PromptResponse{StopReason: "end_turn"}, nil
 }
 
@@ -719,15 +796,28 @@ func (h *acpHandler) OnDeleteSession(ctx context.Context, sid string) error {
 
 func (h *acpHandler) OnCloseSession(ctx context.Context, sid string) error { return nil }
 
-func (h *acpHandler) OnSetSessionConfigOption(ctx context.Context, sessionID string, opt openacp.SetConfigOption) error {
-	modelID, ok := opt.Value.(string)
-	if !ok {
-		return nil
+func (h *acpHandler) OnSetSessionConfigOption(ctx context.Context, sessionID string, opt openacp.SetConfigOption) ([]openacp.SessionConfigOption, error) {
+	switch opt.ID {
+	case "model":
+		modelID, ok := opt.Value.(string)
+		if !ok {
+			return nil, nil
+		}
+		if m := h.findModel(modelID); m == nil {
+			return nil, nil
+		}
+		if err := h.store.SetModel(ctx, sessionID, modelID); err != nil {
+			return nil, err
+		}
+		return h.buildConfigOptions(modelID), nil
+	default:
+		// Unknown or boolean option — accept silently, return current options.
+		currentModel, _ := h.store.GetModel(ctx, sessionID)
+		if currentModel == "" {
+			currentModel = h.defaultModelID
+		}
+		return h.buildConfigOptions(currentModel), nil
 	}
-	if m := h.findModel(modelID); m == nil {
-		return nil
-	}
-	return h.store.SetModel(ctx, sessionID, modelID)
 }
 
 func (h *acpHandler) OnSetSessionMode(ctx context.Context, sessionID string, modeID string) error {
@@ -736,6 +826,75 @@ func (h *acpHandler) OnSetSessionMode(ctx context.Context, sessionID string, mod
 
 // Compile-time check: acpHandler implements ConfigHandler.
 var _ openacp.ConfigHandler = (*acpHandler)(nil)
+
+// ── Permission (ACP request_permission) ──
+
+type acpApprover struct {
+	mu   sync.Mutex
+	reqs map[string]openacp.PermissionRequester
+}
+
+func (a *acpApprover) register(sessionID string, req openacp.PermissionRequester) {
+	a.mu.Lock()
+	a.reqs[sessionID] = req
+	a.mu.Unlock()
+}
+
+func (a *acpApprover) unregister(sessionID string) {
+	a.mu.Lock()
+	delete(a.reqs, sessionID)
+	a.mu.Unlock()
+}
+
+func (a *acpApprover) Approve(ctx context.Context, call openagent.ToolCall, def openagent.FunctionDefinition, session openagent.Session) (bool, string) {
+	a.mu.Lock()
+	req := a.reqs[session.ID]
+	a.mu.Unlock()
+	if req == nil {
+		return true, ""
+	}
+	options := []openacp.PermissionOption{
+		{Kind: "allow_once", Name: "Allow once", OptionID: "allow_once"},
+		{Kind: "allow_always", Name: "Allow always", OptionID: "allow_always"},
+		{Kind: "reject_once", Name: "Reject once", OptionID: "reject_once"},
+	}
+	outcome, err := req.RequestPermission(ctx, openacp.ToolCallEvent{
+		ID:       call.ID,
+		Title:    def.Name,
+		RawInput: json.RawMessage(call.Function.Arguments),
+	}, options)
+	if err != nil {
+		log.Printf("acp: permission request failed (allowing tool %q): %v", def.Name, err)
+		return true, ""
+	}
+	if outcome.Cancelled {
+		return false, "cancelled"
+	}
+	switch outcome.OptionID {
+	case "allow_once", "allow_always":
+		return true, ""
+	case "reject_once", "reject_always":
+		return false, "rejected"
+	default:
+		return true, ""
+	}
+}
+
+func (h *acpHandler) RegisterPermissionRequester(sessionID string, req openacp.PermissionRequester) {
+	if h.approver != nil {
+		h.approver.register(sessionID, req)
+	}
+}
+
+func (h *acpHandler) UnregisterPermissionRequester(sessionID string) {
+	if h.approver != nil {
+		h.approver.unregister(sessionID)
+	}
+}
+
+// Compile-time checks.
+var _ openagent.Approver = (*acpApprover)(nil)
+var _ openacp.PermissionRegistrar = (*acpHandler)(nil)
 
 // ── ACP over WebSocket ──
 
@@ -763,7 +922,7 @@ func RunACPWS(ctx context.Context, cfg *config.Config, port int) error {
 		}
 		defer ws.Close()
 
-		handler := &acpHandler{agent: ac.Agent, store: store, modelInfos: ac.ModelInfos, defaultModelID: firstModelID(ac.ModelInfos)}
+		handler := &acpHandler{agent: ac.Agent, approver: ac.Approver, store: store, modelInfos: ac.ModelInfos, defaultModelID: firstModelID(ac.ModelInfos)}
 		br := &wsBridge{conn: ws}
 		server := openacp.NewServer("openagent-acp", "1.0.0", handler)
 		log.Printf("acp-ws: client connected")

--- a/cmd/cli/server/agent.go
+++ b/cmd/cli/server/agent.go
@@ -1,17 +1,23 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"database/sql"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
-	openacp "github.com/yusheng-g/openagent-go/acp"
+	"github.com/gorilla/websocket"
+	_ "modernc.org/sqlite"
+
 	openagent "github.com/yusheng-g/openagent-go"
+	openacp "github.com/yusheng-g/openagent-go/acp"
 	"github.com/yusheng-g/openagent-go/memory/sqlite"
 	"github.com/yusheng-g/openagent-go/model/openai"
 	"github.com/yusheng-g/openagent-go/rest"
@@ -20,6 +26,7 @@ import (
 	opentool "github.com/yusheng-g/openagent-go/tool"
 
 	"github.com/yusheng-g/openagent-go/cmd/cli/config"
+	"github.com/yusheng-g/openagent-go/cmd/cli/prompt"
 )
 
 type Options struct {
@@ -27,26 +34,44 @@ type Options struct {
 	ACP    bool
 }
 
-func Run(ctx context.Context, opts Options) error {
+type agentContext struct {
+	Agent        *openagent.Agent
+	ModelInfos   []modelReg
+	Mem          openagent.Memory
+	SessionStore rest.SessionStore
+	Cleanup      func()
+}
+
+func buildAgentContext(cfg *config.Config) (*agentContext, error) {
 	cfgDir, _ := config.Path()
 	mem, sessionStore, memCleanup, err := buildMemory(filepath.Join(filepath.Dir(cfgDir), "data", "memory.db"))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if memCleanup != nil {
 		defer memCleanup()
 	}
 
-	// Build models from provider config.
-	models, modelInfos := buildModels(opts.Config.Provider)
+	models, modelInfos := buildModels(cfg.Provider)
 
 	primaryModel := firstModel(models)
 	if primaryModel == nil {
 		log.Println("WARNING: no models configured — server will start but chat will fail")
 	}
 
-	// Sandbox + tools. Workspace is process CWD — per-session isolation
-	// is handled by the sandbox (bwrap) and the agent's own session ID.
+	var modelID string
+	var cw int
+	if primaryModel != nil {
+		modelID = firstModelID(modelInfos)
+		cw = primaryModel.ContextWindow()
+	}
+	if modelID == "" {
+		modelID = "gpt-4o"
+	}
+	if cw == 0 {
+		cw = 128_000
+	}
+
 	workDir, _ := os.Getwd()
 	sandbox, err := native.New(workDir)
 	var agentTools []openagent.Tool
@@ -56,18 +81,38 @@ func Run(ctx context.Context, opts Options) error {
 		log.Printf("WARNING: sandbox unavailable: %v", err)
 	}
 
+	promptBuilder := prompt.DefaultServer(modelID, cw).Build()
+
 	agent := openagent.NewAgent("assistant",
 		openagent.WithModel(primaryModel),
 		openagent.WithMemory(mem),
-		openagent.WithInstructions("You are a helpful assistant."),
+		openagent.WithPrompt(promptBuilder),
 		openagent.WithTools(agentTools...),
 		openagent.WithMaxTurns(10),
 	)
 
-	if opts.ACP {
-		return runACP(agent)
+	return &agentContext{
+		Agent:        agent,
+		ModelInfos:   modelInfos,
+		Mem:          mem,
+		SessionStore: sessionStore,
+		Cleanup:      memCleanup,
+	}, nil
+}
+
+func Run(ctx context.Context, opts Options) error {
+	ac, err := buildAgentContext(opts.Config)
+	if err != nil {
+		return err
 	}
-	return runREST(ctx, opts.Config, agent, modelInfos, mem, sessionStore)
+	if ac.Cleanup != nil {
+		defer ac.Cleanup()
+	}
+
+	if opts.ACP {
+		return runACP(ac)
+	}
+	return runREST(ctx, opts.Config, ac.Agent, ac.ModelInfos, ac.Mem, ac.SessionStore)
 }
 
 func buildModels(providers map[string]config.ProviderConfig) ([]openagent.Model, []modelReg) {
@@ -87,13 +132,30 @@ func buildModels(providers map[string]config.ProviderConfig) ([]openagent.Model,
 	return models, infos
 }
 
-type modelReg struct{ ID, Provider string; Model openagent.Model }
+type modelReg struct {
+	ID, Provider string
+	Model        openagent.Model
+}
 
 func firstModel(models []openagent.Model) openagent.Model {
 	for _, m := range models {
-		if m != nil { return m }
+		if m != nil {
+			return m
+		}
 	}
 	return nil
+}
+
+func firstModelID(infos []modelReg) string {
+	for _, mi := range infos {
+		if mi.ID != "" {
+			if mi.Provider != "" {
+				return mi.Provider + "/" + mi.ID
+			}
+			return mi.ID
+		}
+	}
+	return "gpt-4o"
 }
 
 func buildMemory(path string) (openagent.Memory, rest.SessionStore, func(), error) {
@@ -112,13 +174,25 @@ func buildMemory(path string) (openagent.Memory, rest.SessionStore, func(), erro
 
 func buildTools(sandbox *native.Sandbox, workDir string, toolList []string) []openagent.Tool {
 	enabled := make(map[string]bool)
-	for _, name := range toolList { enabled[name] = true }
+	for _, name := range toolList {
+		enabled[name] = true
+	}
 	var tools []openagent.Tool
-	if enabled["shell"] { tools = append(tools, opentool.NewShell(sandbox, workDir)) }
-	if enabled["read"]  { tools = append(tools, opentool.NewReadFile(workDir)) }
-	if enabled["write"] { tools = append(tools, opentool.NewWriteFile(workDir)) }
-	if enabled["ls"]    { tools = append(tools, opentool.NewListDir(workDir)) }
-	if enabled["grep"]  { tools = append(tools, opentool.NewGrep(workDir)) }
+	if enabled["shell"] {
+		tools = append(tools, opentool.NewShell(sandbox, workDir))
+	}
+	if enabled["read"] {
+		tools = append(tools, opentool.NewReadFile(workDir))
+	}
+	if enabled["write"] {
+		tools = append(tools, opentool.NewWriteFile(workDir))
+	}
+	if enabled["ls"] {
+		tools = append(tools, opentool.NewListDir(workDir))
+	}
+	if enabled["grep"] {
+		tools = append(tools, opentool.NewGrep(workDir))
+	}
 	return tools
 }
 
@@ -151,7 +225,9 @@ func runREST(ctx context.Context, cfg *config.Config, agent *openagent.Agent, mo
 
 	log.Printf("REST server listening on http://localhost%s", addr)
 	err := srv.ListenAndServe()
-	if err == http.ErrServerClosed { return nil }
+	if err == http.ErrServerClosed {
+		return nil
+	}
 	return err
 }
 
@@ -164,7 +240,10 @@ func corsMiddleware(next http.Handler) http.Handler {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
-		if r.Method == http.MethodOptions { w.WriteHeader(http.StatusNoContent); return }
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 		next.ServeHTTP(w, r)
 	})
 }
@@ -183,36 +262,334 @@ func recoveryMiddleware(next http.Handler) http.Handler {
 
 // ── ACP ──
 
-func runACP(agent *openagent.Agent) error {
-	srv := &acpHandler{agent: agent}
+// ACPSessionStore abstracts session persistence. Implementations can
+// be in-memory, SQLite-backed, or any other backend.
+type ACPSessionStore interface {
+	CreateSession(ctx context.Context, cwd string) (string, error)
+	ListSessions(ctx context.Context) ([]acpSessionInfo, error)
+	GetSession(ctx context.Context, id string) (*acpSessionInfo, error)
+	DeleteSession(ctx context.Context, id string) error
+	AppendMessage(ctx context.Context, sessionID, role, content string) error
+	LoadMessages(ctx context.Context, sessionID string) ([]acpMessage, error)
+	SetTitle(ctx context.Context, sessionID, title string) error
+	Close() error
+}
+
+type acpSessionInfo struct {
+	ID        string
+	Cwd       string
+	Title     string
+	UpdatedAt string
+}
+
+type acpMessage struct {
+	Role    string
+	Content string
+}
+
+// ── memory store ──
+
+type memoryACPStore struct {
+	mu       sync.Mutex
+	sessions map[string]*acpSessionInfo
+	messages map[string][]acpMessage // sessionID -> messages
+	nextID   int
+}
+
+func newMemoryACPStore() *memoryACPStore {
+	return &memoryACPStore{
+		sessions: make(map[string]*acpSessionInfo),
+		messages: make(map[string][]acpMessage),
+		nextID:   1,
+	}
+}
+
+func (s *memoryACPStore) CreateSession(ctx context.Context, cwd string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id := fmt.Sprintf("acp_%d", s.nextID)
+	s.nextID++
+	now := time.Now().UTC().Format(time.RFC3339)
+	s.sessions[id] = &acpSessionInfo{ID: id, Cwd: cwd, UpdatedAt: now}
+	return id, nil
+}
+
+func (s *memoryACPStore) GetSession(ctx context.Context, id string) (*acpSessionInfo, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	si := s.sessions[id]
+	if si == nil {
+		return nil, fmt.Errorf("session %s not found", id)
+	}
+	return si, nil
+}
+
+func (s *memoryACPStore) ListSessions(ctx context.Context) ([]acpSessionInfo, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var result []acpSessionInfo
+	for _, si := range s.sessions {
+		result = append(result, *si)
+	}
+	return result, nil
+}
+
+func (s *memoryACPStore) DeleteSession(ctx context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.sessions, id)
+	delete(s.messages, id)
+	return nil
+}
+
+func (s *memoryACPStore) AppendMessage(ctx context.Context, sessionID, role, content string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages[sessionID] = append(s.messages[sessionID], acpMessage{Role: role, Content: content})
+	return nil
+}
+
+func (s *memoryACPStore) LoadMessages(ctx context.Context, sessionID string) ([]acpMessage, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.messages[sessionID], nil
+}
+
+func (s *memoryACPStore) SetTitle(ctx context.Context, sessionID, title string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if si := s.sessions[sessionID]; si != nil && si.Title == "" {
+		si.Title = title
+	}
+	return nil
+}
+
+func (s *memoryACPStore) Close() error { return nil }
+
+// ── sqlite store ──
+
+type sqliteACPStore struct {
+	db *sql.DB
+}
+
+func newSQLiteACPStore(db *sql.DB) (*sqliteACPStore, error) {
+	if err := migrateACPStore(db); err != nil {
+		return nil, err
+	}
+	return &sqliteACPStore{db: db}, nil
+}
+
+func migrateACPStore(db *sql.DB) error {
+	_, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS acp_sessions (
+			id         TEXT PRIMARY KEY,
+			cwd        TEXT NOT NULL DEFAULT '',
+			title      TEXT NOT NULL DEFAULT '',
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS acp_seq (
+			name  TEXT PRIMARY KEY,
+			value INTEGER NOT NULL DEFAULT 0
+		);
+		INSERT OR IGNORE INTO acp_seq (name, value) VALUES ('session_id', 0);
+	`)
+	return err
+}
+
+func (s *sqliteACPStore) nextID() string {
+	var id int64
+	s.db.QueryRow(`UPDATE acp_seq SET value = value + 1 WHERE name = 'session_id' RETURNING value`).Scan(&id)
+	return fmt.Sprintf("acp_%d", id)
+}
+
+func (s *sqliteACPStore) CreateSession(ctx context.Context, cwd string) (string, error) {
+	id := s.nextID()
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO acp_sessions (id, cwd, title, created_at, updated_at) VALUES (?, ?, '', ?, ?)`,
+		id, cwd, now, now)
+	return id, err
+}
+
+func (s *sqliteACPStore) GetSession(ctx context.Context, id string) (*acpSessionInfo, error) {
+	si := &acpSessionInfo{ID: id}
+	err := s.db.QueryRowContext(ctx,
+		`SELECT cwd, title, updated_at FROM acp_sessions WHERE id = ?`, id).
+		Scan(&si.Cwd, &si.Title, &si.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("session %s not found", id)
+	}
+	return si, err
+}
+
+func (s *sqliteACPStore) ListSessions(ctx context.Context) ([]acpSessionInfo, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, cwd, title, updated_at FROM acp_sessions ORDER BY updated_at DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []acpSessionInfo
+	for rows.Next() {
+		var si acpSessionInfo
+		if rows.Scan(&si.ID, &si.Cwd, &si.Title, &si.UpdatedAt) == nil {
+			result = append(result, si)
+		}
+	}
+	return result, nil
+}
+
+func (s *sqliteACPStore) DeleteSession(ctx context.Context, id string) error {
+	s.db.ExecContext(ctx, `DELETE FROM messages WHERE session_id = ?`, id)
+	_, err := s.db.ExecContext(ctx, `DELETE FROM acp_sessions WHERE id = ?`, id)
+	return err
+}
+
+func (s *sqliteACPStore) AppendMessage(ctx context.Context, sessionID, role, content string) error {
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO messages (session_id, role, content) VALUES (?, ?, ?)`,
+		sessionID, role, content)
+	return err
+}
+
+func (s *sqliteACPStore) LoadMessages(ctx context.Context, sessionID string) ([]acpMessage, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT role, content FROM messages WHERE session_id = ? ORDER BY id ASC`, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []acpMessage
+	for rows.Next() {
+		var m acpMessage
+		if rows.Scan(&m.Role, &m.Content) == nil {
+			result = append(result, m)
+		}
+	}
+	return result, nil
+}
+
+func (s *sqliteACPStore) SetTitle(ctx context.Context, sessionID, title string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE acp_sessions SET title = CASE WHEN title = '' THEN ?1 ELSE title END, updated_at = ?2 WHERE id = ?3`,
+		title, time.Now().UTC().Format(time.RFC3339), sessionID)
+	return err
+}
+
+func (s *sqliteACPStore) Close() error { return nil }
+
+// ── handler ──
+
+func runACP(ac *agentContext) error {
+	store := newACPStore(ac.Mem)
+	srv := &acpHandler{agent: ac.Agent, store: store}
 	server := openacp.NewServer("openagent-acp", "1.0.0", srv)
 	log.Println("ACP server starting on stdio")
 	return server.Run(context.Background())
 }
 
-type acpHandler struct{ agent *openagent.Agent }
+func newACPStore(mem openagent.Memory) ACPSessionStore {
+	if sm, ok := mem.(*sqlite.Memory); ok {
+		s, err := newSQLiteACPStore(sm.DB())
+		if err == nil {
+			return s
+		}
+	}
+	return newMemoryACPStore()
+}
+
+type acpHandler struct {
+	agent *openagent.Agent
+	store ACPSessionStore
+}
 
 func (h *acpHandler) OnInitialize(ctx context.Context, req openacp.InitializeRequest) (*openacp.InitializeResponse, error) {
-	return &openacp.InitializeResponse{ProtocolVersion: 1, AgentName: "openagent-acp", AgentVersion: "1.0.0"}, nil
+	return &openacp.InitializeResponse{
+		ProtocolVersion: 1,
+		AgentName:       "openagent-acp",
+		AgentVersion:    "1.0.0",
+		Capabilities: openacp.AgentCapabilities{
+			LoadSession: true,
+			SessionCapabilities: openacp.SessionCapabilities{
+				List:   true,
+				Delete: true,
+				Resume: true,
+				Close:  true,
+			},
+		},
+	}, nil
 }
+
 func (h *acpHandler) OnNewSession(ctx context.Context, req openacp.NewSessionRequest) (*openacp.NewSessionResponse, error) {
-	return &openacp.NewSessionResponse{SessionID: "acp_1"}, nil
+	id, err := h.store.CreateSession(ctx, req.Cwd)
+	if err != nil {
+		return nil, fmt.Errorf("acp create session: %w", err)
+	}
+	return &openacp.NewSessionResponse{SessionID: id}, nil
 }
-func (h *acpHandler) OnLoadSession(ctx context.Context, req openacp.LoadSessionRequest) (*openacp.LoadSessionResponse, error) {
+
+func (h *acpHandler) OnLoadSession(ctx context.Context, req openacp.LoadSessionRequest, sender openacp.SessionEventSender) (*openacp.LoadSessionResponse, error) {
+	si, err := h.store.GetSession(ctx, req.SessionID)
+	if err != nil {
+		return nil, err
+	}
+	msgs, err := h.store.LoadMessages(ctx, req.SessionID)
+	if err != nil {
+		return nil, fmt.Errorf("acp load messages: %w", err)
+	}
+	for _, m := range msgs {
+		switch m.Role {
+		case "user":
+			sender.SendUserMessage(m.Content)
+		case "assistant":
+			sender.SendAgentMessage(m.Content)
+		}
+	}
+	if si.Title != "" {
+		sender.SendSessionInfo(si.Title, nil)
+	}
 	return &openacp.LoadSessionResponse{}, nil
 }
+
 func (h *acpHandler) OnListSessions(ctx context.Context, req openacp.ListSessionsRequest) (*openacp.ListSessionsResponse, error) {
-	return &openacp.ListSessionsResponse{}, nil
+	list, err := h.store.ListSessions(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("acp list sessions: %w", err)
+	}
+	sessions := make([]openacp.SessionInfo, len(list))
+	for i, s := range list {
+		sessions[i] = openacp.SessionInfo{
+			SessionID: s.ID,
+			Cwd:       s.Cwd,
+			Title:     s.Title,
+			UpdatedAt: s.UpdatedAt,
+		}
+	}
+	return &openacp.ListSessionsResponse{Sessions: sessions}, nil
 }
+
 func (h *acpHandler) OnPrompt(ctx context.Context, req openacp.PromptRequest, sender openacp.SessionEventSender) (*openacp.PromptResponse, error) {
 	var input string
-	for _, b := range req.Blocks { if b.Text != "" { input = b.Text; break } }
-	if input == "" { return nil, fmt.Errorf("no text in prompt") }
+	for _, b := range req.Blocks {
+		if b.Text != "" {
+			input = b.Text
+			break
+		}
+	}
+	if input == "" {
+		return nil, fmt.Errorf("no text in prompt")
+	}
+
+	h.store.AppendMessage(ctx, req.SessionID, "user", input)
+
+	var responseText strings.Builder
 	session := openagent.Session{ID: req.SessionID}
 	ch := h.agent.RunStream(ctx, session, openagent.UserMessage(input))
 	for evt := range ch {
 		switch evt.Type {
 		case openagent.StreamTextDelta:
+			responseText.WriteString(evt.Text)
 			sender.SendAgentMessage(evt.Text)
 		case openagent.StreamToolCall:
 			if len(evt.Message.ToolCalls) > 0 {
@@ -227,8 +604,104 @@ func (h *acpHandler) OnPrompt(ctx context.Context, req openacp.PromptRequest, se
 			return &openacp.PromptResponse{StopReason: "cancelled"}, nil
 		}
 	}
+
+	finalText := responseText.String()
+	h.store.AppendMessage(ctx, req.SessionID, "assistant", finalText)
+
+	title := input
+	if len(title) > 50 {
+		title = title[:50]
+	}
+	h.store.SetTitle(ctx, req.SessionID, title)
+
 	return &openacp.PromptResponse{StopReason: "end_turn"}, nil
 }
-func (h *acpHandler) OnCancel(ctx context.Context, sid string) error       { return nil }
-func (h *acpHandler) OnDeleteSession(ctx context.Context, sid string) error { return nil }
-func (h *acpHandler) OnCloseSession(ctx context.Context, sid string) error  { return nil }
+
+func (h *acpHandler) OnCancel(ctx context.Context, sid string) error { return nil }
+
+func (h *acpHandler) OnDeleteSession(ctx context.Context, sid string) error {
+	return h.store.DeleteSession(ctx, sid)
+}
+
+func (h *acpHandler) OnCloseSession(ctx context.Context, sid string) error { return nil }
+
+// ── ACP over WebSocket ──
+
+var wsUpgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool { return true },
+}
+
+func RunACPWS(ctx context.Context, cfg *config.Config, port int) error {
+	ac, err := buildAgentContext(cfg)
+	if err != nil {
+		return err
+	}
+	if ac.Cleanup != nil {
+		defer ac.Cleanup()
+	}
+
+	store := newACPStore(ac.Mem)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/acp", func(w http.ResponseWriter, r *http.Request) {
+		ws, err := wsUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			log.Printf("acp-ws: upgrade: %v", err)
+			return
+		}
+		defer ws.Close()
+
+		handler := &acpHandler{agent: ac.Agent, store: store}
+		br := &wsBridge{conn: ws}
+		server := openacp.NewServer("openagent-acp", "1.0.0", handler)
+		log.Printf("acp-ws: client connected")
+		if err := server.RunTransport(ctx, br, br); err != nil {
+			log.Printf("acp-ws: transport: %v", err)
+		}
+		log.Printf("acp-ws: client disconnected")
+	})
+
+	addr := fmt.Sprintf(":%d", port)
+	srv := &http.Server{Addr: addr, Handler: mux}
+
+	go func() { <-ctx.Done(); srv.Shutdown(context.Background()) }()
+
+	log.Printf("ACP WebSocket server listening on ws://localhost%s/acp", addr)
+	err = srv.ListenAndServe()
+	if err == http.ErrServerClosed {
+		return nil
+	}
+	return err
+}
+
+type wsBridge struct {
+	conn *websocket.Conn
+	mu   sync.Mutex
+	buf  bytes.Buffer
+}
+
+func (w *wsBridge) Read(p []byte) (int, error) {
+	if w.buf.Len() > 0 {
+		return w.buf.Read(p)
+	}
+	_, msg, err := w.conn.ReadMessage()
+	if err != nil {
+		return 0, err
+	}
+	w.buf.Write(msg)
+	w.buf.WriteByte('\n')
+	return w.buf.Read(p)
+}
+
+func (w *wsBridge) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	data := bytes.TrimRight(p, "\n")
+	if len(data) == 0 {
+		return len(p), nil
+	}
+	if err := w.conn.WriteMessage(websocket.TextMessage, data); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}

--- a/cmd/cli/server/agent.go
+++ b/cmd/cli/server/agent.go
@@ -51,9 +51,6 @@ func buildAgentContext(cfg *config.Config) (*agentContext, error) {
 	if err != nil {
 		return nil, err
 	}
-	if memCleanup != nil {
-		defer memCleanup()
-	}
 
 	models, modelInfos := buildModels(cfg.Provider)
 

--- a/cmd/cli/server/agent.go
+++ b/cmd/cli/server/agent.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/yusheng-g/openagent-go/cmd/cli/config"
 	"github.com/yusheng-g/openagent-go/cmd/cli/prompt"
+	skillfs "github.com/yusheng-g/openagent-go/skill/fs"
 )
 
 type Options struct {
@@ -73,9 +74,14 @@ func buildAgentContext(cfg *config.Config) (*agentContext, error) {
 	}
 
 	workDir, _ := os.Getwd()
+
+	homeDir, _ := os.UserHomeDir()
+	skillRoot := filepath.Join(homeDir, ".agents", "skills")
+
 	sandbox, err := native.New(workDir)
 	var agentTools []openagent.Tool
 	if err == nil {
+		sandbox.AddMount(skillRoot, "/skills")
 		agentTools = buildTools(sandbox, workDir, []string{"shell", "read", "write", "ls", "grep"})
 	} else {
 		log.Printf("WARNING: sandbox unavailable: %v", err)
@@ -83,12 +89,15 @@ func buildAgentContext(cfg *config.Config) (*agentContext, error) {
 
 	promptBuilder := prompt.DefaultServer(modelID, cw).Build()
 
+	skillLoader := skillfs.New(skillRoot)
+
 	agent := openagent.NewAgent("assistant",
 		openagent.WithModel(primaryModel),
 		openagent.WithMemory(mem),
 		openagent.WithPrompt(promptBuilder),
+		openagent.WithSkillLoader(skillLoader),
 		openagent.WithTools(agentTools...),
-		openagent.WithMaxTurns(10),
+		openagent.WithMaxTurns(100),
 	)
 
 	return &agentContext{
@@ -272,6 +281,9 @@ type ACPSessionStore interface {
 	AppendMessage(ctx context.Context, sessionID, role, content string) error
 	LoadMessages(ctx context.Context, sessionID string) ([]acpMessage, error)
 	SetTitle(ctx context.Context, sessionID, title string) error
+	SetModel(ctx context.Context, sessionID, modelID string) error
+	GetModel(ctx context.Context, sessionID string) (string, bool)
+	EnsureSession(ctx context.Context, id, cwd string) error
 	Close() error
 }
 
@@ -293,6 +305,7 @@ type memoryACPStore struct {
 	mu       sync.Mutex
 	sessions map[string]*acpSessionInfo
 	messages map[string][]acpMessage // sessionID -> messages
+	models   map[string]string       // sessionID -> modelID
 	nextID   int
 }
 
@@ -300,6 +313,7 @@ func newMemoryACPStore() *memoryACPStore {
 	return &memoryACPStore{
 		sessions: make(map[string]*acpSessionInfo),
 		messages: make(map[string][]acpMessage),
+		models:   make(map[string]string),
 		nextID:   1,
 	}
 }
@@ -364,6 +378,30 @@ func (s *memoryACPStore) SetTitle(ctx context.Context, sessionID, title string) 
 	return nil
 }
 
+func (s *memoryACPStore) SetModel(ctx context.Context, sessionID, modelID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.models[sessionID] = modelID
+	return nil
+}
+
+func (s *memoryACPStore) GetModel(ctx context.Context, sessionID string) (string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	m, ok := s.models[sessionID]
+	return m, ok
+}
+
+func (s *memoryACPStore) EnsureSession(ctx context.Context, id, cwd string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.sessions[id]; !ok {
+		now := time.Now().UTC().Format(time.RFC3339)
+		s.sessions[id] = &acpSessionInfo{ID: id, Cwd: cwd, UpdatedAt: now}
+	}
+	return nil
+}
+
 func (s *memoryACPStore) Close() error { return nil }
 
 // ── sqlite store ──
@@ -380,7 +418,7 @@ func newSQLiteACPStore(db *sql.DB) (*sqliteACPStore, error) {
 }
 
 func migrateACPStore(db *sql.DB) error {
-	_, err := db.Exec(`
+	if _, err := db.Exec(`
 		CREATE TABLE IF NOT EXISTS acp_sessions (
 			id         TEXT PRIMARY KEY,
 			cwd        TEXT NOT NULL DEFAULT '',
@@ -393,8 +431,12 @@ func migrateACPStore(db *sql.DB) error {
 			value INTEGER NOT NULL DEFAULT 0
 		);
 		INSERT OR IGNORE INTO acp_seq (name, value) VALUES ('session_id', 0);
-	`)
-	return err
+	`); err != nil {
+		return err
+	}
+	// Best-effort migration for existing databases.
+	db.Exec(`ALTER TABLE acp_sessions ADD COLUMN model_id TEXT NOT NULL DEFAULT ''`)
+	return nil
 }
 
 func (s *sqliteACPStore) nextID() string {
@@ -477,13 +519,43 @@ func (s *sqliteACPStore) SetTitle(ctx context.Context, sessionID, title string) 
 	return err
 }
 
+func (s *sqliteACPStore) SetModel(ctx context.Context, sessionID, modelID string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE acp_sessions SET model_id = ?, updated_at = ? WHERE id = ?`,
+		modelID, time.Now().UTC().Format(time.RFC3339), sessionID)
+	return err
+}
+
+func (s *sqliteACPStore) GetModel(ctx context.Context, sessionID string) (string, bool) {
+	var m string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT model_id FROM acp_sessions WHERE id = ?`, sessionID).Scan(&m)
+	if err != nil || m == "" {
+		return "", false
+	}
+	return m, true
+}
+
+func (s *sqliteACPStore) EnsureSession(ctx context.Context, id, cwd string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := s.db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO acp_sessions (id, cwd, title, created_at, updated_at) VALUES (?, ?, '', ?, ?)`,
+		id, cwd, now, now)
+	return err
+}
+
 func (s *sqliteACPStore) Close() error { return nil }
 
 // ── handler ──
 
 func runACP(ac *agentContext) error {
 	store := newACPStore(ac.Mem)
-	srv := &acpHandler{agent: ac.Agent, store: store}
+	srv := &acpHandler{
+		agent:      ac.Agent,
+		store:      store,
+		modelInfos: ac.ModelInfos,
+		defaultModelID: firstModelID(ac.ModelInfos),
+	}
 	server := openacp.NewServer("openagent-acp", "1.0.0", srv)
 	log.Println("ACP server starting on stdio")
 	return server.Run(context.Background())
@@ -500,8 +572,23 @@ func newACPStore(mem openagent.Memory) ACPSessionStore {
 }
 
 type acpHandler struct {
-	agent *openagent.Agent
-	store ACPSessionStore
+	agent          *openagent.Agent
+	store          ACPSessionStore
+	modelInfos     []modelReg
+	defaultModelID string
+}
+
+func (h *acpHandler) findModel(modelID string) openagent.Model {
+	for _, mi := range h.modelInfos {
+		id := mi.ID
+		if mi.Provider != "" {
+			id = mi.Provider + "/" + mi.ID
+		}
+		if id == modelID {
+			return mi.Model
+		}
+	}
+	return nil
 }
 
 func (h *acpHandler) OnInitialize(ctx context.Context, req openacp.InitializeRequest) (*openacp.InitializeResponse, error) {
@@ -526,13 +613,15 @@ func (h *acpHandler) OnNewSession(ctx context.Context, req openacp.NewSessionReq
 	if err != nil {
 		return nil, fmt.Errorf("acp create session: %w", err)
 	}
+	h.store.SetModel(ctx, id, h.defaultModelID)
 	return &openacp.NewSessionResponse{SessionID: id}, nil
 }
 
 func (h *acpHandler) OnLoadSession(ctx context.Context, req openacp.LoadSessionRequest, sender openacp.SessionEventSender) (*openacp.LoadSessionResponse, error) {
 	si, err := h.store.GetSession(ctx, req.SessionID)
 	if err != nil {
-		return nil, err
+		h.store.EnsureSession(ctx, req.SessionID, req.Cwd)
+		return &openacp.LoadSessionResponse{}, nil
 	}
 	msgs, err := h.store.LoadMessages(ctx, req.SessionID)
 	if err != nil {
@@ -585,6 +674,11 @@ func (h *acpHandler) OnPrompt(ctx context.Context, req openacp.PromptRequest, se
 
 	var responseText strings.Builder
 	session := openagent.Session{ID: req.SessionID}
+	if mID, ok := h.store.GetModel(ctx, req.SessionID); ok {
+		if m := h.findModel(mID); m != nil {
+			session.Model = m
+		}
+	}
 	ch := h.agent.RunStream(ctx, session, openagent.UserMessage(input))
 	for evt := range ch {
 		switch evt.Type {
@@ -625,6 +719,24 @@ func (h *acpHandler) OnDeleteSession(ctx context.Context, sid string) error {
 
 func (h *acpHandler) OnCloseSession(ctx context.Context, sid string) error { return nil }
 
+func (h *acpHandler) OnSetSessionConfigOption(ctx context.Context, sessionID string, opt openacp.SetConfigOption) error {
+	modelID, ok := opt.Value.(string)
+	if !ok {
+		return nil
+	}
+	if m := h.findModel(modelID); m == nil {
+		return nil
+	}
+	return h.store.SetModel(ctx, sessionID, modelID)
+}
+
+func (h *acpHandler) OnSetSessionMode(ctx context.Context, sessionID string, modeID string) error {
+	return nil
+}
+
+// Compile-time check: acpHandler implements ConfigHandler.
+var _ openacp.ConfigHandler = (*acpHandler)(nil)
+
 // ── ACP over WebSocket ──
 
 var wsUpgrader = websocket.Upgrader{
@@ -651,7 +763,7 @@ func RunACPWS(ctx context.Context, cfg *config.Config, port int) error {
 		}
 		defer ws.Close()
 
-		handler := &acpHandler{agent: ac.Agent, store: store}
+		handler := &acpHandler{agent: ac.Agent, store: store, modelInfos: ac.ModelInfos, defaultModelID: firstModelID(ac.ModelInfos)}
 		br := &wsBridge{conn: ws}
 		server := openacp.NewServer("openagent-acp", "1.0.0", handler)
 		log.Printf("acp-ws: client connected")

--- a/examples/acp/server/main.go
+++ b/examples/acp/server/main.go
@@ -83,7 +83,7 @@ func (s *calcServer) OnNewSession(ctx context.Context, req openacp.NewSessionReq
 	return &openacp.NewSessionResponse{SessionID: id}, nil
 }
 
-func (s *calcServer) OnLoadSession(ctx context.Context, req openacp.LoadSessionRequest) (*openacp.LoadSessionResponse, error) {
+func (s *calcServer) OnLoadSession(ctx context.Context, req openacp.LoadSessionRequest, sender openacp.SessionEventSender) (*openacp.LoadSessionResponse, error) {
 	s.mu.RLock()
 	st, ok := s.sessions[req.SessionID]
 	s.mu.RUnlock()

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17k
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVUrx/c8Unxc48=

--- a/runner.go
+++ b/runner.go
@@ -29,10 +29,11 @@ type runner struct {
 
 // compactionInfo carries compaction outcome from prepareMemory back to run().
 type compactionInfo struct {
-	err   error
-	count int // new messages compacted this run (0 = none)
-	from  int // global index of first new compacted message
-	to    int // global index after compaction (ThroughIndex)
+	err         error
+	count       int  // new messages compacted this run (0 = none)
+	from        int  // global index of first new compacted message
+	to          int  // global index after compaction (ThroughIndex)
+	hadOverflow bool // messages were trimmed from working set
 }
 
 // observe emits a stage event to the agent's RunObserver if configured.
@@ -157,6 +158,31 @@ func (r *runner) run(ctx context.Context, session Session, prefix []Message, inp
 					r.compressed = cc
 				} else {
 					compressedErr = err
+				}
+			}
+
+			// Proactive retrieval: when messages were trimmed from the
+			// working set, search the archive for relevant past context.
+			if ci.hadOverflow && r.agent.Memory != nil && input.Content != "" {
+				results, err := r.agent.Memory.Search(ctx, session.ID, input.Content, 5)
+				if err == nil && len(results) > 0 {
+					existing := make(map[string]bool, len(history))
+					for _, m := range history {
+						existing[m.Content] = true
+					}
+					var buf strings.Builder
+					buf.WriteString("## Relevant Past Messages\n")
+					count := 0
+					for _, res := range results {
+						if existing[res.Message.Content] {
+							continue
+						}
+						count++
+						buf.WriteString(fmt.Sprintf("%d. [%s] %s\n", count, res.Message.Role, res.Message.Content))
+					}
+					if count > 0 {
+						history = append([]Message{{Role: RoleSystem, Content: buf.String()}}, history...)
+					}
 				}
 			}
 
@@ -415,13 +441,16 @@ func (r *runner) run(ctx context.Context, session Session, prefix []Message, inp
 // model's context window. Falls back to 20000 if the model doesn't report
 // its context window.
 func (r *runner) workingTokenBudget() int {
+	var budget int
 	if r.agent.MaxWorkingTokens > 0 {
-		return r.agent.MaxWorkingTokens
+		budget = r.agent.MaxWorkingTokens
+	} else if cw := r.runModel.ContextWindow(); cw > 0 {
+		budget = cw * 7 / 10 // 70%
+	} else {
+		budget = 20000
 	}
-	if cw := r.runModel.ContextWindow(); cw > 0 {
-		return cw * 7 / 10 // 70%
-	}
-	return 20000
+	const retrievalReserve = 1000
+	return budget - retrievalReserve
 }
 
 // prepareMemory fetches the working message set, triggers token-based
@@ -475,6 +504,7 @@ func (r *runner) prepareMemory(ctx context.Context, session Session) ([]Message,
 	}
 	if overflow < len(msgs) {
 		overflow = SafeCompressionBoundary(msgs, overflow)
+		ci.hadOverflow = true
 		// Record pre-compaction ThroughIndex so we can detect whether
 		// Compact() actually covered new messages.
 		oldTI := 0

--- a/runner/acp/runner.go
+++ b/runner/acp/runner.go
@@ -633,6 +633,15 @@ func (h *runnerHandler) OnToolCall(tc openacp.ToolCallEvent) {
 	}
 }
 
+func (h *runnerHandler) OnPlan(entries []openacp.PlanEntry) {
+	// Future: emit StreamPlan events. For now, plan entries are silently
+	// tracked by the collector if needed.
+}
+
+func (h *runnerHandler) OnUsage(info openacp.UsageInfo) {
+	// Future: emit StreamUsage events. For now, usage is silently absorbed.
+}
+
 // ── resultCollector ──
 
 type resultCollector struct {
@@ -677,3 +686,7 @@ var _ openagent.TeamPreparable = (*Runner)(nil)
 var _ openagent.MembershipNotifiable = (*Runner)(nil)
 var _ openagent.Closer = (*Runner)(nil)
 var _ io.Closer = (*Runner)(nil)
+
+var _ openacp.EventHandler = (*runnerHandler)(nil)
+var _ openacp.PlanHandler = (*runnerHandler)(nil)
+var _ openacp.UsageHandler = (*runnerHandler)(nil)

--- a/sandbox/native/native.go
+++ b/sandbox/native/native.go
@@ -25,7 +25,17 @@ import (
 // Sandbox confines command execution using OS-native security mechanisms.
 // Commands can only read/write within the workspace directory.
 type Sandbox struct {
-	workDir string // host path, the only writable directory
+	workDir     string
+	extraMounts []bindMount
+}
+
+type bindMount struct{ src, dst string }
+
+// AddMount adds an additional read-only bind mount inside the sandbox.
+// src is the host path, dst is the path visible inside the sandbox.
+func (s *Sandbox) AddMount(src, dst string) *Sandbox {
+	s.extraMounts = append(s.extraMounts, bindMount{src: src, dst: dst})
+	return s
 }
 
 // New creates a native sandbox rooted at workDir.

--- a/sandbox/native/native.go
+++ b/sandbox/native/native.go
@@ -25,8 +25,10 @@ import (
 // Sandbox confines command execution using OS-native security mechanisms.
 // Commands can only read/write within the workspace directory.
 type Sandbox struct {
-	workDir     string
-	extraMounts []bindMount
+	workDir      string
+	extraMounts  []bindMount
+	bwrapFailed  bool
+	selfTested   bool
 }
 
 type bindMount struct{ src, dst string }

--- a/sandbox/native/native_linux.go
+++ b/sandbox/native/native_linux.go
@@ -17,6 +17,10 @@ import (
 //
 // Falls back to unsandboxed execution with a warning if bwrap is not found.
 func (s *Sandbox) confineAndRun(ctx context.Context, cmd openagent.Command) (openagent.Result, error) {
+	if s.bwrapFailed {
+		return s.unconfinedRun(ctx, cmd)
+	}
+
 	args, ok := s.bwrapArgs(cmd)
 	if !ok {
 		log.Printf("WARNING: bwrap not found — sandbox disabled, running unconfined")
@@ -44,9 +48,17 @@ func (s *Sandbox) confineAndRun(ctx context.Context, cmd openagent.Command) (ope
 	}
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
+			stderrStr := stderr.String()
+			if isBwrapSetupFailure(stderrStr) {
+				log.Printf("WARNING: bwrap setup failed, falling back to unconfined: %s", stderrStr)
+				s.bwrapFailed = true
+				return s.unconfinedRun(ctx, cmd)
+			}
+			log.Printf("bwrap command exited with code %d, stderr: %s", exitErr.ExitCode(), stderrStr)
 			result.ExitCode = exitErr.ExitCode()
 			return result, nil
 		}
+		log.Printf("bwrap execution error: %v", err)
 		return result, fmt.Errorf("native sandbox (linux): %w", err)
 	}
 	return result, nil
@@ -57,9 +69,16 @@ func (s *Sandbox) confineAndRunStream(ctx context.Context, cmd openagent.Command
 	go func() {
 		defer close(ch)
 
+		if s.bwrapFailed {
+			for chunk := range s.unconfinedRunStream(ctx, cmd) {
+				ch <- chunk
+			}
+			return
+		}
+
 		args, ok := s.bwrapArgs(cmd)
 		if !ok {
-			// Fallback: run unconfined.
+			log.Printf("WARNING: bwrap not found — sandbox disabled, running unconfined")
 			for chunk := range s.unconfinedRunStream(ctx, cmd) {
 				ch <- chunk
 			}
@@ -78,7 +97,11 @@ func (s *Sandbox) confineAndRunStream(ctx context.Context, cmd openagent.Command
 		stdout, _ := c.StdoutPipe()
 		stderr, _ := c.StderrPipe()
 		if err := c.Start(); err != nil {
-			ch <- openagent.ToolStreamChunk{Error: fmt.Errorf("native sandbox (linux): %w", err)}
+			log.Printf("WARNING: bwrap start failed, falling back to unconfined: %v", err)
+			s.bwrapFailed = true
+			for chunk := range s.unconfinedRunStream(ctx, cmd) {
+				ch <- chunk
+			}
 			return
 		}
 
@@ -92,6 +115,13 @@ func (s *Sandbox) confineAndRunStream(ctx context.Context, cmd openagent.Command
 	return ch
 }
 
+// isBwrapSetupFailure reports whether stderr indicates a bwrap sandbox
+// setup failure (as opposed to a command execution failure inside the
+// sandbox). bwrap errors are prefixed with "bwrap:".
+func isBwrapSetupFailure(stderr string) bool {
+	return strings.Contains(stderr, "bwrap:")
+}
+
 // bwrapArgs builds Bubblewrap arguments for namespace isolation.
 // Returns false if bwrap is not installed.
 //
@@ -102,8 +132,21 @@ func (s *Sandbox) confineAndRunStream(ctx context.Context, cmd openagent.Command
 //   - New PID namespace
 //   - New UTS namespace
 func (s *Sandbox) bwrapArgs(cmd openagent.Command) ([]string, bool) {
-	if _, err := exec.LookPath("bwrap"); err != nil {
+	if s.bwrapFailed {
 		return nil, false
+	}
+	if _, err := exec.LookPath("bwrap"); err != nil {
+		s.bwrapFailed = true
+		return nil, false
+	}
+	if !s.selfTested {
+		s.selfTested = true
+		test := exec.Command("bwrap", "--ro-bind", "/usr", "/usr", "--", "true")
+		if err := test.Run(); err != nil {
+			log.Printf("WARNING: bwrap self-test failed, sandbox disabled: %v", err)
+			s.bwrapFailed = true
+			return nil, false
+		}
 	}
 
 	args := []string{

--- a/sandbox/native/native_linux.go
+++ b/sandbox/native/native_linux.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -106,7 +107,8 @@ func (s *Sandbox) bwrapArgs(cmd openagent.Command) ([]string, bool) {
 	}
 
 	args := []string{
-		"--unshare-all",            // new namespaces for everything (incl. network)
+		"--unshare-all",            // new namespaces for everything
+		"--share-net",              // but keep host network access
 		"--new-session",            // new session, no controlling tty
 		"--die-with-parent",        // kill container when parent dies
 		"--proc", "/proc",          // mount proc
@@ -120,6 +122,13 @@ func (s *Sandbox) bwrapArgs(cmd openagent.Command) ([]string, bool) {
 	// Bind workspace as writable /workspace.
 	args = append(args, "--bind", s.workDir, "/workspace")
 	args = append(args, "--chdir", "/workspace")
+
+	// Additional read-only bind mounts.
+	for _, m := range s.extraMounts {
+		if _, err := os.Stat(m.src); err == nil {
+			args = append(args, "--ro-bind", m.src, m.dst)
+		}
+	}
 
 	// Pass environment variables.
 	for _, e := range cmd.Env {

--- a/sandbox/native/native_linux.go
+++ b/sandbox/native/native_linux.go
@@ -107,12 +107,12 @@ func (s *Sandbox) bwrapArgs(cmd openagent.Command) ([]string, bool) {
 	}
 
 	args := []string{
-		"--unshare-all",            // new namespaces for everything
-		"--share-net",              // but keep host network access
-		"--new-session",            // new session, no controlling tty
-		"--die-with-parent",        // kill container when parent dies
-		"--proc", "/proc",          // mount proc
-		"--dev", "/dev",            // minimal /dev
+		"--unshare-all",     // new namespaces for everything
+		"--share-net",       // but keep host network access
+		"--new-session",     // new session, no controlling tty
+		"--die-with-parent", // kill container when parent dies
+		"--proc", "/proc",   // mount proc
+		"--dev", "/dev", // minimal /dev
 		"--ro-bind", "/usr", "/usr",
 		"--ro-bind", "/bin", "/bin",
 		"--ro-bind", "/lib", "/lib",
@@ -122,6 +122,31 @@ func (s *Sandbox) bwrapArgs(cmd openagent.Command) ([]string, bool) {
 	// Bind workspace as writable /workspace.
 	args = append(args, "--bind", s.workDir, "/workspace")
 	args = append(args, "--chdir", "/workspace")
+
+	// DNS / name resolution.
+	for _, f := range []string{
+		"/etc/resolv.conf",
+		"/etc/hosts",
+		"/etc/nsswitch.conf",
+	} {
+		if _, err := os.Stat(f); err == nil {
+			args = append(args, "--ro-bind", f, f)
+		}
+	}
+
+	// User / group lookup so names resolve inside the user namespace.
+	for _, f := range []string{"/etc/passwd", "/etc/group"} {
+		if _, err := os.Stat(f); err == nil {
+			args = append(args, "--ro-bind", f, f)
+		}
+	}
+
+	// CA certificates for TLS (HTTPS / curl).
+	for _, f := range []string{"/etc/ssl", "/etc/pki"} {
+		if _, err := os.Stat(f); err == nil {
+			args = append(args, "--ro-bind", f, f)
+		}
+	}
 
 	// Additional read-only bind mounts.
 	for _, m := range s.extraMounts {


### PR DESCRIPTION
## PR: Complete ACP protocol implementation, sandbox hardening, and acpws proxy support

### Summary

This PR implements the full ACP (Agent Client Protocol) server stack for `openagent-go serve --acp`, covering session lifecycle, streaming events, config management, tool permission flow, and external proxy compatibility. Also includes critical sandbox fixes and an expanded system prompt.

---

### ACP Protocol (`acp/`, `cmd/cli/server/agent.go`)

**Session lifecycle** — SQLite-backed persistence with modular store interface (`acp_sessions` table, auto-increment `acp_seq`):

- `session/new`, `session/load`, `session/list`, `session/delete`, `session/close`, `session/fork`
- `session/load` replays conversation history to clients via `SessionEventSender`
- Sessions survive restarts; `EnsureSession` prevents ID mismatch on reconnect
- Config options returned as model selector (`select` type from provider list)

**Streaming events** (agent → client via `SessionEventSender`):

- `agent_message_chunk`, `agent_thought_chunk` — text streaming with `SessionId`
- `tool_call` — start (`in_progress`) + completion (`completed`/`failed`) with raw I/O
- `plan_update` — `PlanEntry` items tracked per-tool with priority/status
- `config_option_update` — pushed after `set_config_option` change
- `current_mode_update`, `usage_update`, `available_commands_update`, `session_info_update`

**Permission flow** — `acpApprover` implements `openagent.Approver`, wired via `WithApprover`:

- Agent sends `request_permission` with `allow_once`/`allow_always`/`reject_once`
- `agentSender.RequestPermission` → `conn.RequestPermission`, 30s timeout, fail-open
- `PermissionRegistrar` wires per-session requester

**Config management** — `ConfigHandler` + `SessionAdminHandler` optional interfaces:

- `session/set_config_option` (boolean/value) returns updated options
- `session/set_mode` — no-op stub for acpws compatibility

---

### acpws Proxy Compatibility (`acp/compat.go`, `acp/server.go`)

- `--acp-db` flag for shared external SQLite file (multi-process via WAL mode)
- `acpCompatReader` intercepts stdin:
  - `session/setup` (not in SDK) → responds with empty `configOptions`
  - `session/resume` / `session/load` without `cwd` → injects `cwd: "/"`
- `sqliteACPStore` tracks `ownedDB` for proper external DB cleanup
- Only affects `serve --acp` (stdio); `--acp-ws` untouched

---

### Graceful Shutdown & Signal Handling

- Propagates signal-cancelled `ctx` through `Run → runACP → server.Run`
- `context.Canceled` treated as normal close (exit 0, no cobra usage dump)

---

### Sandbox Hardening (`sandbox/native/native_linux.go`)

- **bwrap self-test** on first use to detect user namespace availability
- **Graceful fallback**: setup failures via stderr `bwrap:` prefix → unconfined execution
- **DNS / TLS / user**: bind `/etc/resolv.conf`, `/etc/hosts`, `/etc/nsswitch.conf`, `/etc/passwd`, `/etc/group`, `/etc/ssl`, `/etc/pki`
- **`--share-net`** preserves host network access
- **`AddMount(src, dst)`** for additional read-only bind mounts

---

### Memory & Bug Fixes

- **SQLite premature close**: removed `defer memCleanup()` in `buildAgentContext` that closed DB immediately after agent creation — `recall_memory` previously failed silently
- **ls tool schema**: removed trailing comma in `ListDir` JSON Schema (caused DeepSeek API 400)
- **`MaxTurns`**: 10 → 100
- **Skill loader**: `skillfs.New(~/.agents/skills)`, mounted into sandbox as `/skills`

---

### System Prompt (`cmd/cli/prompt/defaults.go`)

Comprehensive rebuild — 11 static sections (Role, Security, System Rules, Tool Usage, Task Execution, Plan, Scratchpad, Skill, Memory Rules, Completion, Tone) + 8 dynamic sections (DynamicContext, Environment, InstalledSkills with authority note, Skill Marketplace workflow).

---

### Deployment

```bash
acpws expose --host 0.0.0.0 --port 8787 \
  --env OPENAI_API_KEY=sk-xxx \
  --cwd /app \
  -- openagent-go serve --acp --acp-db /data/acp.db