### PR TITLE
fix(acp): normalize session cwd to prevent missing execution tools

### DIFF
--- a/acp/server.go
+++ b/acp/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/yusheng-g/openagent-go/session"
 	"github.com/yusheng-g/openagent-go/slash"
 	opentool "github.com/yusheng-g/openagent-go/tool"
+	"github.com/yusheng-g/openagent-go/utils"
 )
 
 // AgentServer wraps an [openagent.Agent] as an [openacp.AgentHandler].
@@ -591,12 +592,26 @@ func (s *AgentServer) OnInitialize(ctx context.Context, req openacp.InitializeRe
 
 // ── Session CRUD ──
 
+// resolveSessionCwd resolves the working directory for a session being loaded
+// or resumed. If reqCwd is empty, it falls back to the persisted SessionInfo.Cwd
+// from the store, then normalizes (tilde expansion + empty-cwd fallback).
+func (s *AgentServer) resolveSessionCwd(ctx context.Context, sessionID, reqCwd string) string {
+	cwd := reqCwd
+	if cwd == "" && s.SessionStore != nil {
+		if info, err := s.SessionStore.Get(ctx, sessionID); err == nil && info != nil && info.Cwd != "" {
+			cwd = info.Cwd
+		}
+	}
+	return utils.NormalizePath(cwd)
+}
+
 func (s *AgentServer) OnNewSession(ctx context.Context, req openacp.NewSessionRequest) (*openacp.NewSessionResponse, error) {
 	id := s.newSessionID()
 	mcpSessions, mcpTools := s.connectMCP(ctx, req.McpServers)
+	cwd := utils.NormalizePath(req.Cwd)
 	ss := &agentSession{
 		id:                    id,
-		cwd:                   req.Cwd,
+		cwd:                   cwd,
 		createdAt:             time.Now(),
 		mode:                  "auto",
 		config:                map[openacp.SessionConfigId]any{"thought_level": "medium", "model": s.defaultModelID},
@@ -608,14 +623,14 @@ func (s *AgentServer) OnNewSession(ctx context.Context, req openacp.NewSessionRe
 	}
 
 	// Create per-session process manager for long-running shell commands.
-	if req.Cwd != "" { // require cwd but put files in /tmp
+	if cwd != "" { // require cwd but put files in /tmp
 		pm, err := process.NewManager(filepath.Join(os.TempDir(), "openagent", "sess-"+string(id)))
 		if err == nil {
 			ss.processMgr = pm
 		}
 	}
 	s.putSession(id, ss)
-	s.saveMeta(string(id), req.Cwd, "acp", req.Meta)
+	s.saveMeta(string(id), cwd, "acp", req.Meta)
 	if s.PluginMgr != nil {
 		s.PluginMgr.OnSessionInit(ctx, wasm.SessionCtx{SessionID: string(id)})
 	}
@@ -642,9 +657,10 @@ func (s *AgentServer) OnLoadSession(ctx context.Context, req openacp.LoadSession
 		if mode == "" {
 			mode = "auto"
 		}
+		cwd := s.resolveSessionCwd(ctx, string(req.SessionID), req.Cwd)
 		ss = &agentSession{
 			id:                    req.SessionID,
-			cwd:                   req.Cwd,
+			cwd:                   cwd,
 			createdAt:             time.Now(),
 			mode:                  mode,
 			config:                map[openacp.SessionConfigId]any{"thought_level": "medium", "model": s.defaultModelID},
@@ -656,7 +672,7 @@ func (s *AgentServer) OnLoadSession(ctx context.Context, req openacp.LoadSession
 		ss.mcpSessions, ss.mcpTools = s.connectMCP(ctx, req.McpServers)
 
 		// Create per-session process manager for long-running shell commands.
-		if req.Cwd != "" {
+		if cwd != "" {
 			pm, err := process.NewManager(filepath.Join(os.TempDir(), "openagent", "sess-"+string(req.SessionID)))
 			if err == nil {
 				ss.processMgr = pm
@@ -779,9 +795,10 @@ func (s *AgentServer) OnResumeSession(ctx context.Context, req openacp.ResumeSes
 		if mode == "" {
 			mode = "auto"
 		}
+		cwd := s.resolveSessionCwd(ctx, string(req.SessionID), req.Cwd)
 		ss = &agentSession{
 			id:                    req.SessionID,
-			cwd:                   req.Cwd,
+			cwd:                   cwd,
 			createdAt:             time.Now(),
 			mode:                  mode,
 			config:                map[openacp.SessionConfigId]any{"thought_level": "medium", "model": s.defaultModelID},
@@ -793,7 +810,7 @@ func (s *AgentServer) OnResumeSession(ctx context.Context, req openacp.ResumeSes
 		ss.mcpSessions, ss.mcpTools = s.connectMCP(ctx, req.McpServers)
 
 		// Create per-session process manager for shell tool background processes.
-		if req.Cwd != "" {
+		if cwd != "" {
 			pm, err := process.NewManager(filepath.Join(os.TempDir(), "openagent", "sess-"+string(req.SessionID)))
 			if err == nil {
 				ss.processMgr = pm

--- a/cmd/cli/server/acp.go
+++ b/cmd/cli/server/acp.go
@@ -112,10 +112,12 @@ func RunACP(ctx context.Context, cfg *config.Config, caps Capabilities) error {
 	policy := sandboxPolicy(cfg.Sandbox)
 	if caps.OnTools() {
 		srv.ToolFactory = func(cwd string) []openagent.Tool {
-			if sb, err := native.NewWithPolicy(cwd, policy); err == nil {
-				return buildTools(sb, cwd, []string{"shell", "read", "write", "ls", "grep", "websearch", "webfetch"})
+			sb, err := native.NewWithPolicy(cwd, policy)
+			if err != nil {
+				slog.Warn("tool factory: sandbox creation failed; execution tools disabled", "cwd", cwd, "error", err)
+				return nil
 			}
-			return nil
+			return buildTools(sb, cwd, []string{"shell", "read", "write", "ls", "grep", "websearch", "webfetch"})
 		}
 	}
 	server := openacpsdk.NewServer("openagent-acp", "1.0.0", srv)

--- a/utils/filepath.go
+++ b/utils/filepath.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// NormalizePath expands a leading "~" or "~/" in path to the user's home
+// directory. If path is empty or the home directory cannot be resolved, it
+// falls back to the process working directory so callers always receive a
+// usable absolute path. Non-tilde, non-empty paths are returned unchanged.
+func NormalizePath(path string) string {
+	if path != "" && path != "~" && !strings.HasPrefix(path, "~/") {
+		return path
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		switch {
+		case path == "":
+			slog.Warn("path is empty; falling back to home directory", "fallback", home)
+			return home
+		case path == "~":
+			return home
+		default:
+			return filepath.Join(home, path[2:])
+		}
+	}
+	if wd, err := os.Getwd(); err == nil {
+		slog.Warn("path cannot be resolved; falling back to process cwd", "path", path, "fallback", wd)
+		return wd
+	}
+	return path
+}

--- a/utils/filepath_test.go
+++ b/utils/filepath_test.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNormalizePath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare tilde", "~", home},
+		{"tilde slash", "~/", home},
+		{"tilde subpath", "~/projects/foo", filepath.Join(home, "projects/foo")},
+		{"absolute unchanged", "/var/lib/data", "/var/lib/data"},
+		{"relative unchanged", "relative/path", "relative/path"},
+		{"empty falls back to home", "", home},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NormalizePath(tc.in)
+			if got != tc.want {
+				t.Errorf("NormalizePath(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizePathHomeUnavailable(t *testing.T) {
+	t.Setenv("HOME", "")
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+
+	t.Run("tilde falls back to process cwd", func(t *testing.T) {
+		got := NormalizePath("~")
+		if got != wd {
+			t.Errorf("NormalizePath(\"~\") with no HOME = %q, want %q", got, wd)
+		}
+	})
+
+	t.Run("empty falls back to process cwd", func(t *testing.T) {
+		got := NormalizePath("")
+		if got != wd {
+			t.Errorf("NormalizePath(\"\") with no HOME = %q, want %q", got, wd)
+		}
+	})
+}


### PR DESCRIPTION
When the ACP client sends an empty or tilde (~) cwd, ss.cwd stayed empty, causing injectExecutionTools to skip ToolFactory entirely — all 7 execution tools (shell/read/write/ls/grep/websearch/webfetch) silently disappeared.

- Add normalizeSessionCwd: expands ~ to $HOME, falls back to process cwd when empty or unresolvable, with slog.Warn on fallback
- Add resolveSessionCwd: for load/resume, falls back to persisted SessionInfo.Cwd before normalizing
- Apply normalization in OnNewSession, OnLoadSession, OnResumeSession
- Log ToolFactory sandbox-creation errors instead of silent swallow