### PR TITLE
feat(cli): add 'run' command for one-shot streaming chat

### DIFF
--- a/cmd/cli/DESIGN.md
+++ b/cmd/cli/DESIGN.md
@@ -141,6 +141,7 @@ The host never distinguishes between "user config" and "plugin config". Everythi
 ```
 openagent-cli
 ├─ serve [--acp] [--port N]        Built-in: REST or ACP server
+├─ run <message>                    Built-in: one-shot chat, streaming output
 ├─ keyring                          Built-in: credential management
 │  ├─ set <key> <value>
 │  ├─ get <key>
@@ -221,7 +222,15 @@ cmd/cli/
       loader.go                Instantiate, CallInit, ReadCommands, RunCommand
       observer.go              ObserverHub: OnStartup/OnShutdown/OnCommandStart/OnCommandEnd
       abi.go                   PluginMeta, Is() matcher, CommandDef
-  server/agent.go              Build openagent.Agent from Config, REST + ACP server
+  server/
+    cli.go                     RunCLI: one-shot chat entry, reuses shared builders
+    shared.go                  Shared agent builders: buildModels, buildTools, resolveProfiles
+    http.go                    RunREST: HTTP REST + SSE server
+    acp.go                     RunACP: ACP protocol server
+    channel.go                 IM channel integration (Feishu)
+    mcp.go                     MCP server connections
+    capabilities.go            Capabilities toggle struct
+    log.go                     Rotated file logging
   plugin/pdk/rust/                    Rust SDK crate (openagent-pdk)
   examples/plugin/
     extended-settings.rs       cli:settings  — reads keyring, merges provider+env
@@ -231,6 +240,27 @@ cmd/cli/
     openagent-cli              Compiled binary
     plugins/                   Compiled .wasm files
 ```
+
+---
+
+---
+
+## `run` command
+
+`run` sends a single message to the agent and streams the response to stdout in real time.
+
+```
+openagent-cli run "analyze main.go"
+```
+
+### Design
+
+- **Thin entry point.** `main.go` calls `server.RunCLI(ctx, cfg, message)` — a single function that encapsulates all setup and I/O.
+- **Same package as server.** `RunCLI` lives in `cmd/cli/server/cli.go`. It shares the package with `RunREST` and `RunACP`, calling the same unexported builders (`buildModels`, `resolveProfiles`, `buildTools`). No exported API surface changes.
+- **Full tool set.** The agent is created with `shell`, `read`, `write`, `ls`, `grep` — the same standard tools as the REST server. Sandbox policy comes from `settings.json` (default: unconfined). When sandbox creation fails, tools are disabled and a warning is printed to stderr.
+- **No persistence.** Each `run` creates a temporary session (`cli-<timestamp>`). No memory backend, no session store. One question, one answer.
+- **Streaming output.** Text deltas print to stdout immediately. Tool calls execute silently in the background. Token usage prints to stderr on completion.
+- **Max 50 turns.** Enough for multi-step tasks (e.g., `ls` → `grep` → `read` → analysis), bounded to prevent runaway loops.
 
 ---
 

--- a/cmd/cli/DESIGN.zh.md
+++ b/cmd/cli/DESIGN.zh.md
@@ -126,6 +126,7 @@ log_error(msg_ptr, msg_len)
 ```
 openagent-cli
 ├─ serve [--acp] [--port N]        内置: REST 或 ACP 服务
+├─ run <message>                    内置: 单轮对话，流式输出
 ├─ keyring                          内置: 凭证管理
 │  ├─ set <key> <value>
 │  ├─ get <key>
@@ -206,7 +207,15 @@ cmd/cli/
       loader.go               实例化、CallInit、ReadCommands、RunCommand
       observer.go             ObserverHub: OnStartup/OnShutdown/OnCommandStart/OnCommandEnd
       abi.go                  PluginMeta、Is() 匹配器、CommandDef
-  server/agent.go             从 Config 构建 openagent.Agent、REST + ACP 服务
+  server/
+    cli.go                     RunCLI: 单轮对话入口，复用共享构建函数
+    shared.go                  共享 Agent 构建器: buildModels, buildTools, resolveProfiles
+    http.go                    RunREST: HTTP REST + SSE 服务器
+    acp.go                     RunACP: ACP 协议服务器
+    channel.go                 IM 通道集成（飞书）
+    mcp.go                     MCP 服务器连接
+    capabilities.go            能力开关结构体
+    log.go                     日志文件轮转
   plugin/pdk/rust/                   Rust SDK crate (openagent-pdk)
   examples/plugin/
     extended-settings.rs      cli:settings  — 读 keyring、合并 provider+env
@@ -216,6 +225,27 @@ cmd/cli/
     openagent-cli             编译后的二进制
     plugins/                  编译后的 .wasm 文件
 ```
+
+---
+
+---
+
+## `run` 命令
+
+`run` 发送一条消息给 Agent，实时流式输出回复到终端。
+
+```
+openagent-cli run "分析 main.go 文件"
+```
+
+### 设计要点
+
+- **薄入口。** `main.go` 仅调用 `server.RunCLI(ctx, cfg, message)` — 一个函数封装所有设置和 I/O。
+- **与 server 同包。** `RunCLI` 位于 `cmd/cli/server/cli.go`，与 `RunREST`、`RunACP` 共享同一包，复用未导出的构建器（`buildModels`、`resolveProfiles`、`buildTools`），不导出额外 API。
+- **完整工具集。** Agent 创建时注册 `shell`、`read`、`write`、`ls`、`grep`，与 REST 服务器相同的标准工具集。Sandbox 策略来自 `settings.json`（默认不隔离）。Sandbox 创建失败时禁用工具并输出 stderr 警告。
+- **不持久化。** 每次 `run` 创建临时会话（`cli-<timestamp>`），无 memory 后端，无 session 存储。一问一答。
+- **流式输出。** 文本增量直接打印到 stdout。工具调用在后台静默执行。Token 用量在结束时输出到 stderr。
+- **最多 50 轮。** 足够完成多步骤任务（如 `ls` → `grep` → `read` → 分析），上限防止失控循环。
 
 ---
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -144,6 +144,7 @@ func main() {
 
 	// 6. Build cobra tree.
 	rootCmd.AddCommand(buildServeCmd(cfg))
+	rootCmd.AddCommand(buildRunCmd(cfg))
 	rootCmd.AddCommand(keyringCmd)
 
 	// 7. Wrap every command's RunE to notify observers on entry/exit.
@@ -372,6 +373,26 @@ func parseCapabilities(cmd *cobra.Command, caps *server.Capabilities) {
 	set("approver", &caps.Approver)
 	set("hooks", &caps.Hooks)
 	set("observer", &caps.Observer)
+}
+
+// ── run ──
+
+func buildRunCmd(cfg config.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run <message>",
+		Short: "Send a message and stream the response",
+		Long: `Send a message to the AI Agent and stream the response to stdout in real time.
+
+Wrap your message in quotes when it contains spaces:
+  openagent-cli run "analyze main.go"`,
+		Example: `  openagent-cli run "Hello, introduce yourself briefly"
+  openagent-cli run "analyze cmd/cli/main.go and summarize"`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return server.RunCLI(cmd.Context(), &cfg, args[0])
+		},
+	}
+	return cmd
 }
 
 // ── keyring ──

--- a/cmd/cli/server/run.go
+++ b/cmd/cli/server/run.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	openagent "github.com/yusheng-g/openagent-go"
+	"github.com/yusheng-g/openagent-go/cmd/cli/config"
+	"github.com/yusheng-g/openagent-go/sandbox/native"
+)
+
+// RunCLI runs a one-shot chat turn with streaming output to stdout.
+// It creates a lightweight agent (model + system prompts + standard tools),
+// sends the message, and streams text deltas to stdout in real time.
+func RunCLI(ctx context.Context, cfg *config.Config, message string) error {
+	// 1. Build model from config (unexported: buildModels, firstModel)
+	models, _ := buildModels(cfg.Provider)
+	m := firstModel(models)
+	if m == nil {
+		return fmt.Errorf("no models configured. Please add a provider in ~/.openagent/settings.json")
+	}
+
+	// 2. System prompts (unexported: resolveProfiles)
+	prompts := resolveProfiles(cfg.Profiles)
+
+	// 3. Sandbox + standard tools (unexported: sandboxPolicy, buildTools)
+	workDir, _ := os.Getwd()
+	policy := sandboxPolicy(cfg.Sandbox)
+	sb, err := native.NewWithPolicy(workDir, policy)
+	var tools []openagent.Tool
+	if err == nil {
+		tools = buildTools(sb, workDir, []string{"shell", "read", "write", "ls", "grep"})
+	} else {
+		fmt.Fprintf(os.Stderr, "sandbox unavailable, tools disabled: %v\n", err)
+	}
+
+	// 4. Construct agent
+	opts := []openagent.AgentOption{
+		openagent.WithModel(m),
+		openagent.WithSystemPrompts(prompts...),
+		openagent.WithMaxTurns(50),
+	}
+	if len(tools) > 0 {
+		opts = append(opts, openagent.WithTools(tools...))
+	}
+	agent := openagent.NewAgent("openagent", opts...)
+
+	// 5. Temporary session (one-shot, no persistence)
+	session := openagent.Session{
+		ID:        fmt.Sprintf("cli-%d", time.Now().UnixNano()),
+		CreatedAt: time.Now(),
+	}
+
+	// 6. Run and stream events to terminal
+	ch := agent.RunStream(ctx, session, openagent.UserMessage(message))
+	for evt := range ch {
+		switch evt.Type {
+		case openagent.StreamTextDelta:
+			fmt.Print(evt.Text)
+
+		case openagent.StreamDone:
+			fmt.Println()
+			if evt.Result != nil {
+				u := evt.Result.Usage
+				fmt.Fprintf(os.Stderr, "─── %d prompt + %d completion = %d tokens, %d turns\n",
+					u.PromptTokens, u.CompletionTokens, u.TotalTokens,
+					evt.Result.TurnCount)
+			}
+
+		case openagent.StreamError:
+			return evt.Error
+
+		case openagent.StreamAborted:
+			if evt.Error != nil {
+				return evt.Error
+			}
+			return ctx.Err()
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Add a new 'run' subcommand that sends a single message to the AI Agent
and streams the response to stdout in real time.

Usage:
  openagent-cli run "hello"
  openagent-cli run "analyze main.go"

New file cmd/cli/server/cli.go provides RunCLI, which reuses unexported
builders from shared.go (buildModels, resolveProfiles, buildTools) —
same-package pattern as RunREST and RunACP. No exported API changes.

Agent is created with full standard tools (shell, read, write, ls, grep)
and sandbox policy from settings.json. Sandbox failure gracefully disables
tools with a stderr warning. Each run uses a temporary session with no
persistence, capped at 50 turns.