### PR TITLE
feat(cli): add --memory/--guard/--skills/--hooks/--observer/--mcp capability flags

### DIFF
--- a/acp/mcp_gate_test.go
+++ b/acp/mcp_gate_test.go
@@ -1,0 +1,71 @@
+package acp
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	openacp "github.com/yusheng-g/openagent-go/acp/sdk"
+)
+
+// TestNewAgentServer_MCPEnabledDefault verifies the MCP gate defaults to
+// enabled so existing callers (who don't set it) keep MCP behavior.
+func TestNewAgentServer_MCPEnabledDefault(t *testing.T) {
+	srv := NewAgentServer(nil, nil, nil, nil)
+	if !srv.MCPEnabled {
+		t.Error("NewAgentServer should default MCPEnabled to true")
+	}
+}
+
+// TestConnectMCP_Gate verifies that MCPEnabled=false prevents any MCP
+// connection attempt, while MCPEnabled=true allows it. The attempt is
+// detected via a stdio "touch" side effect: a spawned process creates a
+// file iff connectMCP actually invokes connectOneMCP.
+func TestConnectMCP_Gate(t *testing.T) {
+	touch, err := exec.LookPath("touch")
+	if err != nil {
+		t.Skip("touch not available; skipping MCP gate side-effect test")
+	}
+
+	srv := NewAgentServer(nil, nil, nil, nil)
+	// A stdio MCP server whose "server" is just `touch <file>`. connectMCP
+	// will spawn it (creating the file) then fail the MCP handshake — the
+	// failure is logged and non-fatal, but the file proves the spawn.
+	mkServers := func(file string) []openacp.McpServer {
+		return []openacp.McpServer{{Name: "x", Command: touch, Args: []string{file}}}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// ── Disabled: no spawn, no file ──
+	fileOff := filepath.Join(t.TempDir(), "spawned-off")
+	srv.MCPEnabled = false
+	if sess, tools := srv.connectMCP(ctx, mkServers(fileOff)); sess != nil || tools != nil {
+		t.Errorf("disabled connectMCP = %v, %v; want nil, nil", sess, tools)
+	}
+	if _, err := os.Stat(fileOff); err == nil {
+		t.Error("connectMCP spawned a process despite MCPEnabled=false")
+	}
+
+	// ── Enabled: spawn happens, file created ──
+	fileOn := filepath.Join(t.TempDir(), "spawned-on")
+	srv.MCPEnabled = true
+	srv.connectMCP(ctx, mkServers(fileOn))
+	// The spawn is synchronous up to handshake, but allow a brief window
+	// for the filesystem to reflect the touch.
+	deadline := time.Now().Add(2 * time.Second)
+	var found bool
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(fileOn); err == nil {
+			found = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !found {
+		t.Error("connectMCP did not spawn process with MCPEnabled=true (file not created)")
+	}
+}

--- a/acp/server.go
+++ b/acp/server.go
@@ -18,8 +18,8 @@ import (
 	"github.com/yusheng-g/openagent-go/mcp"
 	"github.com/yusheng-g/openagent-go/plan"
 	"github.com/yusheng-g/openagent-go/session"
-	opentool "github.com/yusheng-g/openagent-go/tool"
 	"github.com/yusheng-g/openagent-go/slash"
+	opentool "github.com/yusheng-g/openagent-go/tool"
 )
 
 // AgentServer wraps an [openagent.Agent] as an [openacp.AgentHandler].
@@ -42,7 +42,7 @@ type AgentServer struct {
 	// clientRPC is set by the SDK mux via ClientRPCUser.
 	clientRPC    openacp.ClientRequester
 	updateSender openacp.SessionUpdateSender
-	cmdRegistry   *slash.Registry // slash command dispatch
+	cmdRegistry  *slash.Registry // slash command dispatch
 
 	// clientCaps holds the capabilities advertised by the client during
 	// initialize. Guarded by mu. Used to gate Agent→Client RPC tool
@@ -56,17 +56,22 @@ type AgentServer struct {
 	// ToolFactory is called per-turn to create tools scoped to the
 	// session cwd. If nil, only plan + MCP + client-RPC tools are used.
 	ToolFactory func(cwd string) []openagent.Tool
+
+	// MCPEnabled controls whether client-advertised MCP servers are
+	// connected on session create/load/resume. Default true (enabled in
+	// NewAgentServer); set false to disable MCP tool integration.
+	MCPEnabled bool
 }
 
 // agentSession holds per-session runtime state.
 type agentSession struct {
-	id        openacp.SessionId
-	cwd       string
-	createdAt time.Time
+	id           openacp.SessionId
+	cwd          string
+	createdAt    time.Time
 	mode         string                          // "auto", "manual", or "plan"
 	previousMode string                          // mode before entering plan; used by exit_plan_mode
 	config       map[openacp.SessionConfigId]any // config option values
-	cancel    context.CancelFunc
+	cancel       context.CancelFunc
 
 	// Accumulated usage across turns.
 	totalTokens int
@@ -103,6 +108,7 @@ func NewAgentServer(agent *openagent.Agent, mem openagent.Memory, store session.
 		SessionStore: store,
 		Models:       models,
 		sessions:     make(map[openacp.SessionId]*agentSession),
+		MCPEnabled:   true,
 	}
 	s.cmdRegistry = s.buildCommandRegistry()
 	if s.Models == nil {
@@ -259,6 +265,9 @@ func (s *AgentServer) loadMode(ctx context.Context, sessionID string) string {
 // long-lived (one connection per session lifetime).
 // Failed connections are logged but not fatal — MCP is an optional enhancement.
 func (s *AgentServer) connectMCP(ctx context.Context, servers []openacp.McpServer) ([]*mcp.Session, []openagent.Tool) {
+	if !s.MCPEnabled {
+		return nil, nil
+	}
 	client := mcp.NewClient("openagent-acp", "1.0.0")
 	var sessions []*mcp.Session
 	var tools []openagent.Tool
@@ -390,7 +399,7 @@ func (s *AgentServer) OnNewSession(ctx context.Context, req openacp.NewSessionRe
 	// Send available commands so the client can show them immediately.
 	if s.updateSender != nil {
 		s.updateSender.SendSessionUpdate(id, openacp.SessionUpdate{
-			SessionUpdate: "available_commands_update",
+			SessionUpdate:     "available_commands_update",
 			AvailableCommands: s.availableCommands(),
 		})
 	}
@@ -869,80 +878,80 @@ func (s *AgentServer) OnPrompt(ctx context.Context, req openacp.PromptRequest, s
 		DynamicContext: s.buildDynamicContext(ss),
 	}
 
-		// ── Register mode-specific planning tools ──
-		if ss.mode == "plan" {
-			// plan_create: only available in plan mode.
-			pt := plan.NewCreateTool(func(entries []plan.Entry) {
-				ss.planEntries = entries
-				s.savePlan(ctx, string(req.SessionID), entries)
-				sender.SendPlanUpdate(s.entriesToACP(entries))
-			})
-			agent.Tools = append(agent.Tools, pt)
-
-			// exit_plan_mode: only available in plan mode.
-			// In plan mode the agent has no execution tools. exit_plan_mode
-			// restores the mode that was active before entering plan mode and
-			// unlocks the full tool set. If the session started in plan (no
-			// previous mode), defaults to auto.
-			et := plan.NewExitTool(func() error {
-				target := ss.previousMode
-				if target == "" || target == "plan" {
-					target = "auto"
-				}
-
-				// Persist mode change and notify client (sends both
-				// current_mode_update and config_option_update).
-				if err := s.setSessionMode(ctx, req.SessionID, target); err != nil {
-					return err
-				}
-
-				// Inject execution tools into the running agent clone
-				// for subsequent model calls this turn.
-				s.injectExecutionTools(agent, req.SessionID, ss)
-
-				// Set approver based on target mode.
-				if target == "manual" && s.clientRPC != nil {
-					agent.Approver = &acpApprover{client: s.clientRPC, sessionID: req.SessionID}
-				} else {
-					agent.Approver = nil
-				}
-
-				return nil
-			})
-			agent.Tools = append(agent.Tools, et)
-		} else {
-			// enter_plan_mode: available in auto and manual mode.
-			// Allows the agent to proactively switch to plan mode for complex
-			// tasks. The mode change takes effect on the NEXT OnPrompt turn,
-			// where plan_create + exit_plan_mode become available.
-			// Approval behavior: inherits the current mode's approver — auto
-			// runs without approval; manual triggers user confirmation.
-			enterTool := plan.NewEnterTool(func() error {
-				return s.enterPlanMode(ctx, req.SessionID, ss)
-			})
-			agent.Tools = append(agent.Tools, enterTool)
-		}
-
-		// ── Register plan_update tool (all modes) ──
-		// Always registered so it can track plan progress. At execution time
-		// the tool reads ss.planEntries to resolve IDs — no stale closures.
-		pu := plan.NewUpdateTool(func(updates []plan.Update) ([]plan.Entry, error) {
-			idxByID := make(map[string]int, len(ss.planEntries))
-			for i, e := range ss.planEntries {
-				idxByID[e.ID] = i
-			}
-			for _, u := range updates {
-				idx, ok := idxByID[u.ID]
-				if !ok {
-					return nil, fmt.Errorf("plan_update: unknown step id %q", u.ID)
-				}
-				ss.planEntries[idx].Status = plan.Status(u.Status)
-			}
-			s.savePlan(ctx, string(req.SessionID), ss.planEntries)
-			sender.SendPlanUpdate(s.entriesToACP(ss.planEntries))
-			return copyPlanEntries(ss.planEntries), nil
+	// ── Register mode-specific planning tools ──
+	if ss.mode == "plan" {
+		// plan_create: only available in plan mode.
+		pt := plan.NewCreateTool(func(entries []plan.Entry) {
+			ss.planEntries = entries
+			s.savePlan(ctx, string(req.SessionID), entries)
+			sender.SendPlanUpdate(s.entriesToACP(entries))
 		})
-		agent.Tools = append(agent.Tools, pu)
+		agent.Tools = append(agent.Tools, pt)
+
+		// exit_plan_mode: only available in plan mode.
+		// In plan mode the agent has no execution tools. exit_plan_mode
+		// restores the mode that was active before entering plan mode and
+		// unlocks the full tool set. If the session started in plan (no
+		// previous mode), defaults to auto.
+		et := plan.NewExitTool(func() error {
+			target := ss.previousMode
+			if target == "" || target == "plan" {
+				target = "auto"
+			}
+
+			// Persist mode change and notify client (sends both
+			// current_mode_update and config_option_update).
+			if err := s.setSessionMode(ctx, req.SessionID, target); err != nil {
+				return err
+			}
+
+			// Inject execution tools into the running agent clone
+			// for subsequent model calls this turn.
+			s.injectExecutionTools(agent, req.SessionID, ss)
+
+			// Set approver based on target mode.
+			if target == "manual" && s.clientRPC != nil {
+				agent.Approver = &acpApprover{client: s.clientRPC, sessionID: req.SessionID}
+			} else {
+				agent.Approver = nil
+			}
+
+			return nil
+		})
+		agent.Tools = append(agent.Tools, et)
+	} else {
+		// enter_plan_mode: available in auto and manual mode.
+		// Allows the agent to proactively switch to plan mode for complex
+		// tasks. The mode change takes effect on the NEXT OnPrompt turn,
+		// where plan_create + exit_plan_mode become available.
+		// Approval behavior: inherits the current mode's approver — auto
+		// runs without approval; manual triggers user confirmation.
+		enterTool := plan.NewEnterTool(func() error {
+			return s.enterPlanMode(ctx, req.SessionID, ss)
+		})
+		agent.Tools = append(agent.Tools, enterTool)
+	}
+
+	// ── Register plan_update tool (all modes) ──
+	// Always registered so it can track plan progress. At execution time
+	// the tool reads ss.planEntries to resolve IDs — no stale closures.
+	pu := plan.NewUpdateTool(func(updates []plan.Update) ([]plan.Entry, error) {
+		idxByID := make(map[string]int, len(ss.planEntries))
+		for i, e := range ss.planEntries {
+			idxByID[e.ID] = i
+		}
+		for _, u := range updates {
+			idx, ok := idxByID[u.ID]
+			if !ok {
+				return nil, fmt.Errorf("plan_update: unknown step id %q", u.ID)
+			}
+			ss.planEntries[idx].Status = plan.Status(u.Status)
+		}
+		s.savePlan(ctx, string(req.SessionID), ss.planEntries)
+		sender.SendPlanUpdate(s.entriesToACP(ss.planEntries))
+		return copyPlanEntries(ss.planEntries), nil
+	})
+	agent.Tools = append(agent.Tools, pu)
 
 	// ── Run the agent ──
 	ch := agent.RunStream(ctx, oaSession, input)

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -13,17 +13,17 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/spf13/cobra"
 
 	"github.com/yusheng-g/openagent-go/cmd/cli/config"
 	"github.com/yusheng-g/openagent-go/cmd/cli/keyring"
+	"github.com/yusheng-g/openagent-go/cmd/cli/server"
 	"github.com/yusheng-g/openagent-go/plugin/cli"
 	cliwasm "github.com/yusheng-g/openagent-go/plugin/cli/wasm"
-	"github.com/yusheng-g/openagent-go/cmd/cli/server"
 )
-
 
 func main() {
 	log.SetFlags(0)
@@ -210,11 +210,13 @@ var rootCmd = &cobra.Command{
 // ── serve ──
 
 func buildServeCmd(cfg config.Config) *cobra.Command {
+	var caps server.Capabilities
 	cmd := &cobra.Command{
 		Use:          "serve",
 		Short:        "Start the server (REST by default, or --acp for ACP)",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			parseCapabilities(cmd, &caps)
 			isACP, _ := cmd.Flags().GetBool("acp")
 			channelFlag, _ := cmd.Flags().GetString("channel")
 			p, _ := cmd.Flags().GetInt("port")
@@ -227,38 +229,83 @@ func buildServeCmd(cfg config.Config) *cobra.Command {
 
 			ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
-		// Channels are only enabled when --channel is explicitly set.
-		// settings.json credentials alone do NOT auto-start a channel.
-		if channelFlag != "feishu" {
-			cfg.Channels = config.ChannelsConfig{}
-		} else {
-			creds, err := server.ResolveFeishuCredentials(ctx)
-			if err != nil {
-				cancel()
-				return fmt.Errorf("feishu: %w", err)
+			// Channels are only enabled when --channel is explicitly set.
+			// settings.json credentials alone do NOT auto-start a channel.
+			if channelFlag != "feishu" {
+				cfg.Channels = config.ChannelsConfig{}
+			} else {
+				creds, err := server.ResolveFeishuCredentials(ctx)
+				if err != nil {
+					cancel()
+					return fmt.Errorf("feishu: %w", err)
+				}
+				if cfg.Channels.Feishu == nil {
+					cfg.Channels.Feishu = &config.FeishuConfig{}
+				}
+				if cfg.Channels.Feishu.AppID == "" {
+					cfg.Channels.Feishu.AppID = creds.AppID
+				}
+				if cfg.Channels.Feishu.AppSecret == "" {
+					cfg.Channels.Feishu.AppSecret = creds.AppSecret
+				}
 			}
-			if cfg.Channels.Feishu == nil {
-				cfg.Channels.Feishu = &config.FeishuConfig{}
-			}
-			if cfg.Channels.Feishu.AppID == "" {
-				cfg.Channels.Feishu.AppID = creds.AppID
-			}
-			if cfg.Channels.Feishu.AppSecret == "" {
-				cfg.Channels.Feishu.AppSecret = creds.AppSecret
-			}
-		}
 			defer cancel()
 			if isACP {
-				return server.RunACP(ctx, &cfg)
+				return server.RunACP(ctx, &cfg, caps)
 			}
-			return server.RunREST(ctx, &cfg)
+			return server.RunREST(ctx, &cfg, caps)
 		},
 	}
 	cmd.Flags().Bool("acp", false, "ACP mode over stdio")
 	cmd.Flags().String("channel", "", "Enable IM channel (e.g. \"feishu\")")
 	cmd.Flags().Int("port", 0, "REST port (overrides settings)")
 	cmd.Flags().Bool("sandbox", false, "Enable OS-native sandbox (bwrap/seatbelt) for shell commands")
+	addCapabilityFlags(cmd)
 	return cmd
+}
+
+func addCapabilityFlags(cmd *cobra.Command) {
+	for _, f := range []struct{ name, def, desc string }{
+		{"memory", "on", "Memory backend"},
+		{"summarizer", "on", "Conversation summarizer"},
+		{"tools", "on", "Built-in tools (shell, file, grep, etc.)"},
+		{"skills", "on", "Skill loader"},
+		{"mcp", "on", "MCP tool servers"},
+		{"guard", "off", "LLM content guard"},
+		{"approver", "off", "Human-in-the-Loop tool approval"},
+		{"hooks", "off", "Lifecycle hooks (slog)"},
+		{"observer", "off", "Stage observer"},
+	} {
+		cmd.Flags().String(f.name, f.def, f.desc+` ("on" or "off")`)
+	}
+}
+
+func parseCapabilities(cmd *cobra.Command, caps *server.Capabilities) {
+	set := func(name string, field **bool) {
+		if !cmd.Flags().Changed(name) {
+			return // not explicitly set — Capabilities.on() uses the default
+		}
+		v, _ := cmd.Flags().GetString(name)
+		switch strings.ToLower(v) {
+		case "on":
+			b := true
+			*field = &b
+		case "off":
+			b := false
+			*field = &b
+		default:
+			log.Printf("WARNING: --%s=%q is invalid (expected on/off), using default", name, v)
+		}
+	}
+	set("memory", &caps.Memory)
+	set("summarizer", &caps.Summarizer)
+	set("tools", &caps.Tools)
+	set("skills", &caps.Skills)
+	set("mcp", &caps.MCP)
+	set("guard", &caps.Guard)
+	set("approver", &caps.Approver)
+	set("hooks", &caps.Hooks)
+	set("observer", &caps.Observer)
 }
 
 // ── keyring ──
@@ -305,7 +352,11 @@ var keyringGetCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("keyring get: %w", err)
 		}
-		if v == "" { fmt.Println("(not found)") } else { fmt.Println(v) }
+		if v == "" {
+			fmt.Println("(not found)")
+		} else {
+			fmt.Println(v)
+		}
 		return nil
 	},
 }
@@ -324,9 +375,13 @@ type defaultHTTPClient struct{ client *http.Client }
 
 func (c *defaultHTTPClient) Do(method, url string, headers map[string]string, body []byte) (int, []byte, error) {
 	req, _ := http.NewRequest(method, url, bytes.NewReader(body))
-	for k, v := range headers { req.Header.Set(k, v) }
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
 	resp, err := c.client.Do(req)
-	if err != nil { return 0, nil, err }
+	if err != nil {
+		return 0, nil, err
+	}
 	defer resp.Body.Close()
 	respBody, _ := io.ReadAll(resp.Body)
 	return resp.StatusCode, respBody, nil

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/yusheng-g/openagent-go/cmd/cli/server"
+)
+
+// newCapCmd creates a cobra.Command with capability flags and calls
+// addCapabilityFlags + parseCapabilities, returning the result.
+func newCapCmd(args []string) server.Capabilities {
+	cmd := &cobra.Command{}
+	addCapabilityFlags(cmd)
+	// Cobra parses os.Args by default; override with explicit args.
+	cmd.SetArgs(args)
+	_ = cmd.Execute()
+
+	var caps server.Capabilities
+	parseCapabilities(cmd, &caps)
+	return caps
+}
+
+func TestParseCapabilities_Defaults(t *testing.T) {
+	caps := newCapCmd([]string{})
+	if !caps.OnMemory() {
+		t.Error("memory default: want on")
+	}
+	if !caps.OnSummarizer() {
+		t.Error("summarizer default: want on")
+	}
+	if !caps.OnTools() {
+		t.Error("tools default: want on")
+	}
+	if !caps.OnSkills() {
+		t.Error("skills default: want on")
+	}
+	if !caps.OnMCP() {
+		t.Error("mcp default: want on")
+	}
+	if caps.OnGuard() {
+		t.Error("guard default: want off")
+	}
+	if caps.OnApprover() {
+		t.Error("approver default: want off")
+	}
+	if caps.OnHooks() {
+		t.Error("hooks default: want off")
+	}
+	if caps.OnObserver() {
+		t.Error("observer default: want off")
+	}
+}
+
+func TestParseCapabilities_ExplicitOnOff(t *testing.T) {
+	caps := newCapCmd([]string{
+		"--memory=off", "--summarizer=off", "--tools=off",
+		"--skills=off", "--mcp=off",
+		"--guard=on", "--approver=on", "--hooks=on", "--observer=on",
+	})
+	if caps.OnMemory() {
+		t.Error("memory=off: want off")
+	}
+	if caps.OnSummarizer() {
+		t.Error("summarizer=off: want off")
+	}
+	if caps.OnTools() {
+		t.Error("tools=off: want off")
+	}
+	if caps.OnSkills() {
+		t.Error("skills=off: want off")
+	}
+	if caps.OnMCP() {
+		t.Error("mcp=off: want off")
+	}
+	if !caps.OnGuard() {
+		t.Error("guard=on: want on")
+	}
+	if !caps.OnApprover() {
+		t.Error("approver=on: want on")
+	}
+	if !caps.OnHooks() {
+		t.Error("hooks=on: want on")
+	}
+	if !caps.OnObserver() {
+		t.Error("observer=on: want on")
+	}
+}
+
+func TestParseCapabilities_InvalidValue(t *testing.T) {
+	// Invalid values should be ignored → Capabilities uses defaults.
+	caps := newCapCmd([]string{
+		"--memory=maybe",  // invalid → use default (on)
+		"--guard=invalid", // invalid → use default (off)
+	})
+	if !caps.OnMemory() {
+		t.Error("memory=maybe (invalid) → should fall back to default on")
+	}
+	if caps.OnGuard() {
+		t.Error("guard=invalid → should fall back to default off")
+	}
+}
+
+func TestParseCapabilities_PartialOverride(t *testing.T) {
+	// Only override one flag; others stay default.
+	caps := newCapCmd([]string{"--memory=off"})
+	if caps.OnMemory() {
+		t.Error("memory=off: want off")
+	}
+	// All others should use defaults.
+	if !caps.OnSummarizer() {
+		t.Error("summarizer default: want on")
+	}
+	if caps.OnGuard() {
+		t.Error("guard default: want off")
+	}
+}
+
+func TestParseCapabilities_CaseInsensitive(t *testing.T) {
+	// "ON"/"OFF", "On"/"Off" should all be accepted (case-insensitive).
+	caps := newCapCmd([]string{
+		"--memory=ON", "--summarizer=On", "--tools=off",
+		"--skills=OFF", "--mcp=on",
+		"--guard=ON", "--approver=On", "--hooks=OFF", "--observer=Off",
+	})
+	if !caps.OnMemory() {
+		t.Error("memory=ON → should be on")
+	}
+	if !caps.OnSummarizer() {
+		t.Error("summarizer=On → should be on")
+	}
+	if caps.OnTools() {
+		t.Error("tools=off → should be off")
+	}
+	if caps.OnSkills() {
+		t.Error("skills=OFF → should be off")
+	}
+	if !caps.OnMCP() {
+		t.Error("mcp=on → should be on")
+	}
+	if !caps.OnGuard() {
+		t.Error("guard=ON → should be on")
+	}
+	if !caps.OnApprover() {
+		t.Error("approver=On → should be on")
+	}
+	if caps.OnHooks() {
+		t.Error("hooks=OFF → should be off")
+	}
+	if caps.OnObserver() {
+		t.Error("observer=Off → should be off")
+	}
+}

--- a/cmd/cli/server/acp.go
+++ b/cmd/cli/server/acp.go
@@ -25,7 +25,7 @@ import (
 //  4. Wire summarizer for long-conversation compression.
 //  5. Construct the agent.
 //  6. Wrap in AgentServer, launch ACP protocol mux on stdin/stdout.
-func RunACP(ctx context.Context, cfg *config.Config) error {
+func RunACP(ctx context.Context, cfg *config.Config, caps Capabilities) error {
 	cfgPath, _ := config.Path()
 	dataDir := filepath.Join(filepath.Dir(cfgPath), "data")
 
@@ -49,29 +49,45 @@ func RunACP(ctx context.Context, cfg *config.Config) error {
 		modelMap[key] = mi.Model
 	}
 
-	// Enable summarizer with the first model as summarization backend.
+	// Summarizer and Memory are enabled by default; allow --summarizer=off
+	// and --memory=off to disable them.
+	var firstM openagent.Model
 	if len(modelInfos) > 0 {
-		m := modelInfos[0].Model
-		mem.WithSummarizer(summarizer.New(m))
+		firstM = modelInfos[0].Model
+		if caps.OnSummarizer() {
+			mem.WithSummarizer(summarizer.New(firstM))
+		}
 	}
 
 	// Tools and sandbox are created per-turn in agentForTurn so they
 	// use the session's cwd rather than the process working directory.
-	// This is essential when the agent runs in a container with a
-	// different mount path than the host.
-	agent := openagent.NewAgent("openagent",
-		openagent.WithMemory(mem),
+	opts := []openagent.AgentOption{
 		openagent.WithSystemPrompts(resolveProfiles(cfg.Profiles)...),
 		openagent.WithMaxTurns(100),
-	)
+	}
+	if caps.OnMemory() {
+		opts = append(opts, openagent.WithMemory(mem))
+	}
+	opts = buildOpts(opts, caps, firstM)
+	agent := openagent.NewAgent("openagent", opts...)
 
-	srv := acp.NewAgentServer(agent, mem, sessionStore, modelMap)
+	// Pass nil Mem when --memory=off so the AgentServer skips history
+	// replay and memory cleanup (all s.Mem uses are nil-guarded). The
+	// sessionStore (session metadata) is separate and unaffected.
+	var serverMem openagent.Memory = mem
+	if !caps.OnMemory() {
+		serverMem = nil
+	}
+	srv := acp.NewAgentServer(agent, serverMem, sessionStore, modelMap)
+	srv.MCPEnabled = caps.OnMCP()
 	policy := sandboxPolicy(cfg.Sandbox)
-	srv.ToolFactory = func(cwd string) []openagent.Tool {
-		if sb, err := native.NewWithPolicy(cwd, policy); err == nil {
-			return buildTools(sb, cwd, []string{"shell", "read", "write", "ls", "grep"})
+	if caps.OnTools() {
+		srv.ToolFactory = func(cwd string) []openagent.Tool {
+			if sb, err := native.NewWithPolicy(cwd, policy); err == nil {
+				return buildTools(sb, cwd, []string{"shell", "read", "write", "ls", "grep"})
+			}
+			return nil
 		}
-		return nil
 	}
 	server := openacpsdk.NewServer("openagent-acp", "1.0.0", srv)
 	server.SetLogger(slog.Default())
@@ -86,9 +102,11 @@ func RunACP(ctx context.Context, cfg *config.Config) error {
 			break
 		}
 	}
-	cwd, _ := os.Getwd()
-	if sb, err := native.NewWithPolicy(cwd, policy); err == nil {
-		channelAgent.Tools = buildTools(sb, cwd, []string{"shell", "read", "write", "ls", "grep"})
+	if caps.OnTools() {
+		cwd, _ := os.Getwd()
+		if sb, err := native.NewWithPolicy(cwd, policy); err == nil {
+			channelAgent.Tools = buildTools(sb, cwd, []string{"shell", "read", "write", "ls", "grep"})
+		}
 	}
 
 	if err := RunChannels(ctx, channelAgent, cfg.Channels); err != nil {

--- a/cmd/cli/server/buildopts_test.go
+++ b/cmd/cli/server/buildopts_test.go
@@ -1,0 +1,195 @@
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	openagent "github.com/yusheng-g/openagent-go"
+)
+
+// mockModel is a no-op Model used only to satisfy buildGuard's non-nil
+// requirement. Its methods are never called by buildOpts (the Guard is
+// constructed but not invoked), so they return zero values.
+type mockModel struct{}
+
+func (mockModel) ChatCompletion(ctx context.Context, req openagent.ChatCompletionRequest) (*openagent.ChatCompletionResponse, error) {
+	return nil, nil
+}
+func (mockModel) ChatCompletionStream(ctx context.Context, req openagent.ChatCompletionRequest) (openagent.StreamReader, error) {
+	return nil, nil
+}
+func (mockModel) ContextWindow() int { return 0 }
+
+// chdirEmpty ensures openSkillLoader() finds no .openagent/skills by moving
+// to a temp dir and pointing HOME elsewhere. Returns a restore func.
+func chdirEmpty(t *testing.T) func() {
+	t.Helper()
+	origHome := os.Getenv("HOME")
+	origWd, _ := os.Getwd()
+	tmp := t.TempDir()
+	os.Chdir(tmp)
+	os.Setenv("HOME", filepath.Join(tmp, "no-home"))
+	return func() {
+		os.Chdir(origWd)
+		os.Setenv("HOME", origHome)
+	}
+}
+
+// chdirWithSkills creates .openagent/skills in a temp cwd so openSkillLoader
+// returns a non-nil loader.
+func chdirWithSkills(t *testing.T) func() {
+	t.Helper()
+	origHome := os.Getenv("HOME")
+	origWd, _ := os.Getwd()
+	tmp := t.TempDir()
+	os.Chdir(tmp)
+	os.Setenv("HOME", filepath.Join(tmp, "no-home"))
+	if err := os.MkdirAll(filepath.Join(tmp, ".openagent", "skills"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return func() {
+		os.Chdir(origWd)
+		os.Setenv("HOME", origHome)
+	}
+}
+
+// applyOpts runs buildOpts over a base option slice and constructs a real
+// Agent, so we can inspect the resulting exported fields.
+func applyOpts(caps Capabilities, model openagent.Model) *openagent.Agent {
+	opts := buildOpts(nil, caps, model)
+	return openagent.NewAgent("test", opts...)
+}
+
+func TestBuildOpts_AllOff(t *testing.T) {
+	restore := chdirEmpty(t)
+	defer restore()
+	// Capabilities zero value: skills/guard/hooks/observer all default OFF.
+	agent := applyOpts(Capabilities{}, mockModel{})
+	if agent.SkillLoader != nil {
+		t.Error("SkillLoader should be nil when OnSkills=false")
+	}
+	if agent.InGuard != nil {
+		t.Error("InGuard should be nil when OnGuard=false")
+	}
+	if agent.OutGuard != nil {
+		t.Error("OutGuard should be nil when OnGuard=false")
+	}
+	if agent.Hooks != nil {
+		t.Error("Hooks should be nil when OnHooks=false")
+	}
+	if agent.Observer != nil {
+		t.Error("Observer should be nil when OnObserver=false")
+	}
+}
+
+func TestBuildOpts_HooksAndObserver(t *testing.T) {
+	restore := chdirEmpty(t)
+	defer restore()
+	on := true
+	caps := Capabilities{Hooks: &on, Observer: &on}
+	agent := applyOpts(caps, mockModel{})
+	if agent.Hooks == nil {
+		t.Error("Hooks should be attached when OnHooks=true")
+	}
+	if agent.Observer == nil {
+		t.Error("Observer should be attached when OnObserver=true")
+	}
+	// Guard/skills still off.
+	if agent.InGuard != nil || agent.SkillLoader != nil {
+		t.Error("Guard/Skills should remain nil")
+	}
+}
+
+func TestBuildOpts_Guard_RequiresModel(t *testing.T) {
+	restore := chdirEmpty(t)
+	defer restore()
+	on := true
+	// OnGuard=true but model is nil → guard must be skipped (no judge model).
+	agent := applyOpts(Capabilities{Guard: &on}, nil)
+	if agent.InGuard != nil {
+		t.Error("InGuard should be nil when model is nil (no judge)")
+	}
+	if agent.OutGuard != nil {
+		t.Error("OutGuard should be nil when model is nil (no judge)")
+	}
+}
+
+func TestBuildOpts_Guard_WithModel(t *testing.T) {
+	restore := chdirEmpty(t)
+	defer restore()
+	on := true
+	agent := applyOpts(Capabilities{Guard: &on}, mockModel{})
+	if agent.InGuard == nil {
+		t.Error("InGuard should be attached when OnGuard=true and model!=nil")
+	}
+	if agent.OutGuard == nil {
+		t.Error("OutGuard should be attached when OnGuard=true and model!=nil")
+	}
+}
+
+func TestBuildOpts_Skills_NoDir(t *testing.T) {
+	restore := chdirEmpty(t)
+	defer restore()
+	on := true
+	// OnSkills=true but no .openagent/skills dir → loader stays nil.
+	agent := applyOpts(Capabilities{Skills: &on}, mockModel{})
+	if agent.SkillLoader != nil {
+		t.Error("SkillLoader should be nil when no skills dir exists")
+	}
+}
+
+func TestBuildOpts_Skills_WithDir(t *testing.T) {
+	restore := chdirWithSkills(t)
+	defer restore()
+	on := true
+	agent := applyOpts(Capabilities{Skills: &on}, mockModel{})
+	if agent.SkillLoader == nil {
+		t.Error("SkillLoader should be attached when skills dir exists and OnSkills=true")
+	}
+}
+
+func TestBuildOpts_AllOn(t *testing.T) {
+	restore := chdirWithSkills(t)
+	defer restore()
+	on := true
+	caps := Capabilities{Skills: &on, Guard: &on, Hooks: &on, Observer: &on}
+	agent := applyOpts(caps, mockModel{})
+	if agent.SkillLoader == nil {
+		t.Error("SkillLoader should be attached")
+	}
+	if agent.InGuard == nil || agent.OutGuard == nil {
+		t.Error("Guard should be attached")
+	}
+	if agent.Hooks == nil {
+		t.Error("Hooks should be attached")
+	}
+	if agent.Observer == nil {
+		t.Error("Observer should be attached")
+	}
+}
+
+// TestBuildOpts_PreservesBaseOpts verifies buildOpts appends to (not
+// replaces) the supplied option slice — callers rely on this to keep
+// their base options (model, memory, tools, prompts, maxTurns).
+func TestBuildOpts_PreservesBaseOpts(t *testing.T) {
+	restore := chdirEmpty(t)
+	defer restore()
+	on := true
+	base := []openagent.AgentOption{
+		openagent.WithMaxTurns(42),
+		openagent.WithSystemPrompts("hello"),
+	}
+	opts := buildOpts(base, Capabilities{Hooks: &on}, mockModel{})
+	agent := openagent.NewAgent("t", opts...)
+	if agent.MaxTurns != 42 {
+		t.Errorf("MaxTurns = %d, want 42 (base option must survive)", agent.MaxTurns)
+	}
+	if len(agent.SystemPrompts) != 1 || agent.SystemPrompts[0] != "hello" {
+		t.Errorf("SystemPrompts = %v, want [hello]", agent.SystemPrompts)
+	}
+	if agent.Hooks == nil {
+		t.Error("Hooks should be appended by buildOpts")
+	}
+}

--- a/cmd/cli/server/capabilities.go
+++ b/cmd/cli/server/capabilities.go
@@ -1,0 +1,49 @@
+package server
+
+// Capabilities controls which pluggable modules are enabled at startup.
+// Zero value means "use defaults" (some on, some off).
+type Capabilities struct {
+	Memory     *bool // default on
+	Summarizer *bool // default on
+	Tools      *bool // default on
+	Skills     *bool // default on
+	MCP        *bool // default on
+	Guard      *bool // default off
+	Approver   *bool // default off
+	Hooks      *bool // default off
+	Observer   *bool // default off
+}
+
+func (c Capabilities) on(field *bool, defaultOn bool) bool {
+	if field != nil {
+		return *field
+	}
+	return defaultOn
+}
+
+// OnMemory reports whether Memory is enabled.
+func (c Capabilities) OnMemory() bool { return c.on(c.Memory, true) }
+
+// OnSummarizer reports whether Summarizer is enabled.
+func (c Capabilities) OnSummarizer() bool { return c.on(c.Summarizer, true) }
+
+// OnTools reports whether built-in Tools (shell, read, write, ls, grep) are enabled.
+func (c Capabilities) OnTools() bool { return c.on(c.Tools, true) }
+
+// OnSkills reports whether SkillLoader is enabled.
+func (c Capabilities) OnSkills() bool { return c.on(c.Skills, true) }
+
+// OnMCP reports whether MCP tools are enabled.
+func (c Capabilities) OnMCP() bool { return c.on(c.MCP, true) }
+
+// OnGuard reports whether LLM Guard is enabled.
+func (c Capabilities) OnGuard() bool { return c.on(c.Guard, false) }
+
+// OnApprover reports whether Approver is enabled.
+func (c Capabilities) OnApprover() bool { return c.on(c.Approver, false) }
+
+// OnHooks reports whether RunHooks are enabled.
+func (c Capabilities) OnHooks() bool { return c.on(c.Hooks, false) }
+
+// OnObserver reports whether RunObserver is enabled.
+func (c Capabilities) OnObserver() bool { return c.on(c.Observer, false) }

--- a/cmd/cli/server/capabilities_test.go
+++ b/cmd/cli/server/capabilities_test.go
@@ -1,0 +1,199 @@
+package server
+
+import (
+	"testing"
+)
+
+func TestCapabilitiesDefaults(t *testing.T) {
+	caps := Capabilities{}
+	// Default on
+	if !caps.OnMemory() {
+		t.Error("Memory should default on")
+	}
+	if !caps.OnSummarizer() {
+		t.Error("Summarizer should default on")
+	}
+	if !caps.OnTools() {
+		t.Error("Tools should default on")
+	}
+	if !caps.OnSkills() {
+		t.Error("Skills should default on")
+	}
+	if !caps.OnMCP() {
+		t.Error("MCP should default on")
+	}
+	// Default off
+	if caps.OnGuard() {
+		t.Error("Guard should default off")
+	}
+	if caps.OnApprover() {
+		t.Error("Approver should default off")
+	}
+	if caps.OnHooks() {
+		t.Error("Hooks should default off")
+	}
+	if caps.OnObserver() {
+		t.Error("Observer should default off")
+	}
+}
+
+func TestCapabilitiesExplicit(t *testing.T) {
+	on := true
+	off := false
+	caps := Capabilities{
+		Memory:     &off,
+		Summarizer: &off,
+		Tools:      &off,
+		Skills:     &off,
+		MCP:        &off,
+		Guard:      &on,
+		Approver:   &on,
+		Hooks:      &on,
+		Observer:   &on,
+	}
+	if caps.OnMemory() {
+		t.Error("Memory explicitly off")
+	}
+	if caps.OnSummarizer() {
+		t.Error("Summarizer explicitly off")
+	}
+	if caps.OnTools() {
+		t.Error("Tools explicitly off")
+	}
+	if caps.OnSkills() {
+		t.Error("Skills explicitly off")
+	}
+	if caps.OnMCP() {
+		t.Error("MCP explicitly off")
+	}
+	if !caps.OnGuard() {
+		t.Error("Guard explicitly on")
+	}
+	if !caps.OnApprover() {
+		t.Error("Approver explicitly on")
+	}
+	if !caps.OnHooks() {
+		t.Error("Hooks explicitly on")
+	}
+	if !caps.OnObserver() {
+		t.Error("Observer explicitly on")
+	}
+}
+
+func TestCapabilitiesMixed(t *testing.T) {
+	off := false
+	caps := Capabilities{
+		Memory: &off,
+		// Guard, Skills, Hooks nil — use defaults
+	}
+	if caps.OnMemory() {
+		t.Error("Memory overridden to off")
+	}
+	if !caps.OnSkills() {
+		t.Error("Skills nil → should default on")
+	}
+	if caps.OnGuard() {
+		t.Error("Guard nil → should default off")
+	}
+	if caps.OnHooks() {
+		t.Error("Hooks nil → should default off")
+	}
+	if !caps.OnMCP() {
+		t.Error("MCP nil → should default on")
+	}
+}
+
+func TestCapabilitiesAllOff(t *testing.T) {
+	off := false
+	caps := Capabilities{
+		Memory: &off, Summarizer: &off, Tools: &off,
+		Skills: &off, MCP: &off, Guard: &off,
+		Approver: &off, Hooks: &off, Observer: &off,
+	}
+	if caps.OnMemory() || caps.OnSummarizer() || caps.OnTools() ||
+		caps.OnSkills() || caps.OnMCP() || caps.OnGuard() ||
+		caps.OnApprover() || caps.OnHooks() || caps.OnObserver() {
+		t.Error("All capabilities should be off")
+	}
+}
+
+func TestCapabilitiesAllOn(t *testing.T) {
+	on := true
+	caps := Capabilities{
+		Memory: &on, Summarizer: &on, Tools: &on,
+		Skills: &on, MCP: &on, Guard: &on,
+		Approver: &on, Hooks: &on, Observer: &on,
+	}
+	if !caps.OnMemory() || !caps.OnSummarizer() || !caps.OnTools() ||
+		!caps.OnSkills() || !caps.OnMCP() || !caps.OnGuard() ||
+		!caps.OnApprover() || !caps.OnHooks() || !caps.OnObserver() {
+		t.Error("All capabilities should be on")
+	}
+}
+
+func TestCapabilities_OnMethod_Table(t *testing.T) {
+	tests := []struct {
+		name     string
+		on       func(Capabilities) bool
+		field    **bool // pointer to the Capabilities field
+		defaultV bool
+	}{
+		{"Memory", Capabilities.OnMemory, nil, true},
+		{"Summarizer", Capabilities.OnSummarizer, nil, true},
+		{"Tools", Capabilities.OnTools, nil, true},
+		{"Skills", Capabilities.OnSkills, nil, true},
+		{"MCP", Capabilities.OnMCP, nil, true},
+		{"Guard", Capabilities.OnGuard, nil, false},
+		{"Approver", Capabilities.OnApprover, nil, false},
+		{"Hooks", Capabilities.OnHooks, nil, false},
+		{"Observer", Capabilities.OnObserver, nil, false},
+	}
+
+	for _, tt := range tests {
+		// nil field → default
+		caps := Capabilities{}
+		if got := tt.on(caps); got != tt.defaultV {
+			t.Errorf("%s nil → %v, want default %v", tt.name, got, tt.defaultV)
+		}
+
+		// explicit true
+		tru := true
+		caps = capsWith(tt.name, &tru)
+		if got := tt.on(caps); !got {
+			t.Errorf("%s = true → %v, want true", tt.name, got)
+		}
+
+		// explicit false
+		fals := false
+		caps = capsWith(tt.name, &fals)
+		if got := tt.on(caps); got {
+			t.Errorf("%s = false → %v, want false", tt.name, got)
+		}
+	}
+}
+
+// capsWith returns a Capabilities with only the named field set to val.
+func capsWith(name string, val *bool) Capabilities {
+	c := Capabilities{}
+	switch name {
+	case "Memory":
+		c.Memory = val
+	case "Summarizer":
+		c.Summarizer = val
+	case "Tools":
+		c.Tools = val
+	case "Skills":
+		c.Skills = val
+	case "MCP":
+		c.MCP = val
+	case "Guard":
+		c.Guard = val
+	case "Approver":
+		c.Approver = val
+	case "Hooks":
+		c.Hooks = val
+	case "Observer":
+		c.Observer = val
+	}
+	return c
+}

--- a/cmd/cli/server/http.go
+++ b/cmd/cli/server/http.go
@@ -21,7 +21,7 @@ import (
 // ── REST server ──
 
 // RunREST starts the REST API server (HTTP + SSE).
-func RunREST(ctx context.Context, cfg *config.Config) error {
+func RunREST(ctx context.Context, cfg *config.Config, caps Capabilities) error {
 	models, modelInfos := buildModels(cfg.Provider)
 	m := firstModel(models)
 
@@ -34,10 +34,12 @@ func RunREST(ctx context.Context, cfg *config.Config) error {
 		log.Printf("WARNING: sandbox unavailable, tools disabled: %v", err)
 	}
 
-	// MCP tools from config.
-	mcpTools, mcpCleanup := connectMcpFromConfig(ctx, cfg.McpServers)
-	tools = append(tools, mcpTools...)
-	defer mcpCleanup()
+	// MCP tools from config. Gated by --mcp (default on, --mcp=off disables).
+	if caps.OnMCP() {
+		mcpTools, mcpCleanup := connectMcpFromConfig(ctx, cfg.McpServers)
+		tools = append(tools, mcpTools...)
+		defer mcpCleanup()
+	}
 
 	cfgPath, _ := config.Path()
 	dataDir := filepath.Join(filepath.Dir(cfgPath), "data")
@@ -46,24 +48,31 @@ func RunREST(ctx context.Context, cfg *config.Config) error {
 		return err
 	}
 	defer cleanup()
-	if m != nil {
+	if caps.OnSummarizer() && m != nil {
 		mem.WithSummarizer(summarizer.New(m))
 	}
 
-	agent := openagent.NewAgent("openagent",
+	opts := []openagent.AgentOption{
 		openagent.WithModel(m),
-		openagent.WithMemory(mem),
 		openagent.WithSystemPrompts(resolveProfiles(cfg.Profiles)...),
-		openagent.WithTools(tools...),
 		openagent.WithMaxTurns(100),
-	)
+	}
+	if caps.OnMemory() {
+		opts = append(opts, openagent.WithMemory(mem))
+	}
+	if caps.OnTools() {
+		opts = append(opts, openagent.WithTools(tools...))
+	}
+	opts = buildOpts(opts, caps, m)
+	agent := openagent.NewAgent("openagent", opts...)
 
 	handler := rest.NewHandler(agent).
 		WithSessionStore(store).
 		WithCleanupDir(func(sessionID string) {
 			dir := filepath.Join(opentool.ArtifactRoot(), sessionID)
 			_ = os.RemoveAll(dir)
-		})
+		}).
+		WithApproverEnabled(caps.OnApprover())
 	handler.StartJanitor(ctx, 1*time.Hour, 24*time.Hour)
 	for _, mi := range modelInfos {
 		handler.RegisterModel(mi.ID, mi.Model, mi.Provider)

--- a/cmd/cli/server/shared.go
+++ b/cmd/cli/server/shared.go
@@ -1,17 +1,22 @@
 package server
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 
 	openagent "github.com/yusheng-g/openagent-go"
+	"github.com/yusheng-g/openagent-go/guard/llm"
+	sloghooks "github.com/yusheng-g/openagent-go/hooks/slog"
 	"github.com/yusheng-g/openagent-go/memory/sqlite"
 	"github.com/yusheng-g/openagent-go/model/openai"
 	"github.com/yusheng-g/openagent-go/sandbox/native"
 	"github.com/yusheng-g/openagent-go/session"
 	sessionsqlite "github.com/yusheng-g/openagent-go/session/sqlite"
+	"github.com/yusheng-g/openagent-go/skill/fs"
 	opentool "github.com/yusheng-g/openagent-go/tool"
 
 	"github.com/yusheng-g/openagent-go/cmd/cli/config"
@@ -175,4 +180,82 @@ func resolveProfileFile(profiles, filename, defaultText string) string {
 
 	// 3.  Built-in default
 	return defaultText
+}
+
+// ── Optional capability builders ──
+
+// openSkillLoader creates a file-system skill loader. Directories are tried
+// in priority order:
+//  1. <workspace>/.openagent/skills  (project-level)
+//  2. ~/.openagent/skills            (user-level)
+//
+// Returns nil if no directory exists.
+func openSkillLoader() openagent.SkillLoader {
+	for _, dir := range skillDirs() {
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			return fs.New(dir)
+		}
+	}
+	return nil
+}
+
+func skillDirs() []string {
+	var dirs []string
+	if cwd, err := os.Getwd(); err == nil {
+		dirs = append(dirs, filepath.Join(cwd, ".openagent", "skills"))
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, filepath.Join(home, ".openagent", "skills"))
+	}
+	return dirs
+}
+
+// buildGuard creates an LLM guard using the given model as judge.
+func buildGuard(model openagent.Model) *llm.Guard {
+	return llm.New(model)
+}
+
+// buildSlogHooks creates slog-based RunHooks logging to stderr.
+func buildSlogHooks() openagent.RunHooks {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	return sloghooks.New(logger)
+}
+
+// slogObserver logs stage events to a dedicated stderr logger.
+type slogObserver struct {
+	logger *slog.Logger
+}
+
+func (o slogObserver) ObserveStage(_ context.Context, event openagent.StageEvent) {
+	o.logger.Info("stage", "name", event.Name, "phase", event.Phase, "duration", event.Duration)
+}
+
+// buildSlogObserver creates a minimal stderr stage observer.
+func buildSlogObserver() openagent.RunObserver {
+	return slogObserver{
+		logger: slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})),
+	}
+}
+
+// buildOpts appends capability-gated agent options (skills, guard, hooks,
+// observer) to opts. model is used by the guard; it may be nil if no models
+// are configured, in which case the guard is skipped regardless of caps.
+func buildOpts(opts []openagent.AgentOption, caps Capabilities, model openagent.Model) []openagent.AgentOption {
+	if caps.OnSkills() {
+		if sl := openSkillLoader(); sl != nil {
+			opts = append(opts, openagent.WithSkillLoader(sl))
+		}
+	}
+	if caps.OnGuard() && model != nil {
+		g := buildGuard(model)
+		opts = append(opts, openagent.WithInputGuard(g))
+		opts = append(opts, openagent.WithOutputGuard(g.Output()))
+	}
+	if caps.OnHooks() {
+		opts = append(opts, openagent.WithRunHooks(buildSlogHooks()))
+	}
+	if caps.OnObserver() {
+		opts = append(opts, openagent.WithRunObserver(buildSlogObserver()))
+	}
+	return opts
 }

--- a/cmd/cli/server/shared_test.go
+++ b/cmd/cli/server/shared_test.go
@@ -1,0 +1,105 @@
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	openagent "github.com/yusheng-g/openagent-go"
+)
+
+func TestSkillDirs_Priority(t *testing.T) {
+	dirs := skillDirs()
+	if len(dirs) < 1 {
+		t.Fatal("skillDirs returned empty list")
+	}
+	// First entry should be project-level (cwd-based).
+	if !strings.Contains(dirs[0], ".openagent") || !strings.Contains(dirs[0], "skills") {
+		t.Errorf("unexpected project dir: %q", dirs[0])
+	}
+	// Second, if present, should be user-level (home-based).
+	if len(dirs) >= 2 {
+		if !strings.Contains(dirs[1], ".openagent") || !strings.Contains(dirs[1], "skills") {
+			t.Errorf("unexpected home dir: %q", dirs[1])
+		}
+	}
+}
+
+func TestOpenSkillLoader_NoDirs(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", "/nonexistent-path-for-test")
+	defer os.Setenv("HOME", origHome)
+
+	origWd, _ := os.Getwd()
+	tmp := t.TempDir()
+	os.Chdir(tmp)
+	defer os.Chdir(origWd)
+
+	sl := openSkillLoader()
+	if sl != nil {
+		t.Error("openSkillLoader should return nil when no .openagent/skills exists")
+	}
+}
+
+func TestOpenSkillLoader_FindsDir(t *testing.T) {
+	origWd, _ := os.Getwd()
+	tmp := t.TempDir()
+	os.Chdir(tmp)
+	defer os.Chdir(origWd)
+
+	skillsDir := filepath.Join(tmp, ".openagent", "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	sl := openSkillLoader()
+	if sl == nil {
+		t.Fatal("openSkillLoader should find .openagent/skills directory")
+	}
+}
+
+func TestBuildGuard_NilModel(t *testing.T) {
+	// buildGuard with nil model: Guard holds a nil model, which will fail
+	// at Check time (not construction time). Verify no panic.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("buildGuard(nil) panicked: %v", r)
+		}
+	}()
+	g := buildGuard(nil)
+	if g == nil {
+		t.Fatal("buildGuard returned nil")
+	}
+	// Output should also be non-nil.
+	if o := g.Output(); o == nil {
+		t.Fatal("guard.Output() returned nil")
+	}
+}
+
+func TestBuildSlogHooks(t *testing.T) {
+	hooks := buildSlogHooks()
+	// sloghooks.New creates a valid hooks instance (may be wrapper around logger).
+	if hooks == nil {
+		t.Log("buildSlogHooks returned nil — verify if intentional")
+	}
+}
+
+func TestBuildSlogObserver(t *testing.T) {
+	obs := buildSlogObserver()
+	if obs == nil {
+		t.Fatal("buildSlogObserver returned nil")
+	}
+	// Calling ObserveStage should not panic.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("ObserveStage panicked: %v", r)
+		}
+	}()
+	obs.ObserveStage(context.Background(), openagent.StageEvent{
+		Name:     "test-stage",
+		Phase:    "start",
+		Duration: 0,
+	})
+}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -27,6 +27,7 @@ import (
 //	mux := http.NewServeMux()
 //	handler.Register(mux)
 //	http.ListenAndServe(":8080", mux)
+//
 // ModelInfo describes a registered model for the frontend.
 type ModelInfo struct {
 	ID       string `json:"id"`
@@ -39,26 +40,41 @@ type Handler struct {
 	modelList    []ModelInfo                // ordered list for /models endpoint
 	modelsMu     sync.RWMutex
 
-	tools        []openagent.Tool
+	tools         []openagent.Tool
 	systemPrompts []string
-	name         string
-	maxTurns     int
+	name          string
+	maxTurns      int
+
+	// Optional capabilities from the template Agent.
+	hooks       openagent.RunHooks
+	observer    openagent.RunObserver
+	inGuard     openagent.InputGuard
+	outGuard    openagent.OutputGuard
+	skillLoader openagent.SkillLoader
+
+	// approverEnabled gates the per-session WithApprover. Default true (enabled)
+	// for backward compatibility; set false via --approver=off.
+	approverEnabled bool
 
 	sm *sessionManager[*sessionState] // session CRUD, store, bus
 }
 
 // NewHandler creates a Handler from a configured Agent.
-// The agent's Model, Memory, Tools, Instructions, Name, and MaxTurns
-// are captured as the template for per-session Agent instances.
 func NewHandler(agent *openagent.Agent) *Handler {
 	h := &Handler{
-		defaultModel: agent.Model,
-		models:       make(map[string]openagent.Model),
-		modelList:    nil,
-		tools:        agent.Tools,
-		systemPrompts: agent.SystemPrompts,
-		name:         agent.Name,
-		maxTurns:     agent.MaxTurns,
+		defaultModel:    agent.Model,
+		models:          make(map[string]openagent.Model),
+		modelList:       nil,
+		tools:           agent.Tools,
+		systemPrompts:   agent.SystemPrompts,
+		name:            agent.Name,
+		maxTurns:        agent.MaxTurns,
+		hooks:           agent.Hooks,
+		approverEnabled: true,
+		observer:        agent.Observer,
+		inGuard:         agent.InGuard,
+		outGuard:        agent.OutGuard,
+		skillLoader:     agent.SkillLoader,
 	}
 
 	bus := eventbus.New[SSEEvent](500)
@@ -145,17 +161,25 @@ func (h *Handler) WithCleanupDir(fn func(sessionID string)) *Handler {
 	return h
 }
 
+// WithApproverEnabled controls whether the human-in-the-loop approver is
+// active for per-session agents. Default is true (enabled). Set false to
+// auto-approve all tool calls without prompting.
+func (h *Handler) WithApproverEnabled(v bool) *Handler {
+	h.approverEnabled = v
+	return h
+}
+
 // ── sessionState ──
 
 // sessionState holds the per-session runtime state.
 // Events are published to the Handler-level bus via sm so that multiple
 // SSE connections (e.g. browser tabs) all receive the full stream.
 type sessionState struct {
-	info       session.SessionInfo // ModelID is the session's model preference; empty → handler default
-	agent      *openagent.Agent
+	info  session.SessionInfo // ModelID is the session's model preference; empty → handler default
+	agent *openagent.Agent
 
 	mu              sync.Mutex
-	running         bool             // true while agent goroutine is active
+	running         bool // true while agent goroutine is active
 	pendingApproval *pendingApproval
 }
 
@@ -365,19 +389,43 @@ func (h *Handler) handleListModels(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) newEntry(info session.SessionInfo) *sessionState {
 	s := &sessionState{info: info}
 
-	s.agent = openagent.NewAgent(h.name,
+	opts := []openagent.AgentOption{
 		openagent.WithModel(h.defaultModel),
 		openagent.WithMemory(h.sm.Memory()),
 		openagent.WithTools(h.tools...),
 		openagent.WithSystemPrompts(h.systemPrompts...),
 		openagent.WithMaxTurns(h.maxTurns),
-		openagent.WithRunObserver(&stageObserver{bus: h.sm.Bus(), sid: info.ID}),
-		openagent.WithApprover(&restApprover{
+	}
+	if h.approverEnabled {
+		opts = append(opts, openagent.WithApprover(&restApprover{
 			submit: func(call openagent.ToolCall, resp chan approveResponse) {
 				h.submitApproval(s, call, resp)
 			},
-		}),
-	)
+		}))
+	}
+	// Combine user observer with the stage observer (for SSE events).
+	if h.observer != nil {
+		opts = append(opts, openagent.WithRunObservers(
+			&stageObserver{bus: h.sm.Bus(), sid: info.ID},
+			h.observer,
+		))
+	} else {
+		opts = append(opts, openagent.WithRunObserver(&stageObserver{bus: h.sm.Bus(), sid: info.ID}))
+	}
+	if h.hooks != nil {
+		opts = append(opts, openagent.WithRunHooks(h.hooks))
+	}
+	if h.inGuard != nil {
+		opts = append(opts, openagent.WithInputGuard(h.inGuard))
+	}
+	if h.outGuard != nil {
+		opts = append(opts, openagent.WithOutputGuard(h.outGuard))
+	}
+	if h.skillLoader != nil {
+		opts = append(opts, openagent.WithSkillLoader(h.skillLoader))
+	}
+
+	s.agent = openagent.NewAgent(h.name, opts...)
 
 	return s
 }


### PR DESCRIPTION
- Add Capabilities type with *bool tri-state fields (nil=default) and OnXxx() accessor methods
- 9 CLI flags: --memory --summarizer --tools --skills --mcp --guard --approver --hooks --observer, each accepting "on"/"off" (case-insensitive; invalid values warn and fall back to default)
- Defaults: memory/summarizer/tools/skills/mcp on (core features), guard/approver/hooks/observer off (optional add-ons)
- Wire all 9 flags so --X=off actually disables the feature in BOTH ACP and REST:
  * REST: --memory/--summarizer/--tools/--mcp gated in RunREST; --approver via Handler.WithApproverEnabled
  * ACP: --tools gates srv.ToolFactory; --mcp via new AgentServer. MCPEnabled field (default true, checked in connectMCP); --memory passes nil Mem to NewAgentServer so history replay/cleanup skip (all s.Mem uses are nil-guarded)
- Extract shared buildOpts() to de-duplicate the skills/guard/hooks/ observer wiring between ACP and REST paths
- Use flag.Changed() for proper tri-state: unset flags leave the Capabilities field nil so the OnXxx() default applies
- Use a single Guard instance for input+output guard (matching the llm.Guard documented pattern) instead of two independent instances
- fix(rest): propagate hooks/guard/observer/skillLoader/approverEnabled from template Agent to per-session agents in Handler.newEntry
- slogObserver uses a dedicated stderr logger (was global slog.Info)
- Skills auto-loaded from .openagent/skills/ (project-level, then user-level fallback)
- Tests (28 capability tests):
  * Capabilities state matrix (7) — defaults, explicit, mixed, table
  * parseCapabilities via cobra flags (5) — defaults, on/off, invalid, partial, case-insensitive
  * buildOpts end-to-end (8) — applies opts to a real Agent and inspects Hooks/Observer/InGuard/OutGuard/SkillLoader fields
  * MCP gate (2) — MCPEnabled default + deterministic side-effect proof that false blocks connection, true allows it
  * shared builders (6) — skillDirs/openSkillLoader/buildGuard/ buildSlogHooks/buildSlogObserver