### PR TITLE
fix(acp): send config_option_update on mode change to sync VSCode plu…

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -34,9 +34,11 @@ Original issue: `migrate()` created `messages_fts` with the default `unicode61` 
 
 ---
 
-### [P2] VSCode ACP plugin mode indicator not updated after /mode or exit_plan_mode
+### [P2] ~~VSCode ACP plugin mode indicator not updated after /mode or exit_plan_mode~~ ✅ FIXED
 
-[acp/server.go:671-691](acp/server.go), [acp/server.go:851-879](acp/server.go): `setSessionMode` only sends `current_mode_update` (line 684-688), not `config_option_update`. The VSCode ACP plugin renders the mode selector as a config option (ID: `"mode"`) and relies on `config_option_update` to refresh its value. When mode is changed via `/mode` slash command, `session/set_mode` RPC, or `exit_plan_mode` tool, the plugin's mode indicator is not updated — even though the agent's internal mode (and actual tool gating behavior) has correctly changed. `OnSetSessionConfigOption` is the only path that sends both notifications, so only mode changes via the plugin's own config UI work correctly.
+[acp/server.go:671-691](acp/server.go), [acp/server.go:851-879](acp/server.go): **Fixed in this commit** — `setSessionMode` now sends both `current_mode_update` and `config_option_update`; `exit_plan_mode` now calls `setSessionMode` instead of manually setting mode + sending only `current_mode_update`; `OnSetSessionConfigOption` skips duplicate `config_option_update` when mode was changed.
+
+`setSessionMode` only sends `current_mode_update` (line 684-688), not `config_option_update`. The VSCode ACP plugin renders the mode selector as a config option (ID: `"mode"`) and relies on `config_option_update` to refresh its value. When mode is changed via `/mode` slash command, `session/set_mode` RPC, or `exit_plan_mode` tool, the plugin's mode indicator is not updated — even though the agent's internal mode (and actual tool gating behavior) has correctly changed. `OnSetSessionConfigOption` is the only path that sends both notifications, so only mode changes via the plugin's own config UI work correctly.
 
 Additionally, `exit_plan_mode` (line 851-879) manually sets `ss.mode` and sends only `current_mode_update`, bypassing `setSessionMode` entirely. This has the same symptom: after the agent calls `exit_plan_mode`, the actual mode reverts to auto/manual, but the plugin indicator still shows "plan".
 

--- a/acp/server.go
+++ b/acp/server.go
@@ -686,6 +686,12 @@ func (s *AgentServer) setSessionMode(ctx context.Context, sid openacp.SessionId,
 			SessionUpdate: "current_mode_update",
 			CurrentModeID: openacp.SessionModeId(mode),
 		})
+		// Also send config_option_update so the client's mode dropdown
+		// (which reads the "mode" config option) stays in sync.
+		s.updateSender.SendSessionUpdate(sid, openacp.SessionUpdate{
+			SessionUpdate: "config_option_update",
+			ConfigOptions: s.buildConfigOptions(sid),
+		})
 	}
 	return nil
 }
@@ -718,19 +724,25 @@ func (s *AgentServer) OnSetSessionConfigOption(ctx context.Context, req openacp.
 
 	// Sync session mode when the client sets the "mode" config option
 	// (most clients use set_config_option rather than set_mode).
+	// setSessionMode now sends both current_mode_update and
+	// config_option_update, so skip the duplicate notification below.
+	needsConfigUpdate := true
 	if req.ConfigID == "mode" {
 		if v, ok := ss.config["mode"].(string); ok {
 			_ = s.setSessionMode(ctx, req.SessionID, v)
+			needsConfigUpdate = false // already sent by setSessionMode
 		}
 	}
 
 	// Notify clients of the config change.
-	opts := s.buildConfigOptions(req.SessionID)
-	if s.updateSender != nil {
-		s.updateSender.SendSessionUpdate(req.SessionID, openacp.SessionUpdate{
-			SessionUpdate: "config_option_update",
-			ConfigOptions: opts,
-		})
+	if needsConfigUpdate {
+		opts := s.buildConfigOptions(req.SessionID)
+		if s.updateSender != nil {
+			s.updateSender.SendSessionUpdate(req.SessionID, openacp.SessionUpdate{
+				SessionUpdate: "config_option_update",
+				ConfigOptions: opts,
+			})
+		}
 	}
 
 	return &openacp.SetSessionConfigOptionResponse{
@@ -841,13 +853,16 @@ func (s *AgentServer) OnPrompt(ctx context.Context, req openacp.PromptRequest, s
 			if target == "" || target == "plan" {
 				target = "auto"
 			}
-			ss.mode = target
-			s.saveMode(ctx, string(req.SessionID), target)
+
+			// Persist mode change and notify client (sends both
+			// current_mode_update and config_option_update).
+			if err := s.setSessionMode(ctx, req.SessionID, target); err != nil {
+				return err
+			}
 
 			// Inject execution tools into the running agent clone
-			// so they are available this same turn.
+			// for subsequent model calls this turn.
 			s.injectExecutionTools(agent, req.SessionID, ss)
-
 
 			// Set approver based on target mode.
 			if target == "manual" && s.clientRPC != nil {
@@ -856,13 +871,6 @@ func (s *AgentServer) OnPrompt(ctx context.Context, req openacp.PromptRequest, s
 				agent.Approver = nil
 			}
 
-			// Notify client of mode change.
-			if s.updateSender != nil {
-				s.updateSender.SendSessionUpdate(req.SessionID, openacp.SessionUpdate{
-					SessionUpdate: "current_mode_update",
-					CurrentModeID: openacp.SessionModeId(target),
-				})
-			}
 			return nil
 		})
 		agent.Tools = append(agent.Tools, et)


### PR DESCRIPTION
…gin UI

Root cause: When session mode is changed via /mode slash command, session/set_mode RPC, or exit_plan_mode tool, only current_mode_update notification was sent. The VSCode ACP plugin renders the mode selector as a config option (ID: "mode") and relies on config_option_update to refresh its displayed value. Only session/set_config_option (plugin's own UI) sent both notifications.

Additionally, exit_plan_mode bypassed setSessionMode entirely — it manually set ss.mode, called saveMode, and sent only current_mode_update, duplicating logic and missing config_option_update.

Fixes (3 changes, all in acp/server.go):

1. setSessionMode (line 684-691): added config_option_update notification alongside existing current_mode_update so all mode change paths consistently send both notifications.

2. exit_plan_mode callback (line 851-879): replaced manual mode-setting
   + single notification with a call to setSessionMode, converging on the unified notification path.

3. OnSetSessionConfigOption (line 719-738): when mode config option is changed, skip the explicit config_option_update (setSessionMode now sends it) to avoid duplicate notifications.

Ref: BUGS.md [P2]