### PR TITLE
fix: plan mode read-only tools + orphan tool message 400 error

### DIFF
--- a/acp/server.go
+++ b/acp/server.go
@@ -5,10 +5,10 @@
 package acp
 
 import (
-	"log/slog"
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -85,9 +85,9 @@ type ModelConfig struct {
 
 // agentSession holds per-session runtime state.
 type agentSession struct {
-	id           openacp.SessionId
-	cwd          string
-	createdAt    time.Time
+	id        openacp.SessionId
+	cwd       string
+	createdAt time.Time
 
 	// modeMu guards the session mode state machine and cached plan entries
 	// (mode, previousMode, planEntries, injectedPlanTools). It supersedes
@@ -110,8 +110,8 @@ type agentSession struct {
 	// held across saveMode/savePlan SessionStore I/O (those run after
 	// unlock; the snapshot is captured under the lock).
 	modeMu       sync.RWMutex
-	mode         string      // "auto", "manual", or "plan"
-	previousMode string      // mode saved when plan was entered; used by exit_plan_mode
+	mode         string                          // "auto", "manual", or "plan"
+	previousMode string                          // mode saved when plan was entered; used by exit_plan_mode
 	config       map[openacp.SessionConfigId]any // config option values
 	cancel       context.CancelFunc
 
@@ -145,6 +145,13 @@ type agentSession struct {
 	// duplicate injection on repeated enter_plan_mode calls within the
 	// same turn. Guarded by modeMu.
 	injectedPlanTools bool
+
+	// planAllowedTools is the set of tool names allowed during plan
+	// mode. Populated after all tool injection (OnPrompt or
+	// enter_plan_mode callback). Only ReadOnly and PlanTool
+	// implementations are included. Used for auto-exit detection
+	// and dynamic context generation.
+	planAllowedTools map[string]bool
 
 	// processMgr tracks background processes started by the shell tool.
 	// Created on session start, cleaned up on deletion.
@@ -1014,8 +1021,8 @@ func (s *AgentServer) persistAndNotifyMode(ctx context.Context, sid openacp.Sess
 		// Also send config_option_update so the client's mode dropdown
 		// (which reads the "mode" config option) stays in sync.
 		s.updateSender.SendSessionUpdate(sid, openacp.SessionUpdate{
-			SessionUpdate:   "config_option_update",
-			ConfigOptions:   s.buildConfigOptions(sid),
+			SessionUpdate: "config_option_update",
+			ConfigOptions: s.buildConfigOptions(sid),
 		})
 	}
 }
@@ -1135,33 +1142,9 @@ func (s *AgentServer) OnPrompt(ctx context.Context, req openacp.PromptRequest, s
 	// ── Build agent clone for this turn ──
 	agent := s.agentForTurn(req.SessionID)
 
-	providerID, modelID := s.resolveModelConfig(ss)
-	oaSession := openagent.Session{
-		ID:        string(req.SessionID),
-		ModelID:   modelID,
-		Provider:  providerID,
-		CreatedAt: ss.createdAt,
-		Metadata: map[string]any{
-			"cwd":                   ss.cwd,
-			"additionalDirectories": ss.additionalDirectories,
-			"mcpServers":            ss.mcpServers,
-		},
-		DynamicContext: s.buildDynamicContext(ss),
-	}
-
-	// Inject AgentRuntime for runtime_* host exports.
-	if s.PluginMgr != nil {
-		rt := wasm.BuildAgentRuntime(agent, &oaSession, s.SetModel)
-		ctx = wasmhost.WithAgentRuntime(ctx, rt)
-	}
-
-	// Inject ProcessManager so the shell tool can persist
-	// long-running process output across turns.
-	if ss.processMgr != nil {
-		ctx = process.WithManager(ctx, ss.processMgr)
-	}
-
 	// ── Register mode-specific planning tools ──
+	// Moved before oaSession construction so planAllowedTools and
+	// buildDynamicContext can see the complete tool set.
 	if ss.Mode() == "plan" {
 		// plan_create: only available in plan mode.
 		agent.AppendTools(plan.NewCreateTool(s.makeCreateCallback(ctx, req.SessionID, ss, sender)))
@@ -1192,6 +1175,22 @@ func (s *AgentServer) OnPrompt(ctx context.Context, req openacp.PromptRequest, s
 					plan.NewCreateTool(s.makeCreateCallback(ctx, req.SessionID, ss, sender)))
 				agent.AppendTools(
 					plan.NewExitTool(s.makeExitCallback(ctx, req.SessionID, ss, agent, sender)))
+
+				// Populate planAllowedTools for auto-exit
+				// detection this turn. The agent clone
+				// still has ALL execution tools from the
+				// original auto/manual mode injection.
+				// Only ReadOnly and PlanTool tools are
+				// included.
+				ss.planAllowedTools = make(map[string]bool, len(agent.SnapshotTools()))
+				for _, t := range agent.SnapshotTools() {
+					if _, ok := t.(openagent.ReadOnly); ok {
+						ss.planAllowedTools[t.Definition().Name] = true
+					}
+					if _, ok := t.(openagent.PlanTool); ok {
+						ss.planAllowedTools[t.Definition().Name] = true
+					}
+				}
 			} else {
 				ss.modeMu.Unlock()
 			}
@@ -1219,6 +1218,48 @@ func (s *AgentServer) OnPrompt(ctx context.Context, req openacp.PromptRequest, s
 		return snap, nil
 	})
 	agent.AppendTools(pu)
+
+	// ── Populate planAllowedTools after all tool injection ──
+	// Must happen BEFORE buildDynamicContext so it can list available tools.
+	// Includes both ReadOnly (read, grep, ls, read_client_file) and
+	// PlanTool (plan_create, plan_update, exit_plan_mode) implementations.
+	if ss.Mode() == "plan" {
+		ss.planAllowedTools = make(map[string]bool, len(agent.SnapshotTools()))
+		for _, t := range agent.SnapshotTools() {
+			if _, ok := t.(openagent.ReadOnly); ok {
+				ss.planAllowedTools[t.Definition().Name] = true
+			}
+			if _, ok := t.(openagent.PlanTool); ok {
+				ss.planAllowedTools[t.Definition().Name] = true
+			}
+		}
+	}
+
+	providerID, modelID := s.resolveModelConfig(ss)
+	oaSession := openagent.Session{
+		ID:        string(req.SessionID),
+		ModelID:   modelID,
+		Provider:  providerID,
+		CreatedAt: ss.createdAt,
+		Metadata: map[string]any{
+			"cwd":                   ss.cwd,
+			"additionalDirectories": ss.additionalDirectories,
+			"mcpServers":            ss.mcpServers,
+		},
+		DynamicContext: s.buildDynamicContext(ss),
+	}
+
+	// Inject AgentRuntime for runtime_* host exports.
+	if s.PluginMgr != nil {
+		rt := wasm.BuildAgentRuntime(agent, &oaSession, s.SetModel)
+		ctx = wasmhost.WithAgentRuntime(ctx, rt)
+	}
+
+	// Inject ProcessManager so the shell tool can persist
+	// long-running process output across turns.
+	if ss.processMgr != nil {
+		ctx = process.WithManager(ctx, ss.processMgr)
+	}
 	// ── Run the agent ──
 	ch := agent.RunStream(ctx, oaSession, input)
 	var usage openagent.Usage
@@ -1447,8 +1488,19 @@ func (s *AgentServer) agentForTurn(sid openacp.SessionId) *openagent.Agent {
 			clone.NoSpawn = true
 			clone.Approver = nil
 
-			// ACP read_file is safe (reads from client filesystem), but
-			// only register it if the client advertised fs.readTextFile.
+			// Collect read-only tools from ToolFactory. Shell/write/edit
+			// are excluded because they don't implement ReadOnly.
+			if s.ToolFactory != nil && ss.cwd != "" {
+				for _, t := range s.ToolFactory(ss.cwd) {
+					if _, ok := t.(openagent.ReadOnly); ok {
+						clone.AppendTools(t)
+					}
+				}
+			}
+
+			// ACP read_file — supplementary: reads from client filesystem
+			// (VS Code). Only register it if the client advertised
+			// fs.readTextFile.
 			if s.clientRPC != nil && s.clientCanReadFile() {
 				clone.Tools = append(clone.Tools,
 					opentool.NewACPReadFile(s.clientRPC, sid),
@@ -1489,22 +1541,37 @@ func (s *AgentServer) agentForTurn(sid openacp.SessionId) *openagent.Agent {
 
 // injectExecutionTools appends all execution-capable tools to the agent
 // clone. Called in manual mode and after exit_plan_mode transitions.
-// Mirrors the original flat injection — MCP tools, ToolFactory tools,
-// and Agent→Client RPC tools all go through here. The injection goes
+// Idempotent — skips tools whose name is already on the clone to prevent
+// duplicates when exit_plan_mode re-injects onto a clone that already has
+// ReadOnly tools from agentForTurn's plan mode path. The injection goes
 // through AppendTools (toolsMu-guarded): this runs inside exit_plan_mode's
 // callback, which executes within an executeTools parallel-goroutine
 // batch, so sibling tool goroutines read the clone's Tools via the
 // runner's SnapshotTools/findTool concurrently with this append.
 func (s *AgentServer) injectExecutionTools(clone *openagent.Agent, sid openacp.SessionId, ss *agentSession) {
+	// Build set of existing tool names to avoid duplicates.
+	existing := make(map[string]bool, len(clone.SnapshotTools()))
+	for _, t := range clone.SnapshotTools() {
+		existing[t.Definition().Name] = true
+	}
+
 	var add []openagent.Tool
 
 	// MCP tools from connected servers.
-	add = append(add, ss.mcpTools...)
+	for _, t := range ss.mcpTools {
+		if !existing[t.Definition().Name] {
+			add = append(add, t)
+			existing[t.Definition().Name] = true
+		}
+	}
 
 	// Per-turn tools scoped to the session cwd.
 	if s.ToolFactory != nil && ss.cwd != "" {
-		if tools := s.ToolFactory(ss.cwd); len(tools) > 0 {
-			add = append(add, tools...)
+		for _, t := range s.ToolFactory(ss.cwd) {
+			if !existing[t.Definition().Name] {
+				add = append(add, t)
+				existing[t.Definition().Name] = true
+			}
 		}
 	}
 
@@ -1514,18 +1581,23 @@ func (s *AgentServer) injectExecutionTools(clone *openagent.Agent, sid openacp.S
 	// LLM is never offered a tool whose RPC the client will reject.
 	if s.clientRPC != nil {
 		if s.clientCanWriteFile() {
-			add = append(add,
-				opentool.NewACPWriteFile(s.clientRPC, sid),
-			)
+			t := opentool.NewACPWriteFile(s.clientRPC, sid)
+			if !existing[t.Definition().Name] {
+				add = append(add, t)
+			}
 		}
 		if s.clientCanTerminal() {
-			add = append(add,
+			for _, t := range []openagent.Tool{
 				opentool.NewACPTerminalCreate(s.clientRPC, sid),
 				opentool.NewACPTerminalOutput(s.clientRPC, sid),
 				opentool.NewACPTerminalWait(s.clientRPC, sid),
 				opentool.NewACPTerminalKill(s.clientRPC, sid),
 				opentool.NewACPTerminalRelease(s.clientRPC, sid),
-			)
+			} {
+				if !existing[t.Definition().Name] {
+					add = append(add, t)
+				}
+			}
 		}
 	}
 
@@ -1789,17 +1861,6 @@ func (a *acpApprover) Approve(ctx context.Context, call openagent.ToolCall, def 
 	default:
 		return false, fmt.Sprintf("unknown option: %s", *resp.Outcome.OptionID)
 	}
-}
-
-// isPlanTool reports whether the given tool name is a plan-mode-only tool
-// (plan_create, plan_update, exit_plan_mode) or a read-only inspection tool
-// (read_client_file). These tools are allowed in plan mode.
-func isPlanTool(name string) bool {
-	switch name {
-	case "plan_create", "plan_update", "exit_plan_mode", "read_client_file":
-		return true
-	}
-	return false
 }
 
 // firstLine truncates s to the first line, up to maxLen characters.

--- a/cmd/cli/server/buildopts_test.go
+++ b/cmd/cli/server/buildopts_test.go
@@ -76,8 +76,8 @@ func TestBuildOpts_AllOff(t *testing.T) {
 	if agent.OutGuard != nil {
 		t.Error("OutGuard should be nil when OnGuard=false")
 	}
-	if agent.Hooks != nil {
-		t.Error("Hooks should be nil when OnHooks=false")
+	if agent.Hooks == nil {
+		t.Error("ArtifactHook should be present even when OnHooks=false")
 	}
 	if agent.Observer != nil {
 		t.Error("Observer should be nil when OnObserver=false")

--- a/cmd/cli/server/shared.go
+++ b/cmd/cli/server/shared.go
@@ -279,9 +279,17 @@ func buildOpts(opts []openagent.AgentOption, caps Capabilities, model openagent.
 		opts = append(opts, openagent.WithInputGuard(g))
 		opts = append(opts, openagent.WithOutputGuard(g.Output()))
 	}
+	// ArtifactHook is always enabled — it prevents context-window blowup
+	// by saving large tool results to disk regardless of --hooks flag.
+	artifactHook := &opentool.ArtifactHook{}
 	if caps.OnHooks() {
-		opts = append(opts, openagent.WithRunHooks(buildSlogHooks()))
+		opts = append(opts, openagent.WithRunHooks(
+			openagent.MultiRunHooks(artifactHook, buildSlogHooks()),
+		))
+	} else {
+		opts = append(opts, openagent.WithRunHooks(artifactHook))
 	}
+
 	if caps.OnObserver() {
 		opts = append(opts, openagent.WithRunObserver(buildSlogObserver()))
 	}

--- a/hooks.go
+++ b/hooks.go
@@ -28,3 +28,100 @@ type RunHooks interface {
 	// result and err are pointers — hooks may mutate them before memory storage.
 	OnToolEnd(ctx context.Context, tool FunctionDefinition, args json.RawMessage, result *string, err *error, startState any)
 }
+
+// ── Multi-run-hooks combiner ──
+
+// multiHookEntry pairs a hook with its index in the list, used to map
+// start-state slices back to the correct hook on end calls.
+type multiHookEntry struct {
+	idx  int
+	hook RunHooks
+}
+
+// multiHookState bundles the per-hook start states returned by
+// OnAgentStart or OnToolStart.
+type multiHookState struct {
+	states []any // states[i] corresponds to list[i].hook
+}
+
+// MultiRunHooks combines multiple RunHooks into one.
+// Each hook is called in order; one hook failing on start does not prevent
+// subsequent hooks from running. Nil hooks are skipped. On end calls,
+// result/err are passed through each hook in the same order, allowing
+// chained mutations (e.g. artifact hook truncation followed by slog logging).
+func MultiRunHooks(hooks ...RunHooks) RunHooks {
+	var filtered []multiHookEntry
+	for i, h := range hooks {
+		if h != nil {
+			filtered = append(filtered, multiHookEntry{idx: i, hook: h})
+		}
+	}
+	switch len(filtered) {
+	case 0:
+		return nil
+	case 1:
+		return filtered[0].hook
+	default:
+		return &multiRunHooks{list: filtered}
+	}
+}
+
+type multiRunHooks struct {
+	list []multiHookEntry
+}
+
+func (m *multiRunHooks) OnAgentStart(ctx context.Context, req ChatCompletionRequest) (any, error) {
+	states := make([]any, len(m.list))
+	for i, e := range m.list {
+		s, err := e.hook.OnAgentStart(ctx, req)
+		states[i] = s
+		if err != nil {
+			return &multiHookState{states: states}, err
+		}
+	}
+	return &multiHookState{states: states}, nil
+}
+
+func (m *multiRunHooks) OnAgentEnd(ctx context.Context, req ChatCompletionRequest, resp *ChatCompletionResponse, runErr error, startState any) {
+	if startState == nil {
+		return
+	}
+	ms, ok := startState.(*multiHookState)
+	if !ok {
+		return
+	}
+	if len(ms.states) != len(m.list) {
+		return
+	}
+	for i, e := range m.list {
+		e.hook.OnAgentEnd(ctx, req, resp, runErr, ms.states[i])
+	}
+}
+
+func (m *multiRunHooks) OnToolStart(ctx context.Context, tool FunctionDefinition, args json.RawMessage) (any, error) {
+	states := make([]any, len(m.list))
+	for i, e := range m.list {
+		s, err := e.hook.OnToolStart(ctx, tool, args)
+		states[i] = s
+		if err != nil {
+			return &multiHookState{states: states}, err
+		}
+	}
+	return &multiHookState{states: states}, nil
+}
+
+func (m *multiRunHooks) OnToolEnd(ctx context.Context, tool FunctionDefinition, args json.RawMessage, result *string, err *error, startState any) {
+	if startState == nil {
+		return
+	}
+	ms, ok := startState.(*multiHookState)
+	if !ok {
+		return
+	}
+	if len(ms.states) != len(m.list) {
+		return
+	}
+	for i, e := range m.list {
+		e.hook.OnToolEnd(ctx, tool, args, result, err, ms.states[i])
+	}
+}

--- a/plan/tool.go
+++ b/plan/tool.go
@@ -68,6 +68,8 @@ Once the plan is complete, call exit_plan_mode to return to your previous mode a
 	}
 }
 
+func (t *CreateTool) IsPlanTool() bool { return true }
+
 // Execute implements openagent.Tool.
 func (t *CreateTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var params struct {
@@ -182,6 +184,8 @@ func (t *UpdateTool) Definition() openagent.FunctionDefinition {
 	}
 }
 
+func (t *UpdateTool) IsPlanTool() bool { return true }
+
 // Execute implements openagent.Tool.
 func (t *UpdateTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var params struct {
@@ -280,6 +284,8 @@ Only call this once, and only when you are ready to start executing the plan ste
 }`),
 	}
 }
+
+func (t *ExitTool) IsPlanTool() bool { return true }
 
 // Execute implements openagent.Tool. It calls the onExit callback to
 // transition the session mode, then returns confirmation text.

--- a/runner.go
+++ b/runner.go
@@ -616,6 +616,24 @@ func (r *runner) prepareMemory(ctx context.Context, session Session) ([]Message,
 	if keep >= len(msgs) {
 		return msgs, ci
 	}
+
+	// The overflow boundary may land on a non-first tool result in a
+	// batch (e.g. assistant with [call_00, call_01] → tool call_00 →
+	// tool call_01 ← boundary here). SafeCompressionBoundary only
+	// extends when the last compressed message is an assistant with
+	// tool_calls; it does not catch the n≥2 case. Skip leading orphan
+	// tool results to avoid API 400 errors ("Messages with role 'tool'
+	// must be a response to a preceding message with 'tool_calls'").
+	for keep < len(msgs) && msgs[keep].Role == RoleTool {
+		keep++
+	}
+	if keep >= len(msgs) {
+		// All remaining messages are orphan tools. Keep the last
+		// message so the return is non-empty (the compressed summary
+		// carried in the prompt provides context).
+		return msgs[len(msgs)-1:], ci
+	}
+
 	return msgs[keep:], ci
 }
 

--- a/tool.go
+++ b/tool.go
@@ -45,6 +45,28 @@ type SelfApproving interface {
 	CanSelfApprove(args json.RawMessage) bool
 }
 
+// ReadOnly is an optional interface for tools that have no side effects
+// on the file system or external state. Read-only tools are automatically
+// available in plan mode and other restricted contexts where execution
+// tools are disabled.
+//
+// Examples: read, grep, ls, read_client_file.
+type ReadOnly interface {
+	Tool
+	IsReadOnly() bool
+}
+
+// PlanTool is an optional interface for tools that participate in the
+// plan workflow (plan_create, plan_update, exit_plan_mode). These tools
+// are automatically available in plan mode alongside ReadOnly tools.
+//
+// enter_plan_mode does NOT implement PlanTool — it is only available
+// outside plan mode (auto/manual).
+type PlanTool interface {
+	Tool
+	IsPlanTool() bool
+}
+
 // StreamExecutor is an optional interface for tools that produce streaming
 // output during execution. The Runner checks for this interface before
 // calling [Tool.Execute]:

--- a/tool/acp_fs.go
+++ b/tool/acp_fs.go
@@ -37,6 +37,8 @@ func (t *ACPReadFile) Definition() openagent.FunctionDefinition {
 	}
 }
 
+func (t *ACPReadFile) IsReadOnly() bool { return true }
+
 func (t *ACPReadFile) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var params struct {
 		Path  string `json:"path"`

--- a/tool/artifact_hook.go
+++ b/tool/artifact_hook.go
@@ -1,0 +1,110 @@
+// ArtifactHook saves large tool results to disk so the model can
+// inspect them with read/grep instead of consuming context window.
+//
+// Used as a built-in RunHooks: when a tool result exceeds Threshold bytes,
+// the content is written to /tmp/openagent/<sessionID>/<tool>_<ts>.txt and
+// the result is replaced with a short pointer message.
+//
+// Default threshold: 64 * 1024 (64 KB). Set to 0 to always save.
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	openagent "github.com/yusheng-g/openagent-go"
+)
+
+// ArtifactHookDefaultThreshold is the default size (bytes) above which a
+// tool result is saved to disk rather than passed inline to the model.
+const ArtifactHookDefaultThreshold = 64 * 1024 // 64 KB
+
+// ArtifactHook saves large tool results to disk.
+type ArtifactHook struct {
+	Threshold int    // bytes; 0 = always save
+	Prefix    string // optional prefix for the saved-result message
+}
+
+// OnAgentStart is a no-op — artifact hook only cares about tool results.
+func (h *ArtifactHook) OnAgentStart(ctx context.Context, req openagent.ChatCompletionRequest) (any, error) {
+	return nil, nil
+}
+
+// OnAgentEnd is a no-op.
+func (h *ArtifactHook) OnAgentEnd(ctx context.Context, req openagent.ChatCompletionRequest, resp *openagent.ChatCompletionResponse, runErr error, startState any) {
+}
+
+// OnToolStart is a no-op — artifacts are handled after execution.
+func (h *ArtifactHook) OnToolStart(ctx context.Context, tool openagent.FunctionDefinition, args json.RawMessage) (any, error) {
+	return nil, nil
+}
+
+// OnToolEnd checks result size and saves to disk when it exceeds the threshold.
+// Reads from the artifact directory are excluded to prevent artifact-of-artifact
+// recursion.
+func (h *ArtifactHook) OnToolEnd(ctx context.Context, tool openagent.FunctionDefinition, args json.RawMessage, result *string, err *error, startState any) {
+	if result == nil || *result == "" {
+		return
+	}
+
+	threshold := h.Threshold
+	if threshold <= 0 {
+		threshold = ArtifactHookDefaultThreshold
+	}
+	if len(*result) <= threshold {
+		return
+	}
+
+	// Don't re-save reads from the artifact directory itself.
+	if isReadingArtifact(args) {
+		return
+	}
+
+	session, ok := openagent.SessionFromContext(ctx)
+	if !ok {
+		return // no session context — passthrough
+	}
+
+	dir := filepath.Join(ArtifactRoot(), session.ID)
+	_ = os.MkdirAll(dir, 0755)
+
+	name := fmt.Sprintf("%s_%d.txt", sanitizeArtifactName(tool.Name), time.Now().UnixNano())
+	path := filepath.Join(dir, name)
+
+	raw := *result
+	_ = os.WriteFile(path, []byte(raw), 0644)
+
+	// Replace the result with a terse pointer. The model is smart enough
+	// to read/grep the file when it needs details.
+	sizeKB := (len(raw) + 1023) / 1024
+	prefix := h.Prefix
+	if prefix != "" {
+		prefix += ": "
+	}
+	*result = fmt.Sprintf("%sTool output saved to %s (%d KB, %d lines). Use read or grep to inspect.",
+		prefix, path, sizeKB, strings.Count(raw, "\n")+1)
+}
+
+// isReadingArtifact checks whether args contain a path inside the artifact
+// root. Used to prevent artifact-of-artifact recursion when read/grep
+// inspect a previously saved artifact.
+func isReadingArtifact(args json.RawMessage) bool {
+	var params struct {
+		Path string `json:"path"`
+	}
+	json.Unmarshal(args, &params)
+	return params.Path != "" && strings.HasPrefix(params.Path, ArtifactRoot())
+}
+
+// sanitizeArtifactName replaces characters that are unsafe in filenames
+// (slash, null) with underscores.
+func sanitizeArtifactName(name string) string {
+	name = strings.ReplaceAll(name, "/", "_")
+	name = strings.ReplaceAll(name, "\x00", "_")
+	return name
+}

--- a/tool/file.go
+++ b/tool/file.go
@@ -74,6 +74,8 @@ func (t *ReadFile) Definition() openagent.FunctionDefinition {
 	}
 }
 
+func (t *ReadFile) IsReadOnly() bool { return true }
+
 func (t *ReadFile) CanSelfApprove(args json.RawMessage) bool {
 	var params struct {
 		Path string `json:"path"`
@@ -306,6 +308,8 @@ func (t *ListDir) Definition() openagent.FunctionDefinition {
 		}`),
 	}
 }
+
+func (t *ListDir) IsReadOnly() bool { return true }
 
 func (t *ListDir) CanSelfApprove(args json.RawMessage) bool {
 	var params struct {

--- a/tool/grep.go
+++ b/tool/grep.go
@@ -50,6 +50,8 @@ func (t *Grep) Definition() openagent.FunctionDefinition {
 	}
 }
 
+func (t *Grep) IsReadOnly() bool { return true }
+
 func (t *Grep) CanSelfApprove(args json.RawMessage) bool {
 	var params struct {
 		Path string `json:"path"`


### PR DESCRIPTION
Two bug fixes:

Plan mode had a hardcoded `isPlanTool()` whitelist that only allowed 4 tools (plan_create, plan_update, exit_plan_mode, read_client_file). Agents could not explore the codebase to create informed plans.

**Changes:**
- Add `ReadOnly` interface in `tool.go` for side-effect-free tools (read, grep, ls, read_client_file)
- Add `PlanTool` interface in `tool.go` for plan workflow tools (plan_create, plan_update, exit_plan_mode — NOT enter_plan_mode)
- `agentForTurn` plan case: call ToolFactory, filter by ReadOnly so shell/write/edit are automatically excluded
- Move `oaSession` construction after plan tool injection in OnPrompt so `buildDynamicContext` sees the complete tool set
- Add `planAllowedTools` map to agentSession, populated at two points:
  - After all tool injection in OnPrompt (session starts in plan)
  - In enter_plan_mode callback (mid-turn transition) Only ReadOnly + PlanTool implementations are included
- Replace hardcoded `isPlanTool()` with `planAllowedTools` lookup for auto-exit detection
- `buildDynamicContext`: dynamically list available tools by category
- `injectExecutionTools`: make idempotent by checking for existing tool names before appending, preventing "Tool names must be unique" 400 errors when exit_plan_mode re-injects onto a clone that already has ReadOnly tools from agentForTurn plan path

When switching from plan mode to auto mode, the API returned: "Messages with role tool must be a response to a preceding message with tool_calls"

**Root cause:** `prepareMemory` token budget trimming could land on a non-first tool result in a batch (e.g. assistant with [call_00, call_01] → tool call_00 → tool call_01 ← boundary). `SafeCompressionBoundary` only handled single tool calls.

**Fix:** Skip leading orphan tool results after compression boundary to ensure the message array always starts with a valid message (assistant or user).

**Supporting changes:**
- `hooks.go`: Add `MultiRunHooks` to combine multiple RunHooks (same pattern as existing MultiObserver)
- `tool/artifact_hook.go`: New ArtifactHook saves large tool results (>64KB) to disk to prevent context window blowup
- `shared.go`: Always enable ArtifactHook regardless of --hooks flag
- `buildopts_test.go`: Update test for always-on ArtifactHook