### PR TITLE
fix(server): wire Keyring and HTTP into agent plugin HostAPI

### DIFF
--- a/cmd/cli/server/acp.go
+++ b/cmd/cli/server/acp.go
@@ -93,7 +93,7 @@ func RunACP(ctx context.Context, cfg *config.Config, caps Capabilities) error {
 
 	// Plugin manager — loads agent:tools, agent:observers, agent:sessions.
 	pluginDir := filepath.Join(profilesDir, "plugins")
-	mgr := wasm.NewManager(pluginDir).WithHostAPI(&wasmhost.HostAPI{Logger: &logAdapter{}})
+	mgr := wasm.NewManager(pluginDir).WithHostAPI(wasmhost.NewHostAPI(openKeyring()))
 	if err := mgr.Discover(ctx); err != nil {
 		slog.Warn("plugin discover failed", "error", err)
 	} else {

--- a/cmd/cli/server/http.go
+++ b/cmd/cli/server/http.go
@@ -88,7 +88,7 @@ func RunREST(ctx context.Context, cfg *config.Config, caps Capabilities) error {
 
 	// Plugin manager — loads agent:tools, agent:observers, agent:sessions.
 	pluginDir := filepath.Join(profilesDir, "plugins")
-	mgr := wasm.NewManager(pluginDir).WithHostAPI(&wasmhost.HostAPI{Logger: &logAdapter{}})
+	mgr := wasm.NewManager(pluginDir).WithHostAPI(wasmhost.NewHostAPI(openKeyring()))
 	if err := mgr.Discover(ctx); err != nil {
 		slog.Warn("plugin discover failed", "error", err)
 	} else {
@@ -150,10 +150,3 @@ func recoveryMiddleware(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 	})
 }
-
-// logAdapter implements wasmhost.Logger by forwarding to the standard log package.
-type logAdapter struct{}
-
-func (l *logAdapter) Info(msg string)  { slog.Info(msg, "source", "plugin") }
-func (l *logAdapter) Warn(msg string)  { slog.Warn(msg, "source", "plugin") }
-func (l *logAdapter) Error(msg string) { slog.Error(msg, "source", "plugin") }

--- a/cmd/cli/server/shared.go
+++ b/cmd/cli/server/shared.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"log"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 	sloghooks "github.com/yusheng-g/openagent-go/hooks/slog"
 	"github.com/yusheng-g/openagent-go/memory/sqlite"
 	"github.com/yusheng-g/openagent-go/model/openai"
+	"github.com/yusheng-g/openagent-go/plugin/wasmhost"
 	"github.com/yusheng-g/openagent-go/sandbox/native"
 	"github.com/yusheng-g/openagent-go/session"
 	sessionsqlite "github.com/yusheng-g/openagent-go/session/sqlite"
@@ -21,6 +23,7 @@ import (
 	opentool "github.com/yusheng-g/openagent-go/tool"
 
 	"github.com/yusheng-g/openagent-go/cmd/cli/config"
+	"github.com/yusheng-g/openagent-go/cmd/cli/keyring"
 )
 
 // ── Shared agent setup ──
@@ -296,4 +299,15 @@ func buildOpts(opts []openagent.AgentOption, caps Capabilities, model openagent.
 		opts = append(opts, openagent.WithRunObserver(buildSlogObserver()))
 	}
 	return opts
+}
+
+// openKeyring returns the system keyring, falling back to an in-memory
+// store with a warning when the system keychain is unavailable.
+func openKeyring() wasmhost.Keyring {
+	sysKr, err := keyring.Open()
+	if err != nil {
+		log.Printf("WARNING: keyring unavailable, using in-memory fallback: %v", err)
+		return keyring.NewMemStore()
+	}
+	return sysKr
 }

--- a/plugin/wasmhost/default.go
+++ b/plugin/wasmhost/default.go
@@ -1,0 +1,42 @@
+package wasmhost
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net/http"
+)
+
+// NewHostAPI constructs a HostAPI with the given keyring and sensible
+// defaults for HTTP (net/http) and logging (standard log adapter).
+func NewHostAPI(kr Keyring) *HostAPI {
+	return &HostAPI{
+		Keyring: kr,
+		HTTP:    &defaultHTTPClient{client: http.DefaultClient},
+		Logger:  &logAdapter{},
+	}
+}
+
+// defaultHTTPClient implements HTTPClient via net/http.
+type defaultHTTPClient struct{ client *http.Client }
+
+func (c *defaultHTTPClient) Do(method, url string, headers map[string]string, body []byte) (int, []byte, error) {
+	req, _ := http.NewRequest(method, url, bytes.NewReader(body))
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, respBody, nil
+}
+
+// logAdapter implements Logger by forwarding to the standard log package.
+type logAdapter struct{}
+
+func (l *logAdapter) Info(msg string)  { slog.Info(msg, "source", "plugin") }
+func (l *logAdapter) Warn(msg string)  { slog.Warn(msg, "source", "plugin") }
+func (l *logAdapter) Error(msg string) { slog.Error(msg, "source", "plugin") }

--- a/plugin/wasmhost/host_module.go
+++ b/plugin/wasmhost/host_module.go
@@ -97,6 +97,10 @@ func (h *HostAPI) RegisterHostModule(ctx context.Context, rt wazero.Runtime) err
 			headersPtr, headersLen uint32,
 			bodyPtr, bodyLen uint32) uint64 {
 
+			if h.HTTP == nil {
+				return writeJSON(ctx, mod, map[string]string{"error": "http not available"})
+			}
+
 			method := read(mod, methodPtr, methodLen)
 			url := read(mod, urlPtr, urlLen)
 			headersRaw := read(mod, headersPtr, headersLen)


### PR DESCRIPTION
Agent plugins (agent:observers, agent:tools, agent:sessions) running
under RunACP/RunREST could not use keyring_get or http_request because
HostAPI was constructed with only Logger — Keyring and HTTP were nil.

keyring_get silently returned {"error":"keyring not available"} and
http_request would panic on nil pointer dereference (no nil guard).

Add wasmhost.NewHostAPI(kr) that creates a HostAPI with default HTTP
client and log adapter, plus openKeyring() in the server package that
opens the system keyring (with MemStore fallback). Also add a nil guard
to http_request in host_module.go for defensive consistency with
keyring_get.