### PR TITLE
feat(plugin): add runtime_provider export, wire observer plugins, support model insert

### DIFF
--- a/acp/server.go
+++ b/acp/server.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"sync"
@@ -16,8 +17,8 @@ import (
 	openagent "github.com/yusheng-g/openagent-go"
 	openacp "github.com/yusheng-g/openagent-go/acp/sdk"
 	"github.com/yusheng-g/openagent-go/mcp"
-	"github.com/yusheng-g/openagent-go/plan"
 	"github.com/yusheng-g/openagent-go/model/openai"
+	"github.com/yusheng-g/openagent-go/plan"
 	wasm "github.com/yusheng-g/openagent-go/plugin/agent/wasm"
 	"github.com/yusheng-g/openagent-go/plugin/wasmhost"
 	"github.com/yusheng-g/openagent-go/session"
@@ -165,20 +166,24 @@ func (s *AgentServer) SetClientRequester(r openacp.ClientRequester) {
 var _ openacp.ClientRPCUser = (*AgentServer)(nil)
 var _ openacp.AgentHandler = (*AgentServer)(nil)
 
-// SetModel replaces a registered model. Used by runtime_set_model_config.
+// SetModel replaces or inserts a model in the registry. Used by
+// runtime_set_model_config. When the model already exists, empty apiKey
+// or baseURL preserve the originals; when inserting a new model, values
+// are used as-is.
 func (s *AgentServer) SetModel(provider, modelID, apiKey, baseURL string) {
 	s.modelsMu.Lock()
 	defer s.modelsMu.Unlock()
 	key := provider + "/" + modelID
-	old, ok := s.modelConfigs[key]
-	if !ok {
-		return
-	}
-	if apiKey == "" {
-		apiKey = old.APIKey
-	}
-	if baseURL == "" {
-		baseURL = old.BaseURL
+	if old, ok := s.modelConfigs[key]; ok {
+		if apiKey == "" {
+			apiKey = old.APIKey
+		}
+		if baseURL == "" {
+			baseURL = old.BaseURL
+		}
+		log.Printf("[acp] updating model: %s", key)
+	} else {
+		log.Printf("[acp] inserting model: %s", key)
 	}
 	s.Models[key] = openai.New(apiKey, modelID, baseURL)
 	s.modelConfigs[key] = ModelConfig{Provider: provider, ModelID: modelID, APIKey: apiKey, BaseURL: baseURL}
@@ -189,6 +194,26 @@ func (s *AgentServer) RegisterModel(key, provider, modelID, apiKey, baseURL stri
 	s.modelsMu.Lock()
 	defer s.modelsMu.Unlock()
 	s.modelConfigs[key] = ModelConfig{Provider: provider, ModelID: modelID, APIKey: apiKey, BaseURL: baseURL}
+}
+
+// resolveModelConfig returns the provider and bare model ID for the current
+// session's model selection. The session config stores the composite key
+// "provider/modelID"; this looks up modelConfigs to extract both parts so
+// they can be set on session.Provider / session.ModelID for runtime_* host
+// exports and buildModelRequest.
+func (s *AgentServer) resolveModelConfig(ss *agentSession) (provider, modelID string) {
+	key := s.defaultModelID
+	if v, ok := ss.config["model"]; ok {
+		if val, ok := v.(string); ok {
+			key = val
+		}
+	}
+	s.modelsMu.Lock()
+	defer s.modelsMu.Unlock()
+	if mc, ok := s.modelConfigs[key]; ok {
+		return mc.Provider, mc.ModelID
+	}
+	return "", key
 }
 
 // ── Client capability helpers ──
@@ -949,8 +974,11 @@ func (s *AgentServer) OnPrompt(ctx context.Context, req openacp.PromptRequest, s
 	// ── Build agent clone for this turn ──
 	agent := s.agentForTurn(req.SessionID)
 
+	providerID, modelID := s.resolveModelConfig(ss)
 	oaSession := openagent.Session{
 		ID:        string(req.SessionID),
+		ModelID:   modelID,
+		Provider:  providerID,
 		CreatedAt: ss.createdAt,
 		Metadata: map[string]any{
 			"cwd":                   ss.cwd,
@@ -1187,19 +1215,19 @@ func (s *AgentServer) OnPrompt(ctx context.Context, req openacp.PromptRequest, s
 	if stopReason == "" {
 		stopReason = openacp.StopReasonEndTurn
 	}
-		// Auto-exit plan mode if the turn started in plan mode,
-		// execution tools were used (meaning the system already
-		// exited plan mode), but openagent-go's exit_plan_mode
-		// was not called (mode is still "plan").
-		// Restore previousMode (same as exit_plan_mode) instead
-		// of hardcoding "auto" — preserves manual mode.
-		if ss.mode == "plan" && usedNonPlanTool {
-			target := ss.previousMode
-			if target == "" || target == "plan" {
-				target = "auto"
-			}
-			_ = s.setSessionMode(ctx, req.SessionID, target)
+	// Auto-exit plan mode if the turn started in plan mode,
+	// execution tools were used (meaning the system already
+	// exited plan mode), but openagent-go's exit_plan_mode
+	// was not called (mode is still "plan").
+	// Restore previousMode (same as exit_plan_mode) instead
+	// of hardcoding "auto" — preserves manual mode.
+	if ss.mode == "plan" && usedNonPlanTool {
+		target := ss.previousMode
+		if target == "" || target == "plan" {
+			target = "auto"
 		}
+		_ = s.setSessionMode(ctx, req.SessionID, target)
+	}
 	return &openacp.PromptResponse{StopReason: stopReason, Meta: map[string]any{"mode": ss.mode}}, nil
 }
 

--- a/cmd/cli/server/acp.go
+++ b/cmd/cli/server/acp.go
@@ -99,6 +99,14 @@ func RunACP(ctx context.Context, cfg *config.Config, caps Capabilities) error {
 		log.Printf("WARNING: plugin discover: %v", err)
 	} else {
 		srv.PluginMgr = mgr
+		if obs := mgr.Observer(); obs != nil {
+			if agent.Observer != nil {
+				agent.Observer = openagent.MultiObserver(agent.Observer, obs)
+			} else {
+				agent.Observer = obs
+			}
+			log.Printf("[wasm] plugin observer wired into agent")
+		}
 	}
 
 	policy := sandboxPolicy(cfg.Sandbox)

--- a/plugin/agent/wasm/abi.go
+++ b/plugin/agent/wasm/abi.go
@@ -154,6 +154,8 @@ func BuildAgentRuntime(agent *openagent.Agent, session *openagent.Session, setMo
 				return fmt.Sprint(session.Turn), true
 			case wasmhost.RuntimeKeyModelID:
 				return session.ModelID, true
+			case wasmhost.RuntimeKeyProvider:
+				return session.Provider, true
 			default:
 				if strings.HasPrefix(key, wasmhost.RuntimeKeyMetadataPrefix) {
 					k := strings.TrimPrefix(key, wasmhost.RuntimeKeyMetadataPrefix)

--- a/plugin/pdk/rust/src/export.rs
+++ b/plugin/pdk/rust/src/export.rs
@@ -93,6 +93,9 @@ pub trait Plugin: Sized {
         meta.plugin_type = Self::plugin_type().into();
         meta.name = Self::name().into();
         meta.description = Self::description().into();
+        let (stage, phase) = Self::stage_filter();
+        meta.stage = stage;
+        meta.phase = phase;
         meta
     }
 }

--- a/plugin/pdk/rust/src/host.rs
+++ b/plugin/pdk/rust/src/host.rs
@@ -30,6 +30,7 @@ mod ffi {
         pub fn runtime_user_id() -> u64;
         pub fn runtime_turn_count() -> u64;
         pub fn runtime_model_id() -> u64;
+        pub fn runtime_provider() -> u64;
         pub fn runtime_get_metadata(key_p: u32, key_l: u32) -> u64;
         pub fn runtime_set_metadata(key_p: u32, key_l: u32, val_p: u32, val_l: u32) -> u64;
         pub fn runtime_set_model_config(val_p: u32, val_l: u32) -> u64;
@@ -149,6 +150,7 @@ runtime_get_fn!(runtime_session_id, runtime_session_id);
 runtime_get_fn!(runtime_user_id, runtime_user_id);
 runtime_get_fn!(runtime_turn_count, runtime_turn_count);
 runtime_get_fn!(runtime_model_id, runtime_model_id);
+runtime_get_fn!(runtime_provider, runtime_provider);
 
 pub fn runtime_get_metadata(key: &str) -> Result<String, String> {
     let packed = unsafe { ffi::runtime_get_metadata(key.as_ptr() as u32, key.len() as u32) };

--- a/plugin/pdk/rust/src/types.rs
+++ b/plugin/pdk/rust/src/types.rs
@@ -74,6 +74,12 @@ pub struct PluginMeta {
     pub name: String,
     #[serde(default)]
     pub description: String,
+    /// Observer filter: stage name e.g. "model.call". Empty = match all.
+    #[serde(default, skip_serializing_if = "str::is_empty")]
+    pub stage: &'static str,
+    /// Observer filter: "enter", "leave", or "*". Empty = match all.
+    #[serde(default, skip_serializing_if = "str::is_empty")]
+    pub phase: &'static str,
 }
 
 // ── Stage events (agent:observers plugins) ──

--- a/plugin/wasmhost/host_api.go
+++ b/plugin/wasmhost/host_api.go
@@ -59,8 +59,8 @@ type Logger interface {
 // Agent and Session during a run. Get reads a named value; Set writes one;
 // SetModel replaces a model in the global registry.
 type AgentRuntime struct {
-	Get     func(key string) (string, bool)
-	Set     func(key string, value string) error
+	Get      func(key string) (string, bool)
+	Set      func(key string, value string) error
 	SetModel func(provider, modelID, apiKey, baseURL string)
 }
 
@@ -70,7 +70,8 @@ const (
 	RuntimeKeyUserID         = "user_id"
 	RuntimeKeyTurnCount      = "turn_count"
 	RuntimeKeyModelID        = "model_id"
-	RuntimeKeyMetadataPrefix = "metadata."  // Get("metadata.foo") / Set("metadata.foo", "bar")
+	RuntimeKeyProvider       = "provider"
+	RuntimeKeyMetadataPrefix = "metadata." // Get("metadata.foo") / Set("metadata.foo", "bar")
 )
 
 // HostAPI bundles host-provided capabilities available to WASM plugins

--- a/plugin/wasmhost/host_module.go
+++ b/plugin/wasmhost/host_module.go
@@ -185,7 +185,6 @@ func (h *HostAPI) RegisterHostModule(ctx context.Context, rt wazero.Runtime) err
 			}
 		}).
 		Export("log_info").
-
 		NewFunctionBuilder().
 		WithFunc(func(ctx context.Context, mod api.Module, msgPtr uint32, msgLen uint32) {
 			msg := read(mod, msgPtr, msgLen)
@@ -194,7 +193,6 @@ func (h *HostAPI) RegisterHostModule(ctx context.Context, rt wazero.Runtime) err
 			}
 		}).
 		Export("log_warn").
-
 		NewFunctionBuilder().
 		WithFunc(func(ctx context.Context, mod api.Module, msgPtr uint32, msgLen uint32) {
 			msg := read(mod, msgPtr, msgLen)
@@ -217,25 +215,26 @@ func (h *HostAPI) RegisterHostModule(ctx context.Context, rt wazero.Runtime) err
 			return h.runtimeGet(ctx, mod, RuntimeKeySessionID)
 		}).
 		Export("runtime_session_id").
-
 		NewFunctionBuilder().
 		WithFunc(func(ctx context.Context, mod api.Module) uint64 {
 			return h.runtimeGet(ctx, mod, RuntimeKeyUserID)
 		}).
 		Export("runtime_user_id").
-
 		NewFunctionBuilder().
 		WithFunc(func(ctx context.Context, mod api.Module) uint64 {
 			return h.runtimeGet(ctx, mod, RuntimeKeyTurnCount)
 		}).
 		Export("runtime_turn_count").
-
 		NewFunctionBuilder().
 		WithFunc(func(ctx context.Context, mod api.Module) uint64 {
 			return h.runtimeGet(ctx, mod, RuntimeKeyModelID)
 		}).
 		Export("runtime_model_id").
-
+		NewFunctionBuilder().
+		WithFunc(func(ctx context.Context, mod api.Module) uint64 {
+			return h.runtimeGet(ctx, mod, RuntimeKeyProvider)
+		}).
+		Export("runtime_provider").
 		NewFunctionBuilder().
 		WithFunc(func(ctx context.Context, mod api.Module, keyPtr, keyLen uint32) uint64 {
 			key := read(mod, keyPtr, keyLen)
@@ -251,25 +250,21 @@ func (h *HostAPI) RegisterHostModule(ctx context.Context, rt wazero.Runtime) err
 			return h.runtimeSet(ctx, mod, RuntimeKeyMetadataPrefix+key, val)
 		}).
 		Export("runtime_set_metadata").
-
 		NewFunctionBuilder().
 		WithFunc(func(ctx context.Context, mod api.Module, valPtr, valLen uint32) uint64 {
 			return h.runtimeSetModelConfig(ctx, mod, read(mod, valPtr, valLen))
 		}).
 		Export("runtime_set_model_config").
-
 		NewFunctionBuilder().
 		WithFunc(func(ctx context.Context, mod api.Module, valPtr, valLen uint32) uint64 {
 			return h.runtimeSet(ctx, mod, "system_prompts", read(mod, valPtr, valLen))
 		}).
 		Export("runtime_set_system_prompts").
-
 		NewFunctionBuilder().
 		WithFunc(func(ctx context.Context, mod api.Module, valPtr, valLen uint32) uint64 {
 			return h.runtimeSet(ctx, mod, "max_turns", read(mod, valPtr, valLen))
 		}).
 		Export("runtime_set_max_turns").
-
 		Instantiate(ctx)
 	return err
 }

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -119,21 +119,23 @@ func (h *Handler) RegisterModel(id string, model openagent.Model, provider, apiK
 	h.modelList = append(h.modelList, ModelInfo{ID: id, Provider: provider})
 }
 
-// SetModel replaces a model in the registry. apiKey and baseURL override the
-// originals only when non-empty. Used by runtime_set_model_config host export.
+// SetModel replaces or inserts a model in the registry. apiKey and baseURL
+// override the originals only when non-empty (update) or are used as-is
+// (insert). Used by runtime_set_model_config host export.
 func (h *Handler) SetModel(provider, modelID, apiKey, baseURL string) {
 	h.modelsMu.Lock()
 	defer h.modelsMu.Unlock()
 	key := provider + "/" + modelID
-	old, ok := h.modelConfigs[key]
-	if !ok {
-		return
-	}
-	if apiKey == "" {
-		apiKey = old.APIKey
-	}
-	if baseURL == "" {
-		baseURL = old.BaseURL
+	if old, ok := h.modelConfigs[key]; ok {
+		if apiKey == "" {
+			apiKey = old.APIKey
+		}
+		if baseURL == "" {
+			baseURL = old.BaseURL
+		}
+	} else {
+		// New model: add to modelList so /models endpoint includes it.
+		h.modelList = append(h.modelList, ModelInfo{ID: modelID, Provider: provider})
 	}
 	h.models[key] = openai.New(apiKey, modelID, baseURL)
 	h.modelConfigs[key] = ModelConfig{Provider: provider, ModelID: modelID, APIKey: apiKey, BaseURL: baseURL}
@@ -174,6 +176,14 @@ func (h *Handler) lookupModel(provider, modelID string) openagent.Model {
 // Must be called before any session is created.
 func (h *Handler) WithPluginManager(mgr *wasm.Manager) *Handler {
 	h.pluginMgr = mgr
+	if obs := mgr.Observer(); obs != nil {
+		if h.observer != nil {
+			h.observer = openagent.MultiObserver(h.observer, obs)
+		} else {
+			h.observer = obs
+		}
+		log.Printf("[wasm] plugin observer wired into handler")
+	}
 	h.sm.hooks.onDelete = func(e *sessionState) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -367,6 +377,7 @@ func (h *Handler) handleChat(w http.ResponseWriter, r *http.Request) {
 		oaSession := openagent.Session{
 			ID:        id,
 			ModelID:   modelID,
+			Provider:  provider,
 			Model:     model,
 			CreatedAt: s.info.CreatedAt,
 		}

--- a/session.go
+++ b/session.go
@@ -46,10 +46,11 @@ type Session struct {
 	UserID string `json:"user_id"`
 
 	// Model selection (overrides Agent default if set)
-	ModelID         string  `json:"model_id,omitempty"`
-	Model           Model   `json:"-"`                  // per-request model override; nil = use Agent.Model
-	Temperature     *float64 `json:"temperature,omitempty"`
-	MaxTokens       int     `json:"max_tokens,omitempty"`
+	ModelID     string   `json:"model_id,omitempty"`
+	Provider    string   `json:"provider,omitempty"`
+	Model       Model    `json:"-"` // per-request model override; nil = use Agent.Model
+	Temperature *float64 `json:"temperature,omitempty"`
+	MaxTokens   int      `json:"max_tokens,omitempty"`
 
 	// Context for Prompt
 	UserProfile    string `json:"user_profile,omitempty"`


### PR DESCRIPTION

- Add runtime_provider host export (Go + Rust PDK) parallel to runtime_model_id
- Add Provider field to Session, populated in acp/rest handlers
- SetModel now inserts new models instead of silently ignoring unknown keys
- Wire wasm plugin observer into agent (acp) and rest handler
- Add stage/phase filter fields to Rust PDK PluginMeta
- Rename resolveModelID -> resolveModelConfig to return provider + modelID