### PR TITLE
fix(plugin/extended-settings): use serde_json to merge provider/env safely

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -18,37 +18,11 @@ Note: line 43 `json.Unmarshal(raw, &preCfg)` silently swallows the same empty-in
 
 ---
 
-### [P1] extended-settings plugin emits invalid JSON / overwrites existing `provider` map
+### [P1] ~~extended-settings plugin emits invalid JSON / overwrites existing `provider` map~~ ✅ FIXED
 
-[cmd/cli/examples/plugin/extended-settings/src/lib.rs:41-66](cmd/cli/examples/plugin/extended-settings/src/lib.rs): `cli_init` unconditionally prefixes the injected block with `,` and unconditionally creates a fresh `"provider"` object:
+[cmd/cli/examples/plugin/extended-settings/src/lib.rs](cmd/cli/examples/plugin/extended-settings/src/lib.rs): **Fixed in this commit** — `cli_init` now delegates to a pure `inject_settings` helper that parses settings via `serde_json` and deep-merges `provider.my_provider` and `env.MY_PROVIDER_API_KEY` into the existing object tree (creating maps if absent). All merge semantics are overwrite: keyring values replace user values for `api_key`/`base_url`/`models`/`env.MY_PROVIDER_API_KEY`; other existing keys preserved. 6 unit tests cover all three cases below plus overwrite, invalid-JSON fallback, and non-object root.
 
-```rust
-let end = if trimmed.ends_with('}') { trimmed.len() - 1 } else { trimmed.len() };
-let mut out = String::from(&settings[..end]);
-out.push_str(",\"provider\":{\"my_provider\":{...");   // always leading ","
-```
-
-Three failure modes:
-
-1. **Empty settings (`{}`)**: `end == 1` → `out = "{"`; appending `,"provider":...` yields `{,"provider":...` — invalid JSON. (Empty-string input yields `,"provider":...` directly.) Fails with `invalid character ',' looking for beginning of object key string`.
-2. **Non-empty, no `provider` key**: the same code path as case 1; the comma-prefix only happens to be syntactically valid here because the object body is non-empty. The lack of an explicit empty-object guard is the root issue.
-3. **Non-empty, has existing `provider`** (e.g. `{"provider":{"some_other":{...}}}`): the unconditional fresh `"provider":{...}` **overwrites** the existing provider map instead of merging `my_provider` into it → silent data loss of user-configured providers.
-
-Repro for case 1: keyring has `my_provider_api_key` + `my_provider_base_url`; settings.json missing/empty (`{}`) — now normalized upstream by the empty-settings fix.
-Symptom: plugin log `plugin: loaded extended-settings (Injects provider credentials from keyring into settings) type=cli:settings` followed by `parse merged settings: invalid character ',' looking for beginning of object key string`.
-
-Repro for case 3: settings.json contains `{"provider":{"some_other":{...}}}`; after plugin runs, `some_other` is gone.
-
-Root cause: append-based JSON composition with naive string slicing — no handling of empty object body (no comma needed) and no handling of existing key (must merge into existing object).
-
-Suggested fix (handles all three cases): parse settings into a JSON object (or the typed `config.Config`), inject `my_provider` into the `provider` map (creating the map if absent), inject env vars into the `env` map likewise, then re-serialize. This eliminates all three cases uniformly.
-
-If string-splicing must be retained (footprint), the minimum-safe logic per injected key (`provider`, `env`):
-1. Search for existing `"<key>":{` in `out`.
-2. If found → insert the new member right after the opening brace, prefixed with `,` iff the object body is non-empty (next char is not `}`).
-3. If not found → append `"<key>":<value>` to the root, prefixed with `,` iff the root body is non-empty (`out` does not end with `{`).
-
-Same guard needed for the `env` injection (line 64) and for the case where the provider branch was skipped due to missing keyring keys.
+Original issue: `cli_init` unconditionally prefixed the injected block with `,` and unconditionally created a fresh `"provider"` object, producing three failure modes: (1) empty `{}` → `{,"provider":...` invalid JSON; (2) non-empty without `provider` — same fragile code path, only syntactically valid by accident; (3) non-empty with existing `provider` → overwrote the whole map → silent data loss of user-configured providers. Symptom: `parse merged settings: invalid character ',' looking for beginning of object key string` after `plugin: loaded extended-settings (...)`.
 
 ---
 

--- a/cmd/cli/examples/plugin/extended-settings/Cargo.toml
+++ b/cmd/cli/examples/plugin/extended-settings/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 openagent-cli-sdk = { path = "../../../../../plugin/sdk/rust" }
+serde_json = { version = "1", default-features = false, features = ["alloc"] }

--- a/cmd/cli/examples/plugin/extended-settings/src/lib.rs
+++ b/cmd/cli/examples/plugin/extended-settings/src/lib.rs
@@ -10,17 +10,33 @@
 //         --extern openagent_cli_sdk \
 //         -o build/plugins/extended-settings.wasm examples/plugin/extended-settings.rs
 
-#![no_std]
+#![cfg_attr(target_family = "wasm", no_std)]
+extern crate alloc;
+
+#[cfg(target_family = "wasm")]
 extern crate openagent_cli_sdk as sdk;
+
+#[cfg(target_family = "wasm")]
 use sdk::prelude::*;
 
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use serde_json::Value;
+
+#[cfg(target_family = "wasm")]
 static META: &str = r#"{"type":"cli:settings","name":"extended-settings","description":"Injects provider credentials from keyring into settings"}"#;
 
 // ── boilerplate (Rust WASM CDYLIB requires these in the root crate) ──
-#[no_mangle] pub extern "C" fn alloc(size: u32) -> u32 { sdk_alloc(size) }
-#[no_mangle] pub extern "C" fn metadata() -> u64 { sdk_meta(META) }
+#[cfg(target_family = "wasm")]
+#[no_mangle]
+pub extern "C" fn alloc(size: u32) -> u32 { sdk_alloc(size) }
+
+#[cfg(target_family = "wasm")]
+#[no_mangle]
+pub extern "C" fn metadata() -> u64 { sdk_meta(META) }
 
 // ── settings injection ──
+#[cfg(target_family = "wasm")]
 #[no_mangle]
 pub extern "C" fn init(p: u32, l: u32) -> u64 {
     let s = unsafe { wasm_str(p, l) };
@@ -28,42 +44,158 @@ pub extern "C" fn init(p: u32, l: u32) -> u64 {
     sdk_return(result.as_bytes())
 }
 
+#[cfg(target_family = "wasm")]
 fn cli_init(settings: &str) -> String {
     let ak = host::keyring_get("openagent", "my_provider_api_key");
     let bu = host::keyring_get("openagent", "my_provider_base_url");
     if ak.is_none() || bu.is_none() {
-        return String::from(settings);
+        return settings.to_string();
     }
     let ak = ak.unwrap();
     let bu = bu.unwrap();
     let mdls = host::keyring_get("openagent", "my_provider_models");
+    inject_settings(settings, ak, bu, mdls)
+}
 
-    let trimmed = settings.trim_end();
-    let end = if trimmed.ends_with('}') { trimmed.len() - 1 } else { trimmed.len() };
+// inject_settings is a pure function: parse settings as a JSON object,
+// then merge provider.my_provider and env.MY_PROVIDER_API_KEY via
+// serde_json's object semantics. Merge semantics are all overwrite:
+//   - provider.my_provider.api_key/base_url: keyring overrides user
+//   - provider.my_provider.models: keyring list replaces user array
+//   - env.MY_PROVIDER_API_KEY: keyring overrides user
+// Other existing keys (provider.X, server, env.Y) are preserved.
+#[allow(dead_code)] // only called from cli_init (wasm) and tests (host)
+fn inject_settings(settings: &str, ak: &str, bu: &str, mdls: Option<&str>) -> String {
+    let mut root: Value = match serde_json::from_str(settings) {
+        Ok(v) => v,
+        Err(_) => Value::Object(serde_json::Map::new()),
+    };
+    let root_obj = match root.as_object_mut() {
+        Some(o) => o,
+        None => return settings.to_string(),
+    };
 
-    let mut out = String::from(&settings[..end]);
-    out.push_str(",\"provider\":{\"my_provider\":{\"api_key\":\"");
-    out.push_str(ak);
-    out.push_str("\",\"base_url\":\"");
-    out.push_str(bu);
-    out.push_str("\",\"models\":[");
+    let provider = root_obj
+        .entry("provider".to_string())
+        .or_insert_with(|| Value::Object(serde_json::Map::new()))
+        .as_object_mut()
+        .expect("provider must be object");
+    let my = provider
+        .entry("my_provider".to_string())
+        .or_insert_with(|| Value::Object(serde_json::Map::new()))
+        .as_object_mut()
+        .expect("my_provider must be object");
+    my.insert("api_key".to_string(), Value::String(ak.to_string()));
+    my.insert("base_url".to_string(), Value::String(bu.to_string()));
+    let models: Vec<Value> = mdls
+        .unwrap_or("")
+        .split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| Value::String(s.to_string()))
+        .collect();
+    my.insert("models".to_string(), Value::Array(models));
 
-    if let Some(mdls) = mdls {
-        let mut first = true;
-        for m in mdls.split(',') {
-            let m = m.trim();
-            if m.is_empty() { continue }
-            if !first { out.push(',') } else { first = false }
-            out.push('\"');
-            out.push_str(m);
-            out.push('\"');
-        }
+    let env = root_obj
+        .entry("env".to_string())
+        .or_insert_with(|| Value::Object(serde_json::Map::new()))
+        .as_object_mut()
+        .expect("env must be object");
+    env.insert(
+        "MY_PROVIDER_API_KEY".to_string(),
+        Value::String(ak.to_string()),
+    );
+
+    serde_json::to_string(&root).unwrap_or_else(|_| settings.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::inject_settings;
+    use serde_json::Value;
+
+    fn roundtrip(settings: &str, ak: &str, bu: &str, mdls: Option<&str>) -> Value {
+        let out = inject_settings(settings, ak, bu, mdls);
+        serde_json::from_str(&out).expect("output must be valid JSON")
     }
-    out.push_str("]}}");
 
-    out.push_str(",\"env\":{\"MY_PROVIDER_API_KEY\":\"");
-    out.push_str(ak);
-    out.push_str("\"}}");
+    fn assert_my_provider(root: &Value, ak: &str, bu: &str, models: &[&str]) {
+        let my = root["provider"]["my_provider"]
+            .as_object()
+            .expect("my_provider object");
+        assert_eq!(my["api_key"], Value::String(ak.to_string()));
+        assert_eq!(my["base_url"], Value::String(bu.to_string()));
+        let got: Vec<&str> = my["models"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert_eq!(got, models);
+        assert_eq!(
+            root["env"]["MY_PROVIDER_API_KEY"],
+            Value::String(ak.to_string())
+        );
+    }
 
-    out
+    #[test]
+    fn case1_empty_settings() {
+        let root = roundtrip("{}", "k", "u", Some("glm-5,deepseek-v3"));
+        assert_my_provider(&root, "k", "u", &["glm-5", "deepseek-v3"]);
+    }
+
+    #[test]
+    fn case2_no_provider() {
+        let root = roundtrip(
+            r#"{"server":{"port":9090}}"#,
+            "k",
+            "u",
+            Some("glm-5,deepseek-v3"),
+        );
+        assert_eq!(root["server"]["port"], Value::from(9090));
+        assert_my_provider(&root, "k", "u", &["glm-5", "deepseek-v3"]);
+    }
+
+    #[test]
+    fn case3_has_other_provider() {
+        let root = roundtrip(
+            r#"{"provider":{"other":{"api_key":"x"}}}"#,
+            "k",
+            "u",
+            Some("glm-5,deepseek-v3"),
+        );
+        assert_eq!(root["provider"]["other"]["api_key"], "x");
+        assert_my_provider(&root, "k", "u", &["glm-5", "deepseek-v3"]);
+    }
+
+    #[test]
+    fn case3b_my_provider_already_present_overwrite() {
+        let root = roundtrip(
+            r#"{"provider":{"my_provider":{"api_key":"user","models":["old"]}}}"#,
+            "k",
+            "u",
+            Some("glm-5,deepseek-v3"),
+        );
+        assert_eq!(root["provider"]["my_provider"]["api_key"], "k");
+        let models: Vec<&str> = root["provider"]["my_provider"]["models"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert_eq!(models, vec!["glm-5", "deepseek-v3"]);
+        assert_eq!(root["env"]["MY_PROVIDER_API_KEY"], "k");
+    }
+
+    #[test]
+    fn case4_invalid_json_fallback_to_empty_object() {
+        let root = roundtrip("not json", "k", "u", Some("glm-5"));
+        assert_my_provider(&root, "k", "u", &["glm-5"]);
+    }
+
+    #[test]
+    fn case5_top_level_not_object_returns_original() {
+        let out = inject_settings("[1,2,3]", "k", "u", Some("glm-5"));
+        assert_eq!(out, "[1,2,3]");
+    }
 }


### PR DESCRIPTION
Replaces fragile string-splicing with serde_json-based object manipulation, fixing the leading-comma bug on empty settings and the silent overwrite of an existing provider map.

Merge semantics (all overwrite):
- provider.my_provider.api_key/base_url: keyring overrides user
- provider.my_provider.models: keyring list replaces user array
- env.MY_PROVIDER_API_KEY: keyring overrides user
- Other existing keys (provider.X, server, env.Y) preserved.

Extracts inject_settings() as a pure function for cargo test. Gates wasm-only code (SDK extern, FFI exports, panic_handler from SDK) by target_family = "wasm", so host cargo test runs under std with the default global allocator. 6 unit tests cover all three cases plus overwrite, invalid-JSON fallback, non-object root.

Marks the corresponding [P1] entry in BUGS.md as FIXED.