### PR TITLE
fix(acp): prevent spurious auto-exit from plan mode and restore corre…

### DIFF
--- a/acp/server.go
+++ b/acp/server.go
@@ -1061,7 +1061,7 @@ func (s *AgentServer) OnPrompt(ctx context.Context, req openacp.PromptRequest, s
 				for _, tc := range evt.Message.ToolCalls {
 					// Detect execution tool usage in plan mode
 					// for auto-exit fallback.
-					if !isPlanTool(tc.Function.Name) {
+					if ss.mode == "plan" && !isPlanTool(tc.Function.Name) {
 						usedNonPlanTool = true
 					}
 					sender.SendToolCall(openacp.ToolCallUpdate{
@@ -1131,13 +1131,19 @@ func (s *AgentServer) OnPrompt(ctx context.Context, req openacp.PromptRequest, s
 	if stopReason == "" {
 		stopReason = openacp.StopReasonEndTurn
 	}
-	// Auto-exit plan mode if the turn started in plan mode,
-	// execution tools were used (meaning the system already
-	// exited plan mode), but openagent-go's exit_plan_mode
-	// was not called (mode is still "plan").
-	if ss.mode == "plan" && usedNonPlanTool {
-		_ = s.setSessionMode(ctx, req.SessionID, "auto")
-	}
+		// Auto-exit plan mode if the turn started in plan mode,
+		// execution tools were used (meaning the system already
+		// exited plan mode), but openagent-go's exit_plan_mode
+		// was not called (mode is still "plan").
+		// Restore previousMode (same as exit_plan_mode) instead
+		// of hardcoding "auto" — preserves manual mode.
+		if ss.mode == "plan" && usedNonPlanTool {
+			target := ss.previousMode
+			if target == "" || target == "plan" {
+				target = "auto"
+			}
+			_ = s.setSessionMode(ctx, req.SessionID, target)
+		}
 	return &openacp.PromptResponse{StopReason: stopReason, Meta: map[string]any{"mode": ss.mode}}, nil
 }
 


### PR DESCRIPTION
…ct previous mode

Two related fixes in the plan mode auto-exit fallback logic:

1. Add mode precondition to usedNonPlanTool tracking (line 1064)

   The usedNonPlanTool flag is checked at turn end to auto-exit plan mode when execution tools were used without calling exit_plan_mode. However, enter_plan_mode itself was not in the isPlanTool allowlist and was called from auto/manual mode — before ss.mode had been changed to "plan". This caused usedNonPlanTool to be set to true even though only plan-mode tools were used.

   Fix: Only track non-plan tool usage when already in plan mode (ss.mode == "plan"), so enter_plan_mode called from auto/manual mode does not trigger the flag.

2. Restore previousMode in auto-exit fallback instead of hardcoding "auto" (line 1139)

   The auto-exit fallback always switched to "auto" mode, discarding the original mode. If the user was in "manual" mode before entering plan mode, they would be incorrectly placed in "auto" mode after the fallback.

   Fix: Use ss.previousMode to restore the mode that was active before entering plan mode, matching the behavior of exit_plan_mode. Falls back to "auto" if previousMode is empty or "plan".