### PR TITLE
fix(process): make Cleanup portable across Windows and unix

### DIFF
--- a/process/manager.go
+++ b/process/manager.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -251,7 +250,7 @@ func (m *Manager) List() []*Proc {
 	return out
 }
 
-// Cleanup kills every tracked process (SIGKILL), closes files, and removes
+// Cleanup kills every tracked process, closes files, and removes
 // the base directory. Call on session delete.
 func (m *Manager) Cleanup() error {
 	m.mu.Lock()
@@ -264,7 +263,11 @@ func (m *Manager) Cleanup() error {
 
 	for _, p := range procs {
 		if pid := p.PIDNow(); pid > 0 {
-			syscall.Kill(pid, syscall.SIGKILL)
+			// os.FindProcess + Kill is portable across unix and Windows,
+			// unlike syscall.Kill which is not defined on Windows.
+			if proc, err := os.FindProcess(pid); err == nil {
+				proc.Kill()
+			}
 		}
 		p.Close()
 		os.RemoveAll(p.DirNow())


### PR DESCRIPTION
## Problem

`process/manager.go` used `syscall.Kill(pid, syscall.SIGKILL)` in `Manager.Cleanup()`. `syscall.Kill` is **not defined on Windows**, so `GOOS=windows go build ./...` failed:

```
# github.com/yusheng-g/openagent-go/process
process/manager.go:267:12: undefined: syscall.Kill
```

This broke the entire `cmd/cli` binary on Windows, since it transitively depends on `process`.

## Fix

Replace `syscall.Kill(pid, syscall.SIGKILL)` with the portable `os.FindProcess(pid).Kill()`:

- **unix** → issues `kill(pid, SIGKILL)` (same behavior as before)
- **Windows** → calls `TerminateProcess` (the documented way to force-kill by PID)

Drop the now-unused `"syscall"` import and update the doc comment that referenced SIGKILL specifically.

## Verification

```text
GOOS=windows GOARCH=amd64 go build ./...   # PASS  (was FAIL)
GOOS=windows GOARCH=arm64 go build ./...   # PASS
GOOS=linux   GOARCH=amd64 go build ./...   # PASS
GOOS=linux   GOARCH=arm64 go build ./...   # PASS
GOOS=darwin  GOARCH=amd64 go build ./...   # PASS
GOOS=darwin  GOARCH=arm64 go build ./...   # PASS
GOOS=windows GOARCH=amd64 go vet ./...     # PASS
go test ./process/... ./tool/...           # PASS
```

Confirmed the failure is real by temporarily reverting the change — it reproduces `undefined: syscall.Kill` on Windows, then restoring the fix makes it pass.

## Notes

- `cmd/cli/main.go` references `syscall.SIGINT`/`syscall.SIGTERM`, but those constants **are** defined on Windows and `signal.NotifyContext` handles Ctrl-C correctly there, so no change was needed (and changing it would be scope creep).
- `sandbox/native` already had `native_{linux,darwin,windows}.go` platform files and compiled fine on Windows before this change.
- One file changed: `process/manager.go` (+6 −3).
