### PR TITLE
fix(plan): : add enter_plan_mode tool, restrict plan_create to plan mode only

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -444,31 +444,20 @@ Proposed fix (not yet applied):
 
 ---
 
-### [P2] `plan_create` available in all modes, bypassing plan-mode workflow
+### [P2] ~~`plan_create` available in all modes, bypassing plan-mode workflow~~ ✅ FIXED
 
-[acp/server.go:855-864](acp/server.go#L855), [acp/server.go:866-885](acp/server.go#L866), [plan/tool.go:16-116](plan/tool.go):
+[plan/tool.go:205-260](plan/tool.go), [acp/server.go:740-750](acp/server.go), [acp/server.go:867-919](acp/server.go), [acp/server.go:1263-1285](acp/server.go): **Fixed in this commit** — Added `EnterTool` (`enter_plan_mode`) to `plan/tool.go` as a symmetrical counterpart to `ExitTool` (`exit_plan_mode`). `plan_create` registration moved inside the `if ss.mode == "plan"` block in `OnPrompt`; `enter_plan_mode` registered in the `else` branch (auto/manual modes). `enterPlanMode` helper added to `AgentServer` to persist the mode transition via `setSessionMode`. `buildDynamicContext` updated to hint auto/manual agents about `enter_plan_mode` when no plan exists. The `enter_plan_mode` tool result card is suppressed in the CLI channel UI (same as `plan_update`). Cross-turn approach avoids removing execution tools from the agent clone mid-turn. `enter_plan_mode` inherits the current mode's approver automatically — auto runs without approval, manual triggers user confirmation via `acpApprover`.
 
-`plan_create` is registered unconditionally in `OnPrompt` — available in auto, manual, and plan modes. The agent in auto/manual mode can call `plan_create` to produce a structured plan AND immediately begin executing it within the same turn, bypassing the "enter plan mode → create plan → user review → exit plan mode → execute" workflow that plan mode was designed for.
+Original issue: `plan_create` was registered unconditionally in `OnPrompt` — available in auto, manual, and plan modes. The agent in auto/manual mode could call `plan_create` and immediately begin executing, bypassing the "enter plan mode → create plan → user review → exit plan mode → execute" workflow. The symmetry was also broken: `exit_plan_mode` had no `enter_plan_mode` counterpart.
 
-This conflates planning and execution: the plan is created while execution tools remain active, so the agent can skip user review entirely. The symmetry is also broken — `exit_plan_mode` has no `enter_plan_mode` counterpart, so agents in auto/manual mode cannot proactively switch to plan mode when they detect a complex task.
+Final tool availability:
 
-Current vs intended tool availability:
-
-| Tool | auto (current→target) | manual (current→target) | plan |
-|------|:---:|:---:|:----:|
-| `enter_plan_mode` | ✗→✓ | ✗→✓ | ✗ |
-| `plan_create` | ✓→✗ | ✓→✗ | ✓ |
-| `plan_update` | ✓→✓ | ✓→✓ | ✓ |
-| `exit_plan_mode` | ✗→✗ | ✗→✗ | ✓ |
-
-**Proposed fix:**
-1. Add `enter_plan_mode` tool to `plan/tool.go` (symmetrical to existing `exit_plan_mode`).
-2. Move `plan_create` registration inside the `if ss.mode == "plan"` block in `OnPrompt`.
-3. Register `enter_plan_mode` in the else branch (auto/manual modes).
-4. Update `buildDynamicContext` to hint auto/manual agents about `enter_plan_mode` for complex tasks.
-5. Cross-turn approach: `enter_plan_mode` calls `setSessionMode("plan")` to persist the mode change; the next `OnPrompt` turn picks up plan mode and registers `plan_create` + `exit_plan_mode`. This avoids the complexity of removing execution tools from the agent clone mid-turn.
-
-**Approval behavior:** `enter_plan_mode` inherits the current mode's approver automatically — in auto mode it runs without approval; in manual mode it triggers `acpApprover.requestPermission` for user confirmation. No extra wiring needed.
+| Tool | auto | manual | plan |
+|------|:----:|:------:|:----:|
+| `enter_plan_mode` | ✓ (no approval) | ✓ (needs approval) | ✗ |
+| `plan_create` | ✗ | ✗ | ✓ |
+| `plan_update` | ✓ | ✓ | ✓ |
+| `exit_plan_mode` | ✗ | ✗ | ✓ |
 
 ---
 

--- a/acp/server.go
+++ b/acp/server.go
@@ -738,6 +738,18 @@ func (s *AgentServer) setSessionMode(ctx context.Context, sid openacp.SessionId,
 	return nil
 }
 
+// enterPlanMode transitions the session into plan mode. Called by
+// enter_plan_mode's onEnter callback. The mode change takes effect
+// immediately (persisted + client notified), but the agent clone's tools
+// are not mutated — the next OnPrompt turn picks up plan mode and
+// registers plan_create + exit_plan_mode.
+func (s *AgentServer) enterPlanMode(ctx context.Context, sid openacp.SessionId, ss *agentSession) error {
+	if ss.mode == "plan" {
+		return nil // already in plan mode, no-op
+	}
+	return s.setSessionMode(ctx, sid, "plan")
+}
+
 func (s *AgentServer) OnSetSessionMode(ctx context.Context, req openacp.SetSessionModeRequest) (*openacp.SetSessionModeResponse, error) {
 	if err := s.setSessionMode(ctx, req.SessionID, string(req.ModeID)); err != nil {
 		return nil, err
@@ -852,71 +864,80 @@ func (s *AgentServer) OnPrompt(ctx context.Context, req openacp.PromptRequest, s
 		DynamicContext: s.buildDynamicContext(ss),
 	}
 
-	// ── Register plan_create tool ──
-	// The LLM outputs structured plan entries directly via function-calling
-	// arguments. The tool validates, persists, and notifies — no internal
-	// model calls needed.
-	pt := plan.NewCreateTool(func(entries []plan.Entry) {
-		ss.planEntries = entries
-		s.savePlan(ctx, string(req.SessionID), entries)
-		sender.SendPlanUpdate(s.entriesToACP(entries))
-	})
-	agent.Tools = append(agent.Tools, pt)
+		// ── Register mode-specific planning tools ──
+		if ss.mode == "plan" {
+			// plan_create: only available in plan mode.
+			pt := plan.NewCreateTool(func(entries []plan.Entry) {
+				ss.planEntries = entries
+				s.savePlan(ctx, string(req.SessionID), entries)
+				sender.SendPlanUpdate(s.entriesToACP(entries))
+			})
+			agent.Tools = append(agent.Tools, pt)
 
-	// ── Register plan_update tool ──
-	// Always registered so it can track plan progress. At execution time
-	// the tool reads ss.planEntries to resolve IDs — no stale closures.
-	pu := plan.NewUpdateTool(func(updates []plan.Update) ([]plan.Entry, error) {
-		idxByID := make(map[string]int, len(ss.planEntries))
-		for i, e := range ss.planEntries {
-			idxByID[e.ID] = i
+			// exit_plan_mode: only available in plan mode.
+			// In plan mode the agent has no execution tools. exit_plan_mode
+			// restores the mode that was active before entering plan mode and
+			// unlocks the full tool set. If the session started in plan (no
+			// previous mode), defaults to auto.
+			et := plan.NewExitTool(func() error {
+				target := ss.previousMode
+				if target == "" || target == "plan" {
+					target = "auto"
+				}
+
+				// Persist mode change and notify client (sends both
+				// current_mode_update and config_option_update).
+				if err := s.setSessionMode(ctx, req.SessionID, target); err != nil {
+					return err
+				}
+
+				// Inject execution tools into the running agent clone
+				// for subsequent model calls this turn.
+				s.injectExecutionTools(agent, req.SessionID, ss)
+
+				// Set approver based on target mode.
+				if target == "manual" && s.clientRPC != nil {
+					agent.Approver = &acpApprover{client: s.clientRPC, sessionID: req.SessionID}
+				} else {
+					agent.Approver = nil
+				}
+
+				return nil
+			})
+			agent.Tools = append(agent.Tools, et)
+		} else {
+			// enter_plan_mode: available in auto and manual mode.
+			// Allows the agent to proactively switch to plan mode for complex
+			// tasks. The mode change takes effect on the NEXT OnPrompt turn,
+			// where plan_create + exit_plan_mode become available.
+			// Approval behavior: inherits the current mode's approver — auto
+			// runs without approval; manual triggers user confirmation.
+			enterTool := plan.NewEnterTool(func() error {
+				return s.enterPlanMode(ctx, req.SessionID, ss)
+			})
+			agent.Tools = append(agent.Tools, enterTool)
 		}
-		for _, u := range updates {
-			idx, ok := idxByID[u.ID]
-			if !ok {
-				return nil, fmt.Errorf("plan_update: unknown step id %q", u.ID)
+
+		// ── Register plan_update tool (all modes) ──
+		// Always registered so it can track plan progress. At execution time
+		// the tool reads ss.planEntries to resolve IDs — no stale closures.
+		pu := plan.NewUpdateTool(func(updates []plan.Update) ([]plan.Entry, error) {
+			idxByID := make(map[string]int, len(ss.planEntries))
+			for i, e := range ss.planEntries {
+				idxByID[e.ID] = i
 			}
-			ss.planEntries[idx].Status = plan.Status(u.Status)
-		}
-		s.savePlan(ctx, string(req.SessionID), ss.planEntries)
-		sender.SendPlanUpdate(s.entriesToACP(ss.planEntries))
-		return copyPlanEntries(ss.planEntries), nil
-	})
-	agent.Tools = append(agent.Tools, pu)
-
-	// ── Register exit_plan_mode tool (plan mode only) ──
-	// In plan mode the agent has no execution tools. exit_plan_mode
-	// restores the mode that was active before entering plan mode and
-	// unlocks the full tool set. If the session started in plan (no
-	// previous mode), defaults to auto.
-	if ss.mode == "plan" {
-		et := plan.NewExitTool(func() error {
-			target := ss.previousMode
-			if target == "" || target == "plan" {
-				target = "auto"
+			for _, u := range updates {
+				idx, ok := idxByID[u.ID]
+				if !ok {
+					return nil, fmt.Errorf("plan_update: unknown step id %q", u.ID)
+				}
+				ss.planEntries[idx].Status = plan.Status(u.Status)
 			}
-
-			// Persist mode change and notify client (sends both
-			// current_mode_update and config_option_update).
-			if err := s.setSessionMode(ctx, req.SessionID, target); err != nil {
-				return err
-			}
-
-			// Inject execution tools into the running agent clone
-			// for subsequent model calls this turn.
-			s.injectExecutionTools(agent, req.SessionID, ss)
-
-			// Set approver based on target mode.
-			if target == "manual" && s.clientRPC != nil {
-				agent.Approver = &acpApprover{client: s.clientRPC, sessionID: req.SessionID}
-			} else {
-				agent.Approver = nil
-			}
-
-			return nil
+			s.savePlan(ctx, string(req.SessionID), ss.planEntries)
+			sender.SendPlanUpdate(s.entriesToACP(ss.planEntries))
+			return copyPlanEntries(ss.planEntries), nil
 		})
-		agent.Tools = append(agent.Tools, et)
-	}
+		agent.Tools = append(agent.Tools, pu)
 
 	// ── Run the agent ──
 	ch := agent.RunStream(ctx, oaSession, input)
@@ -1256,6 +1277,10 @@ func (s *AgentServer) buildDynamicContext(ss *agentSession) string {
 		b.WriteString("3. Wait for the user to review the plan\n")
 		b.WriteString("4. Call exit_plan_mode to leave plan mode and begin execution\n\n")
 		b.WriteString("Do NOT call exit_plan_mode until you have a complete plan that the user has reviewed.\n")
+	} else if len(ss.planEntries) == 0 {
+		// Auto/manual mode without a plan: hint about enter_plan_mode.
+		b.WriteString("## Task Planning\n")
+		b.WriteString("If this task is complex (involves multiple steps, multiple files, or requires careful sequencing), consider calling **enter_plan_mode** first. This will give you access to plan_create for structured planning. After creating a plan and having it reviewed, call exit_plan_mode to regain your execution tools and work through the plan.\n\n")
 	}
 
 	return b.String()

--- a/cmd/cli/server/channel.go
+++ b/cmd/cli/server/channel.go
@@ -263,7 +263,7 @@ func streamReply(reply channel.ReplyFunc, stream <-chan openagent.StreamEvent) {
 			delete(pendingTool, evt.Message.ToolCallID)
 			delete(toolBuf, evt.Message.ToolCallID)
 
-			if t.name == "plan_update" {
+			if t.name == "plan_update" || t.name == "enter_plan_mode" {
 				continue
 			}
 

--- a/plan/tool.go
+++ b/plan/tool.go
@@ -31,7 +31,7 @@ func (t *CreateTool) Definition() openagent.FunctionDefinition {
 		Name: "plan_create",
 		Description: `Create a structured execution plan for a complex task. Use this when a task involves multiple steps, spans multiple files, or requires careful sequencing.
 
-After creating the plan, proceed to execute each step. Call plan_update to mark each step in_progress when you start working on it and completed when you finish.`,
+After creating the plan and having it reviewed by the user, call exit_plan_mode to return to your previous mode and begin executing each step. Use plan_update to track progress during execution.`,
 		Parameters: json.RawMessage(`{
   "type": "object",
   "properties": {
@@ -200,6 +200,52 @@ func (t *UpdateTool) Execute(ctx context.Context, args json.RawMessage) (string,
 	}
 
 	return formatPlan("", entries), nil
+}
+
+// ── enter_plan_mode Tool ──
+
+// EnterTool is an openagent.Tool named "enter_plan_mode". The agent calls it
+// to enter plan mode when a task requires structured planning. In plan mode,
+// execution tools are removed and plan_create / exit_plan_mode become available.
+//
+// The onEnter callback is called by Execute to transition the session. It is
+// wired by the ACP server at OnPrompt time.
+type EnterTool struct {
+	onEnter func() error
+}
+
+// NewEnterTool creates an enter_plan_mode tool.
+func NewEnterTool(onEnter func() error) *EnterTool {
+	return &EnterTool{onEnter: onEnter}
+}
+
+// Definition implements openagent.Tool.
+func (t *EnterTool) Definition() openagent.FunctionDefinition {
+	return openagent.FunctionDefinition{
+		Name: "enter_plan_mode",
+		Description: `Enter plan mode to create a structured execution plan. Use this when the task is complex, involves multiple steps, spans multiple files, or requires careful sequencing.
+
+After entering plan mode, you will have access to plan_create, plan_update, and exit_plan_mode. Your execution tools (shell, file writes, terminal) will be temporarily unavailable — they will be restored when you call exit_plan_mode.
+
+Workflow: enter_plan_mode → plan_create → (user reviews plan) → exit_plan_mode → execute`,
+		Parameters: json.RawMessage(`{
+  "type": "object",
+  "properties": {},
+  "required": []
+}`),
+	}
+}
+
+// Execute implements openagent.Tool. It calls the onEnter callback to
+// transition the session mode, then returns confirmation text.
+func (t *EnterTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	if t.onEnter == nil {
+		return "enter_plan_mode: no mode transition callback configured.\n", nil
+	}
+	if err := t.onEnter(); err != nil {
+		return "", fmt.Errorf("enter_plan_mode: %w", err)
+	}
+	return "Entered plan mode. You now have access to plan_create and exit_plan_mode. Execution tools are disabled until you call exit_plan_mode. Create a plan with plan_create, then call exit_plan_mode when ready to execute.\n", nil
 }
 
 // ── exit_plan_mode Tool ──


### PR DESCRIPTION
- plan/tool.go: Add EnterTool (enter_plan_mode) as symmetrical counterpart to ExitTool
- acp/server.go: Move plan_create registration inside plan-mode block; register enter_plan_mode in auto/manual modes; add enterPlanMode helper for cross-turn mode transition; update buildDynamicContext
- cmd/cli/server/channel.go: Suppress enter_plan_mode result card in CLI channel UI
- BUGS.md: Mark issue as FIXED, update tool availability table