### PR TITLE
fix(rest/team): wire model selection, ContextWindow, and stale ModelID

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -71,13 +71,16 @@ Fix:
 
 ---
 
-### [P2] Team: no model selection, no ContextWindow, stale ModelID
+### [P2] ~~Team: no model selection, no ContextWindow, stale ModelID~~ ✅ FIXED
 
-[rest/team.go](rest/team.go):
+[rest/team.go](rest/team.go): **Fixed in this commit** — `TeamHandler` now carries a model registry (`models`/`modelList`/`modelsMu`) mirroring `Handler`, with `RegisterModel`/`lookupModel`. `handleChat` resolves the model from `ChatRequest.ModelID`/`Provider` (falling back to stored session meta, then the first-template model), persists `modelId`/`provider` to session meta via `withMeta`+`syncMeta`, and sets `Model`/`ModelID` on the `openagent.Session` handed to `team.RunStream`. Because `runner.go:68-70` does `r.runModel = session.Model if non-nil`, the selected model overrides every team agent's model for that run. `NewTeamHandler` wires a `fillDetail` hook that resolves the session's effective model (stored meta > handler default) and sets `detail.ContextWindow`, so `GET /team/sessions/{id}` returns a non-zero `contextWindow` and the current (non-stale) `modelId`.
 
-1. `handleChat` ignores `ChatRequest.ModelID` — `oaSession` constructed without `Model` or `ModelID`. Frontend model selector has no effect in team mode.
-2. `s.info.ModelID` never synced to team handler. `GET /team/sessions/{id}` returns creation-time `ModelID` forever.
-3. `handleGetSession` missing `ContextWindow` — Frontend shows `contextWindow: 0` for team sessions.
+Original issue:
+1. `handleChat` ignored `ChatRequest.ModelID` — `oaSession` constructed without `Model` or `ModelID`. Frontend model selector had no effect in team mode.
+2. `s.info.ModelID` never synced to team handler. `GET /team/sessions/{id}` returned creation-time `ModelID` forever.
+3. `handleGetSession` missing `ContextWindow` — Frontend showed `contextWindow: 0` for team sessions.
+
+Tests: `rest/team_model_test.go` — `TestTeamHandleChatModelOverride` (model-b is invoked when selected) and `TestTeamGetSessionContextWindow` (`contextWindow == 16000` and `_meta.modelId == "model-b"` after a model-b chat).
 
 ---
 

--- a/examples/backend/main.go
+++ b/examples/backend/main.go
@@ -108,7 +108,7 @@ func main() {
 			{"deepseek-v4-pro", "deepseek"},
 		}
 		for _, o := range opts {
-			handler.RegisterModel(o.id, openai.New(apiKey, o.id, baseURL), o.label)
+			handler.RegisterModel(o.id, openai.New(apiKey, o.id, baseURL).WithContextWindow(128_000), o.label)
 		}
 	}
 
@@ -147,6 +147,20 @@ func main() {
 		rest.TeamAgentTemplate{Name: "coder", Description: "Writes clean, well-structured code with error handling", Agent: coder},
 		rest.TeamAgentTemplate{Name: "reviewer", Description: "Reviews code for correctness, style, and security", Agent: reviewer},
 	).WithSessionStore(sessionStore)
+	// Register the same models on the team handler so the frontend model
+	// selector works in team mode too. The frontend fetches the list via
+	// GET /models (served by the single handler) and sends the chosen
+	// modelId/provider on POST /team/sessions/{id}/chat; teamHandler's
+	// registry must contain the same entries for lookupModel to resolve.
+	if apiKey != "" && baseURL != "" {
+		opts := []struct{ id, label string }{
+			{"deepseek-v4-flash", "deepseek"},
+			{"deepseek-v4-pro", "deepseek"},
+		}
+		for _, o := range opts {
+			teamHandler.RegisterModel(o.id, openai.New(apiKey, o.id, baseURL).WithContextWindow(128_000), o.label)
+		}
+	}
 
 	// ── Plan agents ──
 	planResearcher := openagent.NewAgent("researcher",

--- a/rest/team.go
+++ b/rest/team.go
@@ -6,12 +6,13 @@ import (
 	"log"
 	"net/http"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
 	openagent "github.com/yusheng-g/openagent-go"
-	"github.com/yusheng-g/openagent-go/session"
 	"github.com/yusheng-g/openagent-go/eventbus"
+	"github.com/yusheng-g/openagent-go/session"
 )
 
 // ── TeamHandler ──
@@ -19,7 +20,14 @@ import (
 // TeamHandler serves a REST API for an openagent-go Team.
 type TeamHandler struct {
 	agents []TeamAgentTemplate
-	model  openagent.Model // from first template, for dynamically added agents
+	model  openagent.Model // from first template, for dynamically added agents and as fallback
+
+	// Model registry, mirroring Handler. Frontend model selection in team mode
+	// resolves through this; the chosen model overrides every team agent's
+	// model for that run via openagent.Session.Model (runner.go:68-70).
+	models    map[string]openagent.Model // "provider:id" → model instance
+	modelList []ModelInfo                // ordered list for /models endpoint
+	modelsMu  sync.RWMutex
 
 	sm *sessionManager[*teamSessionState] // session CRUD, store, bus
 }
@@ -47,12 +55,13 @@ func NewTeamHandler(mem openagent.Memory, agents ...TeamAgentTemplate) *TeamHand
 		log.Printf("team: primary agent has nil Model — dynamically added agents will have no model")
 	}
 
-	h := &TeamHandler{agents: agents, model: model}
+	h := &TeamHandler{agents: agents, model: model, models: make(map[string]openagent.Model)}
 
 	bus := eventbus.New[SSEEvent](500)
 	h.sm = newSessionManager[*teamSessionState](nil, mem, bus, sessionHooks[*teamSessionState]{
-		kind:     "team",
-		newEntry: h.newEntry,
+		kind:       "team",
+		newEntry:   h.newEntry,
+		fillDetail: h.fillDetail,
 		onDelete: func(s *teamSessionState) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
@@ -63,6 +72,36 @@ func NewTeamHandler(mem openagent.Memory, agents ...TeamAgentTemplate) *TeamHand
 	})
 
 	return h
+}
+
+// RegisterModel adds a model to the team handler's registry, enabling
+// frontend model selection in team mode. Mirrors Handler.RegisterModel.
+// The chosen model overrides every team agent's model for that run.
+func (h *TeamHandler) RegisterModel(id string, model openagent.Model, provider string) {
+	h.modelsMu.Lock()
+	defer h.modelsMu.Unlock()
+	h.models[provider+":"+id] = model
+	h.modelList = append(h.modelList, ModelInfo{ID: id, Provider: provider})
+}
+
+// lookupModel finds a registered model. Mirrors Handler.lookupModel.
+// When provider is non-empty, uses the exact composite key "provider:modelId";
+// otherwise scans for the first registered model matching modelId.
+func (h *TeamHandler) lookupModel(provider, modelID string) openagent.Model {
+	h.modelsMu.RLock()
+	defer h.modelsMu.RUnlock()
+	if provider != "" {
+		return h.models[provider+":"+modelID]
+	}
+	for key, m := range h.models {
+		if key == "default" {
+			continue
+		}
+		if strings.HasSuffix(key, ":"+modelID) {
+			return m
+		}
+	}
+	return nil
 }
 
 // Register adds the team handler's routes to mux.
@@ -100,13 +139,13 @@ func (h *TeamHandler) WithCleanupDir(fn func(sessionID string)) *TeamHandler {
 // ── teamSessionState ──
 
 type teamSessionState struct {
-	info       session.SessionInfo
-	team       *openagent.Team
-	agentList  []agentInfo
-	agentMems  []*teamAgentMemory // per-agent memory wrappers for cleanup
+	info      session.SessionInfo
+	team      *openagent.Team
+	agentList []agentInfo
+	agentMems []*teamAgentMemory // per-agent memory wrappers for cleanup
 
 	mu              sync.Mutex
-	running         bool             // true while agent goroutine is active
+	running         bool // true while agent goroutine is active
 	pendingApproval *pendingApproval
 }
 
@@ -218,6 +257,33 @@ func (h *TeamHandler) handleChat(w http.ResponseWriter, r *http.Request) {
 	sub := h.sm.Bus().SubscribeLive(id)
 	defer h.sm.Bus().Unsubscribe(id, sub)
 
+	// Resolve model: chat-level override > session default > handler default.
+	// Mirrors Handler.handleChat (handler.go:268-292). The chosen model is
+	// set on openagent.Session and overrides every team agent's model for
+	// this run (runner.go:68-70: r.runModel = session.Model if non-nil).
+	provider := body.Provider
+	modelID := body.ModelID
+	if provider == "" && modelID == "" {
+		h.sm.withMeta(id, func(inf *session.SessionInfo) {
+			p, _ := session.GetMeta[string](*inf, "provider")
+			m, _ := session.GetMeta[string](*inf, "modelId")
+			provider = p
+			modelID = m
+		})
+	}
+	model := h.lookupModel(provider, modelID)
+	if model == nil {
+		model = h.model
+	}
+
+	// Persist the resolved model so GET /team/sessions/{id} reflects it.
+	if inf, ok := h.sm.withMeta(id, func(inf *session.SessionInfo) {
+		inf.SetMeta("modelId", modelID)
+		inf.SetMeta("provider", provider)
+	}); ok {
+		h.sm.syncMeta(inf)
+	}
+
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
@@ -230,6 +296,8 @@ func (h *TeamHandler) handleChat(w http.ResponseWriter, r *http.Request) {
 
 		oaSession := openagent.Session{
 			ID:        id,
+			ModelID:   modelID,
+			Model:     model,
 			CreatedAt: s.info.CreatedAt,
 		}
 
@@ -439,6 +507,21 @@ func (h *TeamHandler) newEntry(info session.SessionInfo) *teamSessionState {
 
 	s.team = openagent.NewTeam(teamOpts...)
 	return s
+}
+
+// fillDetail enriches the SessionDetail with the team session's ContextWindow,
+// derived from the effective model (stored meta override > handler default).
+// Mirrors Handler.fillDetail (handler.go:92-96).
+func (h *TeamHandler) fillDetail(e *teamSessionState, detail *SessionDetail) {
+	provider, _ := session.GetMeta[string](e.info, "provider")
+	modelID, _ := session.GetMeta[string](e.info, "modelId")
+	m := h.lookupModel(provider, modelID)
+	if m == nil {
+		m = h.model
+	}
+	if m != nil {
+		detail.ContextWindow = m.ContextWindow()
+	}
 }
 
 func cloneAgentForSession(tmpl *openagent.Agent, mem openagent.Memory, s *teamSessionState, submitFn func(*teamSessionState, openagent.ToolCall, chan approveResponse)) *openagent.Agent {

--- a/rest/team_model_test.go
+++ b/rest/team_model_test.go
@@ -1,0 +1,279 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	openagent "github.com/yusheng-g/openagent-go"
+)
+
+// stubModel is a minimal openagent.Model with a configurable ContextWindow
+// and a recorded modelID, used to verify which model a team run uses.
+type stubModel struct {
+	name    string
+	cw      int
+	called  int
+	lastReq openagent.ChatCompletionRequest
+}
+
+func (m *stubModel) ChatCompletion(ctx context.Context, req openagent.ChatCompletionRequest) (*openagent.ChatCompletionResponse, error) {
+	m.called++
+	m.lastReq = req
+	return &openagent.ChatCompletionResponse{
+		Choices: []openagent.Choice{{
+			Message:      openagent.Message{Role: openagent.RoleAssistant, Content: "ok"},
+			FinishReason: "stop",
+		}},
+	}, nil
+}
+
+func (m *stubModel) ChatCompletionStream(ctx context.Context, req openagent.ChatCompletionRequest) (openagent.StreamReader, error) {
+	m.called++
+	m.lastReq = req
+	return nil, nil
+}
+
+func (m *stubModel) ContextWindow() int { return m.cw }
+
+// newTeamTestHandler builds a TeamHandler with one template agent on modelA
+// and registers modelA + modelB in the registry.
+func newTeamTestHandler(t *testing.T, modelA, modelB *stubModel) *TeamHandler {
+	t.Helper()
+	agent := openagent.NewAgent("solo",
+		openagent.WithModel(modelA),
+		openagent.WithSystemPrompts("test"),
+		openagent.WithMaxTurns(1),
+	)
+	h := NewTeamHandler(nil, TeamAgentTemplate{Name: "solo", Description: "d", Agent: agent})
+	h.RegisterModel("model-a", modelA, "p")
+	h.RegisterModel("model-b", modelB, "p")
+	return h
+}
+
+// readSSEDone reads SSE events until a "done" or "error" line is seen.
+func readSSEDone(body string) string {
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "data: ") {
+			return strings.TrimPrefix(line, "data: ")
+		}
+	}
+	return ""
+}
+
+// TestTeamHandleChatModelOverride verifies that ChatRequest.ModelID selects
+// the registered model and overrides the team agent's default for the run.
+func TestTeamHandleChatModelOverride(t *testing.T) {
+	modelA := &stubModel{name: "A", cw: 8000}
+	modelB := &stubModel{name: "B", cw: 16000}
+	h := newTeamTestHandler(t, modelA, modelB)
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Create a team session.
+	createResp, err := http.Post(srv.URL+"/team/sessions", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	defer createResp.Body.Close()
+	var info struct {
+		ID string `json:"sessionId"`
+	}
+	if err := json.NewDecoder(createResp.Body).Decode(&info); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	if info.ID == "" {
+		t.Fatal("no session id")
+	}
+
+	// Chat selecting model-b.
+	chatResp, err := http.Post(srv.URL+"/team/sessions/"+info.ID+"/chat",
+		"application/json",
+		strings.NewReader(`{"message":"hi","modelId":"model-b","provider":"p"}`))
+	if err != nil {
+		t.Fatalf("chat: %v", err)
+	}
+	defer chatResp.Body.Close()
+	if chatResp.StatusCode != http.StatusOK {
+		t.Fatalf("chat status %d", chatResp.StatusCode)
+	}
+	body, _ := io.ReadAll(chatResp.Body)
+	readSSEDone(string(body))
+
+	if modelB.called == 0 {
+		t.Error("model-b was not used for the run — frontend model selection has no effect")
+	}
+}
+
+// TestTeamGetSessionContextWindow verifies that GET /team/sessions/{id}
+// returns a non-zero ContextWindow derived from the session's model.
+func TestTeamGetSessionContextWindow(t *testing.T) {
+	modelA := &stubModel{name: "A", cw: 8000}
+	modelB := &stubModel{name: "B", cw: 16000}
+	h := newTeamTestHandler(t, modelA, modelB)
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Create + chat selecting model-b so meta is persisted.
+	createResp, err := http.Post(srv.URL+"/team/sessions", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	var info struct {
+		ID string `json:"sessionId"`
+	}
+	json.NewDecoder(createResp.Body).Decode(&info)
+	createResp.Body.Close()
+
+	chatResp, err := http.Post(srv.URL+"/team/sessions/"+info.ID+"/chat",
+		"application/json",
+		strings.NewReader(`{"message":"hi","modelId":"model-b","provider":"p"}`))
+	if err != nil {
+		t.Fatalf("chat: %v", err)
+	}
+	io.ReadAll(chatResp.Body)
+	chatResp.Body.Close()
+
+	// GET session detail.
+	getResp, err := http.Get(srv.URL + "/team/sessions/" + info.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer getResp.Body.Close()
+	var detail struct {
+		ContextWindow int            `json:"contextWindow"`
+		Meta          map[string]any `json:"_meta"`
+	}
+	if err := json.NewDecoder(getResp.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode detail: %v", err)
+	}
+	if detail.ContextWindow != 16000 {
+		t.Errorf("ContextWindow = %d, want 16000 (model-b's window)", detail.ContextWindow)
+	}
+	if got, _ := detail.Meta["modelId"].(string); got != "model-b" {
+		t.Errorf("meta modelId = %v, want model-b (stale ModelID bug)", detail.Meta["modelId"])
+	}
+}
+
+// TestTeamHandleChatUnknownModelFallback verifies that an unregistered modelId
+// falls back to h.model (the first template agent's model) rather than failing
+// or silently dropping the run. Covers the model == nil → h.model branch in
+// handleChat (team.go:274-277).
+func TestTeamHandleChatUnknownModelFallback(t *testing.T) {
+	modelA := &stubModel{name: "A", cw: 8000}
+	modelB := &stubModel{name: "B", cw: 16000}
+	h := newTeamTestHandler(t, modelA, modelB)
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	createResp, err := http.Post(srv.URL+"/team/sessions", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	var info struct {
+		ID string `json:"sessionId"`
+	}
+	json.NewDecoder(createResp.Body).Decode(&info)
+	createResp.Body.Close()
+
+	// Chat selecting a modelId that was never registered (with its provider).
+	chatResp, err := http.Post(srv.URL+"/team/sessions/"+info.ID+"/chat",
+		"application/json",
+		strings.NewReader(`{"message":"hi","modelId":"no-such-model","provider":"p"}`))
+	if err != nil {
+		t.Fatalf("chat: %v", err)
+	}
+	defer chatResp.Body.Close()
+	if chatResp.StatusCode != http.StatusOK {
+		t.Fatalf("chat status %d, want 200 (unknown model should fall back, not error)", chatResp.StatusCode)
+	}
+	body, _ := io.ReadAll(chatResp.Body)
+	readSSEDone(string(body))
+
+	// h.model is modelA (first template), so the fallback run must use modelA
+	// and must NOT touch modelB.
+	if modelA.called == 0 {
+		t.Error("modelA (h.model fallback) was not used for an unknown modelId")
+	}
+	if modelB.called != 0 {
+		t.Error("modelB was invoked during fallback — lookupModel leaked across registry entries")
+	}
+
+	// The run fell back to h.model, but meta still records the requested id.
+	// GET must report ContextWindow from the fallback model (modelA, 8000),
+	// proving fillDetail resolves the effective model, not the stale request id.
+	getResp, err := http.Get(srv.URL + "/team/sessions/" + info.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer getResp.Body.Close()
+	var detail struct {
+		ContextWindow int            `json:"contextWindow"`
+		Meta          map[string]any `json:"_meta"`
+	}
+	if err := json.NewDecoder(getResp.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode detail: %v", err)
+	}
+	if detail.ContextWindow != 8000 {
+		t.Errorf("ContextWindow = %d, want 8000 (fallback modelA's window)", detail.ContextWindow)
+	}
+}
+
+// TestTeamHandleChatModelIDOnlyNoProvider verifies the provider-less lookup
+// path: when only modelId is sent (provider == ""), lookupModel scans via
+// strings.HasSuffix(":"+modelID) and must resolve p:model-b → modelB. Covers
+// the for-loop branch in lookupModel (team.go:96-103).
+func TestTeamHandleChatModelIDOnlyNoProvider(t *testing.T) {
+	modelA := &stubModel{name: "A", cw: 8000}
+	modelB := &stubModel{name: "B", cw: 16000}
+	h := newTeamTestHandler(t, modelA, modelB)
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	createResp, err := http.Post(srv.URL+"/team/sessions", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	var info struct {
+		ID string `json:"sessionId"`
+	}
+	json.NewDecoder(createResp.Body).Decode(&info)
+	createResp.Body.Close()
+
+	// Chat selecting model-b with NO provider — exercises the HasSuffix scan.
+	chatResp, err := http.Post(srv.URL+"/team/sessions/"+info.ID+"/chat",
+		"application/json",
+		strings.NewReader(`{"message":"hi","modelId":"model-b"}`))
+	if err != nil {
+		t.Fatalf("chat: %v", err)
+	}
+	defer chatResp.Body.Close()
+	if chatResp.StatusCode != http.StatusOK {
+		t.Fatalf("chat status %d", chatResp.StatusCode)
+	}
+	body, _ := io.ReadAll(chatResp.Body)
+	readSSEDone(string(body))
+
+	if modelB.called == 0 {
+		t.Error("model-b was not resolved by the provider-less HasSuffix scan")
+	}
+	if modelA.called != 0 {
+		t.Error("modelA was invoked — provider-less scan should resolve model-b, not fall back")
+	}
+}


### PR DESCRIPTION
Fixes the [P2] Team entry in BUGS.md: team mode ignored the frontend model selector, always returned `contextWindow: 0`, and kept a stale `modelId` on `GET /team/sessions/{id}`.

## Root cause
`TeamHandler` never got the model-registry + resolve + persist + `fillDetail` wiring that the single `Handler` has. `handleChat` built `openagent.Session` without `Model`/`ModelID`; `NewTeamHandler` registered no `fillDetail` hook; meta was written once at `create` and never updated.

## Changes
- **`rest/team.go`**: `TeamHandler` now carries `models`/`modelList`/`modelsMu` + `RegisterModel`/`lookupModel` mirroring `Handler`. `handleChat` resolves the model (chat override → session meta → first-template model), persists `modelId`/`provider` via `withMeta`+`syncMeta`, and sets `Model`/`ModelID` on the `openagent.Session`. Because `runner.go:68-70` does `r.runModel = session.Model if non-nil`, the selected model overrides every team agent for that run. `fillDetail` hook fills `detail.ContextWindow` from the effective model.
- **`examples/backend/main.go`**: `RegisterModel` on `teamHandler` (same two deepseek models) and `.WithContextWindow(128_000)` on all registered models so `contextWindow` is non-zero after a model switch (both single and team).
- **`rest/team_model_test.go`**: httptest tests for model override + contextWindow.
- **`BUGS.md`**: mark [P2] Team entry ✅ FIXED.

## Verification
End-to-end against a running `examples/backend`:
```
POST /team/sessions/{id}/chat  modelId=deepseek-v4-pro
GET  /team/sessions/{id}
→ _meta.modelId = "deepseek-v4-pro"   (was "" / stale before)
  contextWindow  = 128000              (was 0 before)
```

## Not in scope (separate issues, not fixed here)
- **Frontend model tag empty**: `SessionInfo.modelId` (frontend) reads a top-level field, but backend stores it under `_meta.modelId`. Affects single + team. Needs a frontend or `SessionInfo` field change.
- **Evicted session loses contextWindow**: `sessionManager.get` store branch (`rest/session.go:197-215`) doesn't call `fillDetail`, so a session evicted from memory returns `contextWindow: 0` on GET. Affects single + team. Needs a `sessionManager` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)