### PR TITLE
fix(rest): cancel agent on SSE client disconnect to stop API credit leak

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -104,9 +104,11 @@ Original issue (stale — described a version before `995bbb8`): `parseResult` d
 
 ---
 
-### [P3] API credit leak on client SSE disconnect
+### [P3] ~~API credit leak on client SSE disconnect~~ ✅ FIXED
 
-[rest/handler.go:272](rest/handler.go#L272), [rest/team.go:222](rest/team.go#L222), [rest/orchestrate_handler.go:264](rest/orchestrate_handler.go#L264): All three use `context.Background()` (with long timeout) for agent goroutines. SSE client disconnects → goroutine continues running with no consumer.
+[rest/handler.go:301](rest/handler.go), [rest/team.go:227](rest/team.go), [rest/orchestrate_handler.go:268](rest/orchestrate_handler.go): **Fixed in this commit** — all three chat goroutines now derive the run context from the request via `context.WithTimeout(r.Context(), ...)` instead of `context.WithTimeout(context.Background(), ...)`. On client SSE disconnect, `r.Context()` is cancelled → the derived ctx is cancelled → `runner.go:126` sees `ctx.Done()` and returns from `run` → `RunStream`'s internal goroutine runs `defer close(ch)` (`agent.go:120`) → the publish `for range ch` loop exits. The LLM call stops immediately instead of running to the timeout with no consumer. The timeout still caps the run on a healthy connection. `handler.go`'s manual `select <-r.Context().Done()` check in the publish loop was removed (now redundant — ctx propagation stops the agent directly). `rest/sse_disconnect_test.go` adds two end-to-end httptest cases: `TestSSEDisconnectCancelsAgent` (disconnect → model ctx cancelled within 3s; confirmed to hang on the old `context.Background` code) and `TestSSENormalCompletionNotPrematurelyCancelled` (normal completion → model returns, not prematurely cancelled).
+
+Original issue: all three used `context.Background()` (with long timeout) for agent goroutines. SSE client disconnects → goroutine continues running with no consumer.
 
 ---
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -364,8 +364,13 @@ func (h *Handler) handleChat(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Start the agent run in a background goroutine.
+	//
+	// The run context is derived from the request so a client SSE disconnect
+	// cancels the agent (stops LLM calls) instead of letting it run to the
+	// 5-minute timeout on context.Background — which burns API credit with no
+	// consumer. The timeout still caps the run on a healthy connection.
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Minute)
 		defer cancel()
 		defer func() {
 			s.mu.Lock()
@@ -390,15 +395,14 @@ func (h *Handler) handleChat(w http.ResponseWriter, r *http.Request) {
 		}
 
 		ch := s.agent.RunStream(ctx, oaSession, openagent.UserMessage(body.Message))
+		// On client SSE disconnect: r.Context() cancelled → ctx (derived from it)
+		// cancelled → runner sees ctx.Done() at runner.go:126 and returns from run →
+		// RunStream's internal goroutine runs `defer close(ch)` (agent.go:120) →
+		// this range loop sees ch close and exits. No manual r.Context().Done()
+		// check needed here (removed when context source switched from
+		// context.Background to r.Context).
 		for evt := range ch {
 			se := streamToSSE(evt)
-			select {
-			case <-r.Context().Done():
-				// Client disconnected — stop publishing.
-				// Agent continues with its own ctx; timeout cleans up.
-				return
-			default:
-			}
 			h.sm.Bus().Publish(id, se)
 		}
 	}()

--- a/rest/orchestrate_handler.go
+++ b/rest/orchestrate_handler.go
@@ -260,8 +260,12 @@ func (h *OrchestrateHandler) handleExecute(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Create a cancellable context for the execution.
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	// Create a cancellable context for the execution. Derived from the request
+	// so a client SSE disconnect cancels the plan (stops LLM calls) instead of
+	// letting it run to the 30-minute timeout on context.Background — which
+	// burns API credit with no consumer. handleCancel can still cancel via the
+	// stored cancel func. The timeout still caps the run on a healthy connection.
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Minute)
 
 	s.mu.Lock()
 	s.execCancel = cancel
@@ -300,6 +304,9 @@ func (h *OrchestrateHandler) handleExecute(w http.ResponseWriter, r *http.Reques
 			ch := s.plan.ExecuteWithState(ctx, oaSession, def, state)
 
 			paused := false
+			// On client SSE disconnect: r.Context() cancelled → ctx (derived from
+			// it) cancelled → plan sees ctx.Done() and returns → ExecuteWithState's
+			// goroutine closes ch → this range loop sees ch close and exits.
 			for evt := range ch {
 				se := planEventToSSE(evt)
 				if se.Type == "" {

--- a/rest/sse_disconnect_test.go
+++ b/rest/sse_disconnect_test.go
@@ -1,0 +1,163 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	openagent "github.com/yusheng-g/openagent-go"
+)
+
+// ── test models ──
+
+// blockingModel hangs in ChatCompletion until ctx is cancelled, then returns
+// ctx.Err(). Records whether it exited via ctx cancel — the behaviour we want
+// on client SSE disconnect.
+type blockingModel struct {
+	ctxCancelled atomic.Bool
+}
+
+func (m *blockingModel) ChatCompletion(ctx context.Context, req openagent.ChatCompletionRequest) (*openagent.ChatCompletionResponse, error) {
+	<-ctx.Done()
+	m.ctxCancelled.Store(true)
+	return nil, ctx.Err()
+}
+
+func (m *blockingModel) ChatCompletionStream(ctx context.Context, req openagent.ChatCompletionRequest) (openagent.StreamReader, error) {
+	<-ctx.Done()
+	m.ctxCancelled.Store(true)
+	return nil, ctx.Err()
+}
+
+func (m *blockingModel) ContextWindow() int { return 128_000 }
+
+// promptModel returns a fixed completion after a short delay. It records how
+// it exited: 0 = still running, 1 = returned normally, 2 = ctx cancelled.
+type promptModel struct {
+	exit atomic.Int32 // 0 pending, 1 normal, 2 cancelled
+}
+
+func (m *promptModel) ChatCompletion(ctx context.Context, req openagent.ChatCompletionRequest) (*openagent.ChatCompletionResponse, error) {
+	// Race a tiny delay against ctx cancel so we can distinguish "returned
+	// normally" from "cancelled prematurely".
+	select {
+	case <-time.After(50 * time.Millisecond):
+		m.exit.Store(1)
+		return &openagent.ChatCompletionResponse{
+			Choices: []openagent.Choice{{
+				Message:      openagent.Message{Role: openagent.RoleAssistant, Content: "done"},
+				FinishReason: "stop",
+			}},
+		}, nil
+	case <-ctx.Done():
+		m.exit.Store(2)
+		return nil, ctx.Err()
+	}
+}
+
+func (m *promptModel) ChatCompletionStream(ctx context.Context, req openagent.ChatCompletionRequest) (openagent.StreamReader, error) {
+	return nil, nil
+}
+
+func (m *promptModel) ContextWindow() int { return 128_000 }
+
+// ── helpers ──
+
+// newServerWithAgent wires a Handler for the given agent onto an httptest server.
+func newServerWithAgent(t *testing.T, agent *openagent.Agent) *httptest.Server {
+	t.Helper()
+	h := NewHandler(agent)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	s := httptest.NewServer(mux)
+	t.Cleanup(s.Close)
+	return s
+}
+
+// createSession POSTs /sessions and returns the new session id.
+func createSession(t *testing.T, server *httptest.Server) string {
+	t.Helper()
+	req, _ := http.NewRequest("POST", server.URL+"/sessions", strings.NewReader(`{"title":"t"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	var info struct {
+		ID string `json:"sessionId"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&info); err != nil {
+		t.Fatalf("decode create resp: %v", err)
+	}
+	resp.Body.Close()
+	return info.ID
+}
+
+// ── tests ──
+
+// TestSSEDisconnectCancelsAgent verifies that closing the SSE client connection
+// cancels the agent's run context, so the model call stops instead of running
+// to the 5-minute timeout on a detached context.Background (credit leak).
+func TestSSEDisconnectCancelsAgent(t *testing.T) {
+	m := &blockingModel{}
+	agent := openagent.NewAgent("assistant", openagent.WithModel(m), openagent.WithMaxTurns(1))
+	server := newServerWithAgent(t, agent)
+	sid := createSession(t, server)
+
+	// Open the SSE chat stream and close it mid-stream.
+	req, _ := http.NewRequest("POST", server.URL+"/sessions/"+sid+"/chat", strings.NewReader(`{"message":"hi"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("chat: %v", err)
+	}
+	buf := make([]byte, 1)
+	_, _ = resp.Body.Read(buf) // ensure the agent goroutine has started
+	resp.Body.Close()          // simulate client disconnect
+
+	// The model call should see ctx cancel within a short window. Before the
+	// fix (context.Background-derived ctx) it would hang until the 5-minute
+	// timeout — this wait would time out.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if m.ctxCancelled.Load() {
+			return // pass
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("model ChatCompletion was not cancelled after client disconnect — " +
+		"agent ctx is not derived from request ctx (credit leak on disconnect)")
+}
+
+// TestSSENormalCompletionNotPrematurelyCancelled verifies that deriving the
+// agent ctx from r.Context() does NOT cancel the agent prematurely on the
+// normal-completion path: the model returns its response (exit==1), not a
+// ctx-cancel error (exit==2). Guards against the regression where a too-eager
+// r.Context cancellation would kill the agent before it finishes.
+func TestSSENormalCompletionNotPrematurelyCancelled(t *testing.T) {
+	m := &promptModel{}
+	agent := openagent.NewAgent("assistant", openagent.WithModel(m), openagent.WithMaxTurns(1))
+	server := newServerWithAgent(t, agent)
+	sid := createSession(t, server)
+
+	// Run the chat to completion (drain the full SSE stream until server closes).
+	req, _ := http.NewRequest("POST", server.URL+"/sessions/"+sid+"/chat", strings.NewReader(`{"message":"hi"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("chat: %v", err)
+	}
+	_, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if got := m.exit.Load(); got != 1 {
+		t.Fatalf("model exit = %d, want 1 (normal); the r.Context-derived ctx "+
+			"cancelled the agent before it finished", got)
+	}
+}

--- a/rest/team.go
+++ b/rest/team.go
@@ -284,8 +284,13 @@ func (h *TeamHandler) handleChat(w http.ResponseWriter, r *http.Request) {
 		h.sm.syncMeta(inf)
 	}
 
+	// The run context is derived from the request so a client SSE disconnect
+	// cancels the team run (stops LLM calls across all agents) instead of
+	// letting it run to the 5-minute timeout on context.Background — which
+	// burns API credit with no consumer. The timeout still caps the run on a
+	// healthy connection.
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Minute)
 		defer cancel()
 		defer func() {
 			s.mu.Lock()
@@ -302,6 +307,9 @@ func (h *TeamHandler) handleChat(w http.ResponseWriter, r *http.Request) {
 		}
 
 		ch := s.team.RunStream(ctx, oaSession, openagent.UserMessage(body.Message))
+		// On client SSE disconnect: r.Context() cancelled → ctx (derived from it)
+		// cancelled → runner sees ctx.Done() and returns → RunStream's goroutine
+		// runs `defer close(ch)` → this range loop sees ch close and exits.
 		for evt := range ch {
 			se := teamEventToSSE(evt)
 			if se.Type == "" {


### PR DESCRIPTION
Fixes the [P3] SSE credit leak entry in BUGS.md.

## Root cause
All three chat goroutines (`rest/handler.go`, `rest/team.go`, `rest/orchestrate_handler.go`) derived the run context from `context.Background()` with a long timeout. A client SSE disconnect left the agent running — continuing to call the LLM with no consumer and burning API credit until the timeout fired (5–30 min).

## Change
Derive the run context from `r.Context()` instead:
```
disconnect → r.Context() cancelled → ctx (derived) cancelled
           → runner.go:126 sees ctx.Done() and returns
           → RunStream's goroutine runs defer close(ch) (agent.go:120)
           → publish for-range-ch loop exits; LLM call stops immediately
```
The timeout still caps the run on a healthy connection. `handler.go`'s manual `select <-r.Context().Done()` in the publish loop is removed (now redundant — ctx propagation stops the agent directly).

`handleCancel` (orchestrate) is untouched: it calls the stored `s.execCancel` cancel func, which remains valid regardless of the context's parent.

## Tests
`rest/sse_disconnect_test.go` — two end-to-end httptest cases:
- `TestSSEDisconnectCancelsAgent`: disconnect → model ctx cancelled within 3s. **Confirmed to hang on the old `context.Background` code** (model blocks on `<-ctx.Done()` until the 5-min timeout), so the test is genuinely exercising the fix.
- `TestSSENormalCompletionNotPrematurelyCancelled`: normal completion → model returns normally (not prematurely cancelled by `r.Context`).

## Verification
Manual verification is weak for this bug (no visible signal that the agent stopped after disconnect; credit consumption isn't observable in real time). The tests above are the primary evidence — the disconnect test fails/hangs on old code and passes on the fix.

`go build ./...` and `go test ./rest/...` both green.