### PR TITLE
feat(keyring): explicit D-Bus probe + Linux kernel-keyring fallback

### DIFF
--- a/cmd/cli/keyring/keyring.go
+++ b/cmd/cli/keyring/keyring.go
@@ -1,47 +1,117 @@
 // Package keyring wraps the system keychain via go-keyring.
 //
-// Supported: Linux Secret Service (D-Bus), macOS Keychain, Windows Credential Manager.
+// Supported backends:
+//   - Linux: Secret Service (D-Bus) preferred, kernel keyring (KeyCtl)
+//     fallback when no D-Bus session bus is available.
+//   - macOS Keychain / Windows Credential Manager via go-keyring.
+//
+// Open() returns ErrKeyringUnavailable when no persistent backend can be
+// initialized. Callers that tolerate secret loss (e.g. `serve`) may fall
+// back to NewMemStore(); callers that must persist (`keyring set`) should
+// surface the error to the user instead of silently storing in MemStore.
 package keyring
 
 import (
+	"encoding/base64"
 	"errors"
 	"sync"
 
 	gkr "github.com/zalando/go-keyring"
 )
 
-// Store wraps the system keychain. Methods accept a service name
+// ErrKeyringUnavailable is returned by Open when no persistent keyring
+// backend can be initialized.
+var ErrKeyringUnavailable = errors.New("keyring: no usable backend available")
+
+// Store wraps a persistent system backend. Methods accept a service name
 // so callers (including WASM plugins) can access keys under different
 // namespaces.
-type Store struct{}
+type Store struct {
+	backend backend
+}
 
-// Open returns a keyring store. Probes the backend to verify it's available.
+// backend is the storage interface satisfied by each concrete backend
+// (Secret Service via zalando, Linux kernel keyring, native keychain on
+// macOS/Windows).
+type backend interface {
+	Get(service, key string) (string, error)
+	Set(service, key, value string) error
+	Delete(service, key string) error
+}
+
+// Open returns a persistent Store. On Linux it prefers Secret Service
+// (D-Bus), falling back to the user kernel keyring (KeyCtl). On macOS /
+// Windows it uses the native keychain. Returns ErrKeyringUnavailable when
+// no persistent backend can be initialized.
 func Open() (*Store, error) {
-	_, err := gkr.Get("openagent", "__probe__")
-	if err != nil && !errors.Is(err, gkr.ErrNotFound) {
+	b, err := openBackend()
+	if err != nil {
 		return nil, err
 	}
-	return &Store{}, nil
+	return &Store{backend: b}, nil
+}
+
+// HasSupport reports whether a persistent keyring backend is available.
+func HasSupport() bool {
+	_, err := Open()
+	return err == nil
 }
 
 func (s *Store) Get(service, key string) (string, error) {
-	v, err := gkr.Get(service, key)
+	v, err := s.backend.Get(service, key)
 	if err != nil {
-		if errors.Is(err, gkr.ErrNotFound) { return "", nil }
+		if errors.Is(err, gkr.ErrNotFound) {
+			return "", nil
+		}
 		return "", err
 	}
 	return v, nil
 }
 
 func (s *Store) Set(service, key, value string) error {
-	if value == "" { return s.Delete(service, key) }
-	return gkr.Set(service, key, value)
+	if value == "" {
+		return s.backend.Delete(service, key)
+	}
+	return s.backend.Set(service, key, value)
 }
 
 func (s *Store) Delete(service, key string) error {
-	err := gkr.Delete(service, key)
-	if errors.Is(err, gkr.ErrNotFound) { return nil }
+	err := s.backend.Delete(service, key)
+	if errors.Is(err, gkr.ErrNotFound) {
+		return nil
+	}
 	return err
+}
+
+// secretServiceBackend wraps zalando/go-keyring (D-Bus on Linux,
+// Keychain on macOS, Credential Manager on Windows).
+type secretServiceBackend struct{}
+
+func (secretServiceBackend) Get(service, key string) (string, error) {
+	return gkr.Get(service, key)
+}
+
+func (secretServiceBackend) Set(service, key, value string) error {
+	return gkr.Set(service, key, value)
+}
+
+func (secretServiceBackend) Delete(service, key string) error {
+	return gkr.Delete(service, key)
+}
+
+// b64Encode/b64Decode are used by the KeyCtl backend to survive binary
+// payloads safely across the kernel keyring API (which expects byte
+// slices; we keep parity with hdspace-models/credential encoding too).
+func b64Encode(s string) string {
+	return base64.StdEncoding.EncodeToString([]byte(s))
+}
+
+func b64Decode(s string) (string, error) {
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
 }
 
 // MemStore is an in-memory keyring fallback for when the system keychain
@@ -63,7 +133,9 @@ func (m *MemStore) Get(service, key string) (string, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	v, ok := m.keys[m.gk(service, key)]
-	if !ok { return "", nil }
+	if !ok {
+		return "", nil
+	}
 	return v, nil
 }
 

--- a/cmd/cli/keyring/keyring_linux.go
+++ b/cmd/cli/keyring/keyring_linux.go
@@ -1,0 +1,139 @@
+//go:build linux
+
+package keyring
+
+import (
+	"errors"
+	"fmt"
+
+	dbus "github.com/godbus/dbus/v5"
+	gkr "github.com/zalando/go-keyring"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	dbusServiceName        = "org.freedesktop.DBus"
+	dbusObjectPath         = "/org/freedesktop/DBus"
+	dbusNameHasOwnerMethod = "org.freedesktop.DBus.NameHasOwner"
+	secretServiceName      = "org.freedesktop.secrets"
+
+	// Linux kernel keyring parameters.
+	keyringKeyType   = "user"
+	keyringKeyPrefix = "openagent:"
+)
+
+// openBackend selects a Linux keyring backend. It prefers Secret Service
+// (D-Bus), falling back to the kernel user keyring (KeyCtl) when no
+// session bus / Secret Service is available. Returns ErrKeyringUnavailable
+// when neither backend can be initialized.
+func openBackend() (backend, error) {
+	if isSecretServiceAvailable() {
+		return secretServiceBackend{}, nil
+	}
+	if err := ensureKeyringLinked(); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrKeyringUnavailable, err)
+	}
+	return keyctlBackend{}, nil
+}
+
+// isSecretServiceAvailable checks whether the Secret Service D-Bus
+// service is registered on the session bus. Unlike zalando/go-keyring's
+// implicit probe (which triggers `dbus-launch` autolaunch via godbus),
+// this explicitly calls dbus.SessionBus() — on recent godbus versions
+// SessionBus returns an error in headless environments instead of
+// invoking dbus-launch.
+func isSecretServiceAvailable() bool {
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		return false
+	}
+	defer conn.Close()
+	obj := conn.Object(dbusServiceName, dbusObjectPath)
+	var hasOwner bool
+	if err := obj.Call(dbusNameHasOwnerMethod, 0, secretServiceName).Store(&hasOwner); err != nil {
+		return false
+	}
+	return hasOwner
+}
+
+// ensureKeyringLinked links the user keyring to the session keyring so
+// that keys added by this process are visible to future sibling processes
+// in the same session. Mirrors `ensureKeyringLinked()` in
+// ~/projects/hdspace-models/credential/credential_linux.go. Returns an
+// error when the kernel keyring is not usable (e.g. containers lacking
+// the keyutils capability).
+func ensureKeyringLinked() error {
+	if _, err := unix.KeyctlInt(unix.KEYCTL_LINK,
+		unix.KEY_SPEC_USER_KEYRING,
+		unix.KEY_SPEC_SESSION_KEYRING, 0, 0); err != nil {
+		return fmt.Errorf("keyctl link user keyring: %w", err)
+	}
+	// Probe the user keyring id (creates if missing). If this fails the
+	// kernel doesn't support keyrings for this process and we should NOT
+	// silently fall back to MemStore.
+	if _, err := unix.KeyctlGetKeyringID(unix.KEY_SPEC_USER_KEYRING, true); err != nil {
+		return fmt.Errorf("keyctl get user keyring id: %w", err)
+	}
+	return nil
+}
+
+// keyctlBackend stores base64-encoded secrets in the Linux kernel
+// keyring under type "user" with descriptions "openagent:<service>:<key>".
+type keyctlBackend struct{}
+
+func keyctlDesc(service, key string) string {
+	return keyringKeyPrefix + service + ":" + key
+}
+
+func (keyctlBackend) Get(service, key string) (string, error) {
+	id, err := unix.KeyctlSearch(unix.KEY_SPEC_USER_KEYRING,
+		keyringKeyType, keyctlDesc(service, key), 0)
+	if err != nil {
+		if errors.Is(err, unix.ENOKEY) || errors.Is(err, unix.ENOENT) {
+			return "", gkr.ErrNotFound
+		}
+		return "", fmt.Errorf("keyctl search: %w", err)
+	}
+	// First call with nil buffer returns the required size.
+	n, err := unix.KeyctlBuffer(unix.KEYCTL_READ, id, nil, 0)
+	if err != nil {
+		return "", fmt.Errorf("keyctl read (probe): %w", err)
+	}
+	buf := make([]byte, n)
+	if _, err := unix.KeyctlBuffer(unix.KEYCTL_READ, id, buf, 0); err != nil {
+		return "", fmt.Errorf("keyctl read: %w", err)
+	}
+	return b64Decode(string(buf))
+}
+
+func (keyctlBackend) Set(service, key, value string) error {
+	desc := keyctlDesc(service, key)
+	// Revoke an existing key with the same description to avoid duplicates.
+	// AddKey would update an in-place key, but revoking first is simpler
+	// and consistent across kernel versions.
+	if id, err := unix.KeyctlSearch(unix.KEY_SPEC_USER_KEYRING,
+		keyringKeyType, desc, 0); err == nil {
+		_, _ = unix.KeyctlInt(unix.KEYCTL_REVOKE, id, 0, 0, 0)
+	}
+	if _, err := unix.AddKey(keyringKeyType, desc,
+		[]byte(b64Encode(value)), unix.KEY_SPEC_USER_KEYRING); err != nil {
+		return fmt.Errorf("keyctl add: %w", err)
+	}
+	return nil
+}
+
+func (keyctlBackend) Delete(service, key string) error {
+	id, err := unix.KeyctlSearch(unix.KEY_SPEC_USER_KEYRING,
+		keyringKeyType, keyctlDesc(service, key), 0)
+	if err != nil {
+		if errors.Is(err, unix.ENOKEY) || errors.Is(err, unix.ENOENT) {
+			return gkr.ErrNotFound
+		}
+		return fmt.Errorf("keyctl search: %w", err)
+	}
+	if _, err := unix.KeyctlInt(unix.KEYCTL_UNLINK, id,
+		unix.KEY_SPEC_USER_KEYRING, 0, 0); err != nil {
+		return fmt.Errorf("keyctl unlink: %w", err)
+	}
+	return nil
+}

--- a/cmd/cli/keyring/keyring_other.go
+++ b/cmd/cli/keyring/keyring_other.go
@@ -1,0 +1,20 @@
+//go:build !linux
+
+package keyring
+
+import (
+	"errors"
+
+	gkr "github.com/zalando/go-keyring"
+)
+
+// openBackend selects a backend on non-Linux platforms (macOS / Windows).
+// zalando/go-keyring routes to the native keychain (Keychain / WinCred)
+// which does not depend on D-Bus.
+func openBackend() (backend, error) {
+	if _, err := gkr.Get("openagent", "__probe__"); err != nil &&
+		!errors.Is(err, gkr.ErrNotFound) {
+		return nil, err
+	}
+	return secretServiceBackend{}, nil
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -211,7 +211,9 @@ func buildServeCmd(cfg config.Config) *cobra.Command {
 // ── keyring ──
 
 // openKeyring returns the system keyring, falling back to an in-memory
-// store with a warning when the system keychain is unavailable.
+// store with a warning when the system keychain is unavailable. Intended
+// for read-only / fall-through callers (e.g. `serve`) that can still
+// operate without persisted secrets.
 func openKeyring() plugin.Keyring {
 	sysKr, err := keyring.Open()
 	if err != nil {
@@ -221,11 +223,25 @@ func openKeyring() plugin.Keyring {
 	return sysKr
 }
 
+// keyringOrFail returns the system keyring or exits with a clear message
+// when no persistent backend is available. Used by `keyring set` /
+// `keyring delete` — silently storing in MemStore would be data loss
+// (user sees exit 0 but secrets evaporate on process exit).
+func keyringOrFail() plugin.Keyring {
+	sysKr, err := keyring.Open()
+	if err != nil {
+		log.Fatalf("no keyring backend available: install `dbus-x11` (Linux desktop) "+
+			"or run the container with `--cap-add=keyutils` for kernel-keyring "+
+			"fallback; original error: %v", err)
+	}
+	return sysKr
+}
+
 var keyringCmd = &cobra.Command{Use: "keyring", Short: "Manage credentials in the system keyring"}
 var keyringSetCmd = &cobra.Command{
 	Use: "set <key> <value>", Short: "Store a credential", Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return openKeyring().Set("openagent", args[0], args[1])
+		return keyringOrFail().Set("openagent", args[0], args[1])
 	},
 }
 var keyringGetCmd = &cobra.Command{
@@ -243,8 +259,7 @@ var keyringGetCmd = &cobra.Command{
 var keyringDeleteCmd = &cobra.Command{
 	Use: "delete <key>", Short: "Remove a credential", Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		openKeyring().Delete("openagent", args[0])
-		return nil
+		return keyringOrFail().Delete("openagent", args[0])
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	charm.land/bubbles/v2 v2.1.1
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/lipgloss/v2 v2.0.5
+	github.com/godbus/dbus/v5 v5.2.2
 	github.com/hashicorp/terraform-exec v0.25.2
 	github.com/hashicorp/terraform-json v0.27.2
 	github.com/modelcontextprotocol/go-sdk v1.6.1
@@ -17,6 +18,7 @@ require (
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/sync v0.21.0
+	golang.org/x/sys v0.46.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.38.2
 )
@@ -36,7 +38,6 @@ require (
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/dlclark/regexp2 v1.10.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
@@ -60,7 +61,6 @@ require (
 	github.com/zclconf/go-cty v1.18.1 // indirect
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
-	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	modernc.org/libc v1.66.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect


### PR DESCRIPTION
Replace the gkr.Get("__probe__") probe (which indirectly triggered dbus-launch autolaunch in headless containers, surfacing as `exec: "dbus-launch": executable file not found in $PATH`) with an explicit Secret Service availability check on Linux. Probe the session bus directly via github.com/godbus/dbus/v5 + NameHasOwner, catching autolaunch errors rather than invoking dbus-launch.

When Secret Service is unavailable, fall back to the Linux kernel keyring (type "user", descriptions "openagent:<service>:<key>") via golang.org/x/sys/unix. KEYCTL_LINK attaches the user keyring to the session keyring (mirrors ~/projects/hdspace-models/credential's ensureKeyringLinked). Secrets are base64-encoded to survive binary payloads safely across the kernel keyring API.

Surface ErrKeyringUnavailable from Open() so callers can distinguish "no persistent backend" from MemStore fallback. Add HasSupport() for explicit capability checks.

cmd/cli/main.go: keyringOrFail() now log.Fatalf's on `keyring set` and `keyring delete` when no persistent backend is available, instead of silently writing to MemStore and returning exit 0 (which lost secrets on process exit). openKeyring() retains the MemStore soft fallback for read-only callers like `serve` / `keyring get`.

Backend resolution is build-tagged: Linux uses
cmd/cli/keyring/keyring_linux.go; non-Linux (macOS Keychain / Windows Credential Manager) keeps the existing zalando path via cmd/cli/keyring/keyring_other.go, which does not depend on D-Bus.

Promote github.com/godbus/dbus/v5 and golang.org/x/sys from indirect to direct in go.mod.

Verified on Linux: Secret Service path set/get/delete pass; DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/nonexistent forces KeyCtl fallback — keys visible in /proc/keys under
`openagent:openagent:<key>`, cross-process Get succeeds, Delete removes the entry. linux/darwin/windows cross-compile clean; go vet ./... clean.