### PR TITLE
feat(hooks/redact): add built-in redact hook for sensitive env-var values

### DIFF
--- a/cmd/cli/config/config.go
+++ b/cmd/cli/config/config.go
@@ -34,6 +34,8 @@ type Config struct {
 // Scope limits: this redacts ONLY tool results/errors, NOT tool call
 // arguments (args). Only the exact value of a named env var is matched —
 // no regex, so unregistered secrets, PII, keys, etc. are not detected.
+// Values shorter than 8 characters are skipped (they are rarely real
+// secrets and would mis-mask normal output).
 // See the hooks/redact package doc for the full coverage scope and known
 // limitations (e.g. JSON-escaped secret values are not matched).
 type SensitiveConfig struct {

--- a/cmd/cli/config/config.go
+++ b/cmd/cli/config/config.go
@@ -19,6 +19,25 @@ type Config struct {
 	Plugins    []string                   `json:"plugins,omitempty"`
 	Profiles   string                     `json:"profiles,omitempty"`
 	Env        map[string]string          `json:"env,omitempty"`
+	Sensitive  SensitiveConfig            `json:"sensitive,omitempty"`
+}
+
+// SensitiveConfig controls redaction of sensitive values in tool results.
+//
+// Env is a list of environment-variable *names* (not values) whose values,
+// when present in a tool *result* (output) or error, are replaced with
+// "[REDACTED]" and flagged with a hint telling the model not to reconstruct
+// them. Values are resolved lazily via os.Getenv at redaction time, so
+// secrets never live in this struct and envvars set after agent construction
+// are still honored.
+//
+// Scope limits: this redacts ONLY tool results/errors, NOT tool call
+// arguments (args). Only the exact value of a named env var is matched —
+// no regex, so unregistered secrets, PII, keys, etc. are not detected.
+// See the hooks/redact package doc for the full coverage scope and known
+// limitations (e.g. JSON-escaped secret values are not matched).
+type SensitiveConfig struct {
+	Env []string `json:"env,omitempty"`
 }
 
 type ProviderConfig struct {

--- a/cmd/cli/server/acp.go
+++ b/cmd/cli/server/acp.go
@@ -66,7 +66,7 @@ func RunACP(ctx context.Context, cfg *config.Config, caps Capabilities) error {
 	if caps.OnMemory() {
 		opts = append(opts, openagent.WithMemory(mem))
 	}
-	opts = buildOpts(opts, caps, firstM)
+	opts = buildOpts(opts, caps, firstM, cfg.Sensitive)
 	agent := openagent.NewAgent("openagent", opts...)
 
 	if caps.OnMemory() && caps.OnSummarizer() && firstM != nil {

--- a/cmd/cli/server/buildopts_test.go
+++ b/cmd/cli/server/buildopts_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	openagent "github.com/yusheng-g/openagent-go"
+
+	"github.com/yusheng-g/openagent-go/cmd/cli/config"
 )
 
 // mockModel is a no-op Model used only to satisfy buildGuard's non-nil
@@ -58,7 +60,7 @@ func chdirWithSkills(t *testing.T) func() {
 // applyOpts runs buildOpts over a base option slice and constructs a real
 // Agent, so we can inspect the resulting exported fields.
 func applyOpts(caps Capabilities, model openagent.Model) *openagent.Agent {
-	opts := buildOpts(nil, caps, model)
+	opts := buildOpts(nil, caps, model, config.SensitiveConfig{})
 	return openagent.NewAgent("test", opts...)
 }
 
@@ -181,7 +183,7 @@ func TestBuildOpts_PreservesBaseOpts(t *testing.T) {
 		openagent.WithMaxTurns(42),
 		openagent.WithSystemPrompts("hello"),
 	}
-	opts := buildOpts(base, Capabilities{Hooks: &on}, mockModel{})
+	opts := buildOpts(base, Capabilities{Hooks: &on}, mockModel{}, config.SensitiveConfig{})
 	agent := openagent.NewAgent("t", opts...)
 	if agent.MaxTurns != 42 {
 		t.Errorf("MaxTurns = %d, want 42 (base option must survive)", agent.MaxTurns)

--- a/cmd/cli/server/http.go
+++ b/cmd/cli/server/http.go
@@ -63,7 +63,7 @@ func RunREST(ctx context.Context, cfg *config.Config, caps Capabilities) error {
 	if caps.OnTools() {
 		opts = append(opts, openagent.WithTools(tools...))
 	}
-	opts = buildOpts(opts, caps, m)
+	opts = buildOpts(opts, caps, m, cfg.Sensitive)
 	agent := openagent.NewAgent("openagent", opts...)
 
 	if caps.OnSummarizer() && m != nil && caps.OnMemory() {

--- a/cmd/cli/server/shared.go
+++ b/cmd/cli/server/shared.go
@@ -11,6 +11,7 @@ import (
 	openagent "github.com/yusheng-g/openagent-go"
 	"github.com/yusheng-g/openagent-go/guard/llm"
 	artifacthook "github.com/yusheng-g/openagent-go/hooks/artifact"
+	redacthook "github.com/yusheng-g/openagent-go/hooks/redact"
 	sloghooks "github.com/yusheng-g/openagent-go/hooks/slog"
 	"github.com/yusheng-g/openagent-go/memory/sqlite"
 	"github.com/yusheng-g/openagent-go/model/openai"
@@ -306,7 +307,12 @@ func buildSlogObserver() openagent.RunObserver {
 // buildOpts appends capability-gated agent options (skills, guard, hooks,
 // observer) to opts. model is used by the guard; it may be nil if no models
 // are configured, in which case the guard is skipped regardless of caps.
-func buildOpts(opts []openagent.AgentOption, caps Capabilities, model openagent.Model) []openagent.AgentOption {
+//
+// sensitive carries the user-configured sensitive env-var names; it is
+// honored only when caps.OnHooks() is true (redact rides the hooks pipeline).
+// Hook order is redact → slog → artifact: redact must run first so logs and
+// artifact files never see raw secrets.
+func buildOpts(opts []openagent.AgentOption, caps Capabilities, model openagent.Model, sensitive config.SensitiveConfig) []openagent.AgentOption {
 	if caps.OnSkills() {
 		if sl := openSkillLoader(); sl != nil {
 			opts = append(opts, openagent.WithSkillLoader(sl))
@@ -318,7 +324,12 @@ func buildOpts(opts []openagent.AgentOption, caps Capabilities, model openagent.
 		opts = append(opts, openagent.WithOutputGuard(g.Output()))
 	}
 	if caps.OnHooks() {
+		// Order: redact → slog → artifact. redact must run FIRST so every
+		// downstream observer (slog error logging, artifact disk save)
+		// sees already-redacted data. Putting slog before redact would
+		// write the raw secret into the log on tool errors.
 		opts = append(opts, openagent.WithRunHooks(
+			redacthook.NewHook(sensitive.Env),
 			buildSlogHooks(),
 			artifacthook.NewHook(),
 		))

--- a/hooks.go
+++ b/hooks.go
@@ -31,23 +31,6 @@ type RunHooks interface {
 	OnToolEnd(ctx context.Context, tool FunctionDefinition, args json.RawMessage, result *string, err *error, startState any)
 }
 
-// ResultBufferingHook is an optional capability a RunHooks may implement to
-// declare that it mutates tool results in OnToolEnd and therefore must see
-// the complete result before any of it is exposed downstream. When the
-// runner's active hook implements this interface, the streaming-tool path
-// suppresses real-time StreamToolProgress chunks and only emits the final
-// (post-hook) result — otherwise a hook that redacts secrets would run too
-// late: the raw chunks would already have reached the client/LLM.
-//
-// Hooks that only observe (slog, otel) and never mutate result/err should
-// NOT implement this interface, so streaming tools keep their live progress.
-type ResultBufferingHook interface {
-	// BufferToolResult reports whether OnToolEnd may mutate the result.
-	// Returning true makes the runner buffer streaming output until the
-	// tool finishes and OnToolEnd has run, then send one final event.
-	BufferToolResult() bool
-}
-
 // MultiHooks combines multiple RunHooks into one. Each hook is called in
 // order; one hook returning an error does not prevent subsequent hooks
 // from running. Nil hooks are skipped.
@@ -74,18 +57,6 @@ func MultiHooks(hooks ...RunHooks) RunHooks {
 
 type multiHooks struct {
 	list []RunHooks
-}
-
-// BufferToolResult reports whether any constituent hook buffers tool results.
-// If any child implements ResultBufferingHook and returns true, the combined
-// hook does too — one redacting hook is enough to require buffering.
-func (m *multiHooks) BufferToolResult() bool {
-	for _, h := range m.list {
-		if b, ok := h.(ResultBufferingHook); ok && b.BufferToolResult() {
-			return true
-		}
-	}
-	return false
 }
 
 func (m *multiHooks) OnAgentStart(ctx context.Context, req ChatCompletionRequest) (any, error) {

--- a/hooks.go
+++ b/hooks.go
@@ -31,6 +31,23 @@ type RunHooks interface {
 	OnToolEnd(ctx context.Context, tool FunctionDefinition, args json.RawMessage, result *string, err *error, startState any)
 }
 
+// ResultBufferingHook is an optional capability a RunHooks may implement to
+// declare that it mutates tool results in OnToolEnd and therefore must see
+// the complete result before any of it is exposed downstream. When the
+// runner's active hook implements this interface, the streaming-tool path
+// suppresses real-time StreamToolProgress chunks and only emits the final
+// (post-hook) result — otherwise a hook that redacts secrets would run too
+// late: the raw chunks would already have reached the client/LLM.
+//
+// Hooks that only observe (slog, otel) and never mutate result/err should
+// NOT implement this interface, so streaming tools keep their live progress.
+type ResultBufferingHook interface {
+	// BufferToolResult reports whether OnToolEnd may mutate the result.
+	// Returning true makes the runner buffer streaming output until the
+	// tool finishes and OnToolEnd has run, then send one final event.
+	BufferToolResult() bool
+}
+
 // MultiHooks combines multiple RunHooks into one. Each hook is called in
 // order; one hook returning an error does not prevent subsequent hooks
 // from running. Nil hooks are skipped.
@@ -57,6 +74,18 @@ func MultiHooks(hooks ...RunHooks) RunHooks {
 
 type multiHooks struct {
 	list []RunHooks
+}
+
+// BufferToolResult reports whether any constituent hook buffers tool results.
+// If any child implements ResultBufferingHook and returns true, the combined
+// hook does too — one redacting hook is enough to require buffering.
+func (m *multiHooks) BufferToolResult() bool {
+	for _, h := range m.list {
+		if b, ok := h.(ResultBufferingHook); ok && b.BufferToolResult() {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *multiHooks) OnAgentStart(ctx context.Context, req ChatCompletionRequest) (any, error) {

--- a/hooks/redact/hook.go
+++ b/hooks/redact/hook.go
@@ -20,6 +20,10 @@
 //     value of a named env var is matched (plain substring, no regex).
 //     PII, credit cards, AWS keys, private keys, JWTs, etc. are NOT
 //     detected unless their value happens to be an env var listed here.
+//   - env-var values shorter than 8 characters. Short values are skipped to
+//     avoid mis-masking normal output (e.g. "x", "true", "us-east"). A real
+//     secret shorter than 8 chars will silently pass through — do not rely
+//     on this hook for very short secrets.
 //   - secrets whose value contains JSON special characters (", \, control
 //     chars) when the result is JSON. The env-var holds the raw (unescaped)
 //     value, but inside a JSON string it is escaped (e.g. `"` → `\"`), so
@@ -57,6 +61,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	openagent "github.com/yusheng-g/openagent-go"
@@ -66,10 +71,10 @@ import (
 const redacted = "[REDACTED]"
 
 // hint is appended once to the result when any redaction occurred.
-const hint = "\n\n[hint] 以上结果包含敏感信息，已脱敏。不要试图复原该值。"
+const hint = "\n\n[REDACTED] values were present in this result and have been masked. Do not attempt to reconstruct them."
 
 // Hook masks sensitive env-var values in tool results. Implements
-// openagent.RunHooks and ResultBufferingHook.
+// openagent.RunHooks.
 type Hook struct {
 	envNames []string
 }
@@ -93,12 +98,6 @@ func NewHook(envNames []string) *Hook {
 	}
 	return &Hook{envNames: clean}
 }
-
-// BufferToolResult reports true: this hook mutates tool results in OnToolEnd,
-// so the runner must buffer streaming output and only expose the final,
-// redacted result. Without buffering, raw secret-bearing chunks would reach
-// the client/LLM before OnToolEnd runs. Implements ResultBufferingHook.
-func (h *Hook) BufferToolResult() bool { return len(h.envNames) > 0 }
 
 // OnAgentStart is a no-op.
 func (h *Hook) OnAgentStart(ctx context.Context, req openagent.ChatCompletionRequest) (any, error) {
@@ -150,7 +149,7 @@ func (h *Hook) OnToolEnd(ctx context.Context, tool openagent.FunctionDefinition,
 // orig is the pre-redaction string, used only to avoid double-hinting when
 // the original already carried a hint from a prior redaction.
 func applyHint(s, orig string) string {
-	if strings.Contains(orig, "[hint]") {
+	if strings.Contains(orig, hint) {
 		// Already hinted in a prior pass — don't stack.
 		return s
 	}
@@ -161,15 +160,39 @@ func applyHint(s, orig string) string {
 	return s + hint
 }
 
+// minSecretLen is the minimum length a secret value must have to be
+// redacted. Shorter values are skipped: a 1–7 char env-var value (e.g. a
+// region code, a mode flag) is almost never a real secret, and redacting
+// it would mis-mask large swaths of normal output (every occurrence of "x",
+// "true", "us-east"…). Real secrets (API keys, tokens) are far longer.
+const minSecretLen = 8
+
 // redactString replaces every sensitive value in s with "[REDACTED]" and
 // reports whether any replacement occurred.
+//
+// Values are resolved lazily via os.Getenv. Empty values and values shorter
+// than minSecretLen are skipped. Surviving values are replaced longest-first
+// so a shorter secret that is a substring of a longer one cannot partially
+// consume it and block the longer match — e.g. with TOKEN_A="abcdef" and
+// TOKEN_B="abc", replacing "abc" first would turn "abcdef" into
+// "[REDACTED]def" and leak "def". Longest-first guarantees the longer
+// value matches cleanly before the shorter one gets a chance.
 func redactString(s string, envNames []string) (string, bool) {
-	changed := false
+	// Resolve and filter values up front.
+	values := make([]string, 0, len(envNames))
 	for _, name := range envNames {
 		v := os.Getenv(name)
-		if v == "" {
+		if len(v) < minSecretLen {
 			continue
 		}
+		values = append(values, v)
+	}
+	// Longest-first so substring secrets don't clobber longer matches.
+	sort.SliceStable(values, func(i, j int) bool {
+		return len(values[i]) > len(values[j])
+	})
+	changed := false
+	for _, v := range values {
 		if strings.Contains(s, v) {
 			s = strings.ReplaceAll(s, v, redacted)
 			changed = true

--- a/hooks/redact/hook.go
+++ b/hooks/redact/hook.go
@@ -1,0 +1,179 @@
+// Package redact provides a RunHooks implementation that masks sensitive
+// environment-variable values in tool results. Each configured env-var name
+// is resolved at redaction time via os.Getenv; if its value appears in the
+// tool result, every occurrence is replaced with "[REDACTED]" and a hint is
+// appended telling the model the value was sensitive and must not be
+// reconstructed.
+//
+// The hook stores env-var *names* only — secret values are never held in
+// struct state and are resolved lazily so construction order (e.g. env set
+// after agent creation) does not matter.
+//
+// # Coverage scope — read carefully
+//
+// This hook ONLY redacts the *result* (output) and *error* of a tool call.
+// It does NOT redact:
+//   - tool call *arguments* (args) — the LLM may place secrets in args
+//     (e.g. shell command, http headers, DB DSN); those are stored in
+//     memory and sent to the client unredacted.
+//   - secrets that were not pre-registered as env-var names. Only the exact
+//     value of a named env var is matched (plain substring, no regex).
+//     PII, credit cards, AWS keys, private keys, JWTs, etc. are NOT
+//     detected unless their value happens to be an env var listed here.
+//   - secrets whose value contains JSON special characters (", \, control
+//     chars) when the result is JSON. The env-var holds the raw (unescaped)
+//     value, but inside a JSON string it is escaped (e.g. `"` → `\"`), so
+//     the byte-level substring match silently fails and the secret passes
+//     through. This is a known limitation of text-level matching; a
+//     JSON-aware redactor would be needed to cover it.
+//
+// For a hook that redacts args or matches regex patterns, extend this
+// package or compose another hook — that is out of scope for this one.
+//
+// # Ordering with other hooks
+//
+// redact must run FIRST (before slog, artifact) so downstream observers
+// never see raw secrets in logs or on disk. This ordering is established by
+// the caller in buildOpts, not by this hook.
+//
+// # Failure mode
+//
+// redaction never fails: it uses only os.Getenv + strings.ReplaceAll, which
+// cannot error. If this hook is ever extended with regex or JSON parsing,
+// the degradation policy is: on any internal failure, replace the whole
+// result with a safe placeholder rather than return the original (leaking)
+// data. Never fall back to the unredacted input.
+//
+// Usage:
+//
+//	agent := openagent.NewAgent("bot",
+//	    openagent.WithRunHooks(redact.NewHook([]string{"AWS_SECRET_ACCESS_KEY"})),
+//	    ...
+//	)
+package redact
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	openagent "github.com/yusheng-g/openagent-go"
+)
+
+// redacted is the placeholder substituted for every sensitive value.
+const redacted = "[REDACTED]"
+
+// hint is appended once to the result when any redaction occurred.
+const hint = "\n\n[hint] 以上结果包含敏感信息，已脱敏。不要试图复原该值。"
+
+// Hook masks sensitive env-var values in tool results. Implements
+// openagent.RunHooks and ResultBufferingHook.
+type Hook struct {
+	envNames []string
+}
+
+// NewHook creates a Hook that redacts the values of the given env-var names.
+// A nil or empty slice yields a hook that never modifies results.
+func NewHook(envNames []string) *Hook {
+	// Dedup and drop empty names so OnToolEnd does no redundant work and
+	// os.Getenv("") is never called.
+	seen := make(map[string]struct{}, len(envNames))
+	clean := make([]string, 0, len(envNames))
+	for _, n := range envNames {
+		if n == "" {
+			continue
+		}
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		clean = append(clean, n)
+	}
+	return &Hook{envNames: clean}
+}
+
+// BufferToolResult reports true: this hook mutates tool results in OnToolEnd,
+// so the runner must buffer streaming output and only expose the final,
+// redacted result. Without buffering, raw secret-bearing chunks would reach
+// the client/LLM before OnToolEnd runs. Implements ResultBufferingHook.
+func (h *Hook) BufferToolResult() bool { return len(h.envNames) > 0 }
+
+// OnAgentStart is a no-op.
+func (h *Hook) OnAgentStart(ctx context.Context, req openagent.ChatCompletionRequest) (any, error) {
+	return nil, nil
+}
+
+// OnAgentEnd is a no-op.
+func (h *Hook) OnAgentEnd(ctx context.Context, req openagent.ChatCompletionRequest, resp *openagent.ChatCompletionResponse, runErr error, startState any) {
+}
+
+// OnToolStart is a no-op. Tool args are not redacted by this hook (see
+// package doc — Coverage scope).
+func (h *Hook) OnToolStart(ctx context.Context, tool openagent.FunctionDefinition, args json.RawMessage) (any, error) {
+	return nil, nil
+}
+
+// OnToolEnd replaces every occurrence of each sensitive env-var value in
+// *result with "[REDACTED]". If any replacement happened, a hint is appended
+// once (idempotently). The error string is redacted likewise when *err != nil.
+//
+// Values are resolved lazily via os.Getenv so secrets never live in hook
+// state and envvars set after construction are still honored. Empty values
+// (unset or blank env vars) are skipped — redacting the empty string would
+// corrupt every result.
+//
+// If the result is valid JSON, the hint is NOT appended as a trailing string
+// (that would break JSON validity); the redaction still happens in-place
+// and the result stays parseable.
+func (h *Hook) OnToolEnd(ctx context.Context, tool openagent.FunctionDefinition, args json.RawMessage, result *string, err *error, startState any) {
+	if len(h.envNames) == 0 {
+		return
+	}
+	if result != nil && *result != "" {
+		if r, ok := redactString(*result, h.envNames); ok {
+			*result = applyHint(r, *result)
+		}
+	}
+	if err != nil && *err != nil {
+		if s, ok := redactString((*err).Error(), h.envNames); ok {
+			// err is free-form text, never JSON-parsed downstream, so a
+			// trailing hint is always safe.
+			*err = fmt.Errorf("%s%s", s, hint)
+		}
+	}
+}
+
+// applyHint appends the redaction hint to s unless s already contains it
+// (idempotent) or s is valid JSON (appending would break JSON validity).
+// orig is the pre-redaction string, used only to avoid double-hinting when
+// the original already carried a hint from a prior redaction.
+func applyHint(s, orig string) string {
+	if strings.Contains(orig, "[hint]") {
+		// Already hinted in a prior pass — don't stack.
+		return s
+	}
+	if json.Valid([]byte(s)) {
+		// Result is (still) valid JSON: don't append trailing text.
+		return s
+	}
+	return s + hint
+}
+
+// redactString replaces every sensitive value in s with "[REDACTED]" and
+// reports whether any replacement occurred.
+func redactString(s string, envNames []string) (string, bool) {
+	changed := false
+	for _, name := range envNames {
+		v := os.Getenv(name)
+		if v == "" {
+			continue
+		}
+		if strings.Contains(s, v) {
+			s = strings.ReplaceAll(s, v, redacted)
+			changed = true
+		}
+	}
+	return s, changed
+}

--- a/hooks/redact/hook_test.go
+++ b/hooks/redact/hook_test.go
@@ -52,8 +52,8 @@ func TestOnToolEnd_EmptyEnvValue_Skipped(t *testing.T) {
 }
 
 func TestOnToolEnd_EmptyResult_ShortCircuit(t *testing.T) {
-	// Empty result must not enter the redaction loop (🟡-1).
-	withEnv(t, "REDACT_ER", "x")
+	// Empty result must not enter the redaction loop.
+	withEnv(t, "REDACT_ER", "xsecret1")
 	h := NewHook([]string{"REDACT_ER"})
 	res := ""
 	h.OnToolEnd(context.Background(), openagent.FunctionDefinition{}, nil, &res, nil, nil)
@@ -73,37 +73,37 @@ func TestOnToolEnd_SingleHit_RedactedWithHint(t *testing.T) {
 	if !strings.Contains(res, "[REDACTED]") {
 		t.Fatalf("result missing [REDACTED]: %q", res)
 	}
-	if !strings.Contains(res, "[hint]") {
+	if !strings.Contains(res, hint) {
 		t.Fatalf("result missing hint: %q", res)
 	}
 }
 
 func TestOnToolEnd_MultipleOccurrences_AllReplaced(t *testing.T) {
-	withEnv(t, "REDACT_TOK", "abc")
+	withEnv(t, "REDACT_TOK", "abcdef12")
 	h := NewHook([]string{"REDACT_TOK"})
-	res := "abc and abc and again abc"
+	res := "abcdef12 and abcdef12 and again abcdef12"
 	h.OnToolEnd(context.Background(), openagent.FunctionDefinition{}, nil, &res, nil, nil)
-	want := strings.ReplaceAll("abc and abc and again abc", "abc", "[REDACTED]") + hint
+	want := strings.ReplaceAll("abcdef12 and abcdef12 and again abcdef12", "abcdef12", "[REDACTED]") + hint
 	if res != want {
 		t.Fatalf("got %q want %q", res, want)
 	}
 }
 
 func TestOnToolEnd_MultipleSecrets_HintAppendedOnce(t *testing.T) {
-	withEnv(t, "REDACT_A", "AAA", "REDACT_B", "BBB")
+	withEnv(t, "REDACT_A", "AAAAsecret", "REDACT_B", "BBBBsecret")
 	h := NewHook([]string{"REDACT_A", "REDACT_B"})
-	res := "AAA here, BBB there, AAA again"
+	res := "AAAAsecret here, BBBBsecret there, AAAAsecret again"
 	h.OnToolEnd(context.Background(), openagent.FunctionDefinition{}, nil, &res, nil, nil)
-	if strings.Contains(res, "AAA") || strings.Contains(res, "BBB") {
+	if strings.Contains(res, "AAAAsecret") || strings.Contains(res, "BBBBsecret") {
 		t.Fatalf("secret leaked: %q", res)
 	}
-	if c := strings.Count(res, "[hint]"); c != 1 {
+	if c := strings.Count(res, hint); c != 1 {
 		t.Fatalf("hint count = %d, want 1: %q", c, res)
 	}
 }
 
 func TestOnToolEnd_NoHit_Unchanged(t *testing.T) {
-	withEnv(t, "REDACT_X", "xyz")
+	withEnv(t, "REDACT_X", "xyzsecret")
 	h := NewHook([]string{"REDACT_X"})
 	out := "completely unrelated output"
 	res := out
@@ -114,7 +114,7 @@ func TestOnToolEnd_NoHit_Unchanged(t *testing.T) {
 }
 
 func TestOnToolEnd_NilResult_NoPanic(t *testing.T) {
-	withEnv(t, "REDACT_N", "n")
+	withEnv(t, "REDACT_N", "nosecret")
 	h := NewHook([]string{"REDACT_N"})
 	h.OnToolEnd(context.Background(), openagent.FunctionDefinition{}, nil, nil, nil, nil)
 }
@@ -150,7 +150,7 @@ func TestOnToolEnd_LazyResolution_EnvSetAfterConstruction(t *testing.T) {
 
 func TestOnToolEnd_JSONResult_NoTrailingHint(t *testing.T) {
 	// A JSON result must stay valid JSON after redaction — no trailing
-	// hint appended (🟡-3).
+	// hint appended.
 	withEnv(t, "REDACT_J", "supersecret")
 	h := NewHook([]string{"REDACT_J"})
 	res := `{"token":"supersecret","ok":true}`
@@ -161,40 +161,40 @@ func TestOnToolEnd_JSONResult_NoTrailingHint(t *testing.T) {
 	if !strings.Contains(res, "[REDACTED]") {
 		t.Fatalf("missing [REDACTED]: %q", res)
 	}
-	if strings.Contains(res, "[hint]") {
+	if strings.Contains(res, hint) {
 		t.Fatalf("hint appended to JSON result, breaking validity: %q", res)
 	}
 }
 
 func TestOnToolEnd_HintIdempotent_AlreadyHinted(t *testing.T) {
 	// If the result already carries a hint (e.g. reprocessed), don't
-	// stack a second one (🟡-2).
-	withEnv(t, "REDACT_I", "sec")
+	// stack a second one.
+	withEnv(t, "REDACT_I", "secsecret")
 	h := NewHook([]string{"REDACT_I"})
-	res := "sec here" + hint
+	res := "secsecret here" + hint
 	h.OnToolEnd(context.Background(), openagent.FunctionDefinition{}, nil, &res, nil, nil)
-	if c := strings.Count(res, "[hint]"); c != 1 {
+	if c := strings.Count(res, hint); c != 1 {
 		t.Fatalf("hint count = %d, want 1 (idempotent): %q", c, res)
 	}
 }
 
 func TestNewHook_DedupAndDropEmpty(t *testing.T) {
-	// 🔵-1: duplicate and empty names are collapsed.
-	withEnv(t, "REDACT_D", "val")
+	// duplicate and empty names are collapsed.
+	withEnv(t, "REDACT_D", "sensitive-dedup-token")
 	h := NewHook([]string{"REDACT_D", "REDACT_D", "", "REDACT_D"})
-	res := "val"
+	res := "sensitive-dedup-token"
 	h.OnToolEnd(context.Background(), openagent.FunctionDefinition{}, nil, &res, nil, nil)
-	if strings.Contains(res, "val") {
+	if strings.Contains(res, "sensitive-dedup-token") {
 		t.Fatalf("secret leaked despite dup/empty names: %q", res)
 	}
 	// Functional check: envNames deduped to 1, no panic, no double hint.
-	if c := strings.Count(res, "[hint]"); c != 1 {
+	if c := strings.Count(res, hint); c != 1 {
 		t.Fatalf("hint count = %d, want 1: %q", c, res)
 	}
 }
 
 func TestOnToolEnd_ConcurrentSafe(t *testing.T) {
-	// 🟡-4: multiple goroutines using the same Hook must be safe.
+	// multiple goroutines using the same Hook must be safe.
 	// Hook.envNames is read-only and os.Getenv is concurrency-safe; this
 	// test pins the invariant so future mutable state (e.g. regex cache)
 	// won't silently introduce a data race.
@@ -214,4 +214,35 @@ func TestOnToolEnd_ConcurrentSafe(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+func TestOnToolEnd_ShortValueSkipped(t *testing.T) {
+	// Values shorter than minSecretLen (8) are not real secrets and are
+	// skipped — redacting "x" or "true" would corrupt vast swaths of output.
+	withEnv(t, "REDACT_SHORT", "abc")
+	h := NewHook([]string{"REDACT_SHORT"})
+	out := "the value abc appears here"
+	res := out
+	h.OnToolEnd(context.Background(), openagent.FunctionDefinition{}, nil, &res, nil, nil)
+	if res != out {
+		t.Fatalf("short value was redacted (should be skipped): %q", res)
+	}
+}
+
+func TestOnToolEnd_LongestFirst_NestedSecrets(t *testing.T) {
+	// When one secret value is a substring of another, the longer one must
+	// be replaced first. Otherwise the shorter one would partially consume
+	// the longer match and leak the remainder.
+	withEnv(t, "REDACT_LONG", "abcdef1234", "REDACT_SHORT", "abcdef12")
+	h := NewHook([]string{"REDACT_SHORT", "REDACT_LONG"}) // short listed first on purpose
+	res := "token=abcdef1234 here"
+	h.OnToolEnd(context.Background(), openagent.FunctionDefinition{}, nil, &res, nil, nil)
+	// The long value must be fully redacted; "34" must not leak as a
+	// leftover from a partial short-match.
+	if strings.Contains(res, "abcdef1234") || strings.Contains(res, "abcdef12") {
+		t.Fatalf("secret leaked: %q", res)
+	}
+	if !strings.Contains(res, "[REDACTED]") {
+		t.Fatalf("missing [REDACTED]: %q", res)
+	}
 }

--- a/hooks/redact/hook_test.go
+++ b/hooks/redact/hook_test.go
@@ -1,0 +1,217 @@
+package redact
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	openagent "github.com/yusheng-g/openagent-go"
+)
+
+// withEnv sets env vars for a test; t.Setenv handles save/restore.
+func withEnv(t *testing.T, kv ...string) {
+	t.Helper()
+	if len(kv)%2 != 0 {
+		t.Fatal("withEnv: odd number of kv args")
+	}
+	for i := 0; i < len(kv); i += 2 {
+		t.Setenv(kv[i], kv[i+1])
+	}
+}
+
+func TestOnToolEnd_NoEnvNames_NoOp(t *testing.T) {
+	h := NewHook(nil)
+	out := "secret: abc"
+	res := out
+	h.OnToolEnd(context.Background(), openagent.FunctionDefinition{}, nil, &res, nil, nil)
+	if res != out {
+		t.Fatalf("nil envNames modified result: %q", res)
+	}
+
+	h2 := NewHook([]string{})
+	res2 := out
+	h2.OnToolEnd(context.Background(), openagent.FunctionDefinition{}, nil, &res2, nil, nil)
+	if res2 != out {
+		t.Fatalf("empty envNames modified result: %q", res2)
+	}
+}
+
+func TestOnToolEnd_EmptyEnvValue_Skipped(t *testing.T) {
+	// An unset/empty env var must be skipped — redacting "" would insert
+	// "[REDACTED]" between every rune and corrupt all output.
+	withEnv(t, "REDACT_EMPTY", "")
+	h := NewHook([]string{"REDACT_EMPTY"})
+	out := "nothing to see here"
+	res := out
+	h.OnToolEnd(context.Background(), openagent.FunctionDefinition{}, nil, &res, nil, nil)
+	if res != out {
+		t.Fatalf("empty-valued env var corrupted result: %q", res)
+	}
+}
+
+func TestOnToolEnd_EmptyResult_ShortCircuit(t *testing.T) {
+	// Empty result must not enter the redaction loop (🟡-1).
+	withEnv(t, "REDACT_ER", "x")
+	h := NewHook([]string{"REDACT_ER"})
+	res := ""
+	h.OnToolEnd(context.Background(), openagent.FunctionDefinition{}, nil, &res, nil, nil)
+	if res != "" {
+		t.Fatalf("empty result modified: %q", res)
+	}
+}
+
+func TestOnToolEnd_SingleHit_RedactedWithHint(t *testing.T) {
+	withEnv(t, "REDACT_TOKEN", "supersecret")
+	h := NewHook([]string{"REDACT_TOKEN"})
+	res := "the token is supersecret and that is bad"
+	h.OnToolEnd(context.Background(), openagent.FunctionDefinition{}, nil, &res, nil, nil)
+	if strings.Contains(res, "supersecret") {
+		t.Fatalf("secret leaked in result: %q", res)
+	}
+	if !strings.Contains(res, "[REDACTED]") {
+		t.Fatalf("result missing [REDACTED]: %q", res)
+	}
+	if !strings.Contains(res, "[hint]") {
+		t.Fatalf("result missing hint: %q", res)
+	}
+}
+
+func TestOnToolEnd_MultipleOccurrences_AllReplaced(t *testing.T) {
+	withEnv(t, "REDACT_TOK", "abc")
+	h := NewHook([]string{"REDACT_TOK"})
+	res := "abc and abc and again abc"
+	h.OnToolEnd(context.Background(), openagent.FunctionDefinition{}, nil, &res, nil, nil)
+	want := strings.ReplaceAll("abc and abc and again abc", "abc", "[REDACTED]") + hint
+	if res != want {
+		t.Fatalf("got %q want %q", res, want)
+	}
+}
+
+func TestOnToolEnd_MultipleSecrets_HintAppendedOnce(t *testing.T) {
+	withEnv(t, "REDACT_A", "AAA", "REDACT_B", "BBB")
+	h := NewHook([]string{"REDACT_A", "REDACT_B"})
+	res := "AAA here, BBB there, AAA again"
+	h.OnToolEnd(context.Background(), openagent.FunctionDefinition{}, nil, &res, nil, nil)
+	if strings.Contains(res, "AAA") || strings.Contains(res, "BBB") {
+		t.Fatalf("secret leaked: %q", res)
+	}
+	if c := strings.Count(res, "[hint]"); c != 1 {
+		t.Fatalf("hint count = %d, want 1: %q", c, res)
+	}
+}
+
+func TestOnToolEnd_NoHit_Unchanged(t *testing.T) {
+	withEnv(t, "REDACT_X", "xyz")
+	h := NewHook([]string{"REDACT_X"})
+	out := "completely unrelated output"
+	res := out
+	h.OnToolEnd(context.Background(), openagent.FunctionDefinition{}, nil, &res, nil, nil)
+	if res != out {
+		t.Fatalf("no-hit result modified: %q", res)
+	}
+}
+
+func TestOnToolEnd_NilResult_NoPanic(t *testing.T) {
+	withEnv(t, "REDACT_N", "n")
+	h := NewHook([]string{"REDACT_N"})
+	h.OnToolEnd(context.Background(), openagent.FunctionDefinition{}, nil, nil, nil, nil)
+}
+
+func TestOnToolEnd_ErrorString_Redacted(t *testing.T) {
+	withEnv(t, "REDACT_E", "leaked-in-error")
+	h := NewHook([]string{"REDACT_E"})
+	e := errors.New("tool failed: leaked-in-error")
+	h.OnToolEnd(context.Background(), openagent.FunctionDefinition{}, nil, nil, &e, nil)
+	if e == nil {
+		t.Fatal("err became nil")
+	}
+	if strings.Contains(e.Error(), "leaked-in-error") {
+		t.Fatalf("secret leaked in error: %q", e.Error())
+	}
+	if !strings.Contains(e.Error(), "[REDACTED]") {
+		t.Fatalf("error missing [REDACTED]: %q", e.Error())
+	}
+}
+
+func TestOnToolEnd_LazyResolution_EnvSetAfterConstruction(t *testing.T) {
+	// Hook constructed before the env var exists; value set after must
+	// still be honored at redaction time (lazy os.Getenv).
+	t.Setenv("REDACT_LATE", "")
+	h := NewHook([]string{"REDACT_LATE"})
+	t.Setenv("REDACT_LATE", "late-value")
+	res := "contains late-value here"
+	h.OnToolEnd(context.Background(), openagent.FunctionDefinition{}, nil, &res, nil, nil)
+	if strings.Contains(res, "late-value") {
+		t.Fatalf("lazily-resolved secret leaked: %q", res)
+	}
+}
+
+func TestOnToolEnd_JSONResult_NoTrailingHint(t *testing.T) {
+	// A JSON result must stay valid JSON after redaction — no trailing
+	// hint appended (🟡-3).
+	withEnv(t, "REDACT_J", "supersecret")
+	h := NewHook([]string{"REDACT_J"})
+	res := `{"token":"supersecret","ok":true}`
+	h.OnToolEnd(context.Background(), openagent.FunctionDefinition{}, nil, &res, nil, nil)
+	if strings.Contains(res, "supersecret") {
+		t.Fatalf("secret leaked: %q", res)
+	}
+	if !strings.Contains(res, "[REDACTED]") {
+		t.Fatalf("missing [REDACTED]: %q", res)
+	}
+	if strings.Contains(res, "[hint]") {
+		t.Fatalf("hint appended to JSON result, breaking validity: %q", res)
+	}
+}
+
+func TestOnToolEnd_HintIdempotent_AlreadyHinted(t *testing.T) {
+	// If the result already carries a hint (e.g. reprocessed), don't
+	// stack a second one (🟡-2).
+	withEnv(t, "REDACT_I", "sec")
+	h := NewHook([]string{"REDACT_I"})
+	res := "sec here" + hint
+	h.OnToolEnd(context.Background(), openagent.FunctionDefinition{}, nil, &res, nil, nil)
+	if c := strings.Count(res, "[hint]"); c != 1 {
+		t.Fatalf("hint count = %d, want 1 (idempotent): %q", c, res)
+	}
+}
+
+func TestNewHook_DedupAndDropEmpty(t *testing.T) {
+	// 🔵-1: duplicate and empty names are collapsed.
+	withEnv(t, "REDACT_D", "val")
+	h := NewHook([]string{"REDACT_D", "REDACT_D", "", "REDACT_D"})
+	res := "val"
+	h.OnToolEnd(context.Background(), openagent.FunctionDefinition{}, nil, &res, nil, nil)
+	if strings.Contains(res, "val") {
+		t.Fatalf("secret leaked despite dup/empty names: %q", res)
+	}
+	// Functional check: envNames deduped to 1, no panic, no double hint.
+	if c := strings.Count(res, "[hint]"); c != 1 {
+		t.Fatalf("hint count = %d, want 1: %q", c, res)
+	}
+}
+
+func TestOnToolEnd_ConcurrentSafe(t *testing.T) {
+	// 🟡-4: multiple goroutines using the same Hook must be safe.
+	// Hook.envNames is read-only and os.Getenv is concurrency-safe; this
+	// test pins the invariant so future mutable state (e.g. regex cache)
+	// won't silently introduce a data race.
+	withEnv(t, "REDACT_C", "concurrent-secret")
+	h := NewHook([]string{"REDACT_C"})
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			res := "prefix concurrent-secret suffix"
+			h.OnToolEnd(context.Background(), openagent.FunctionDefinition{}, nil, &res, nil, nil)
+			if strings.Contains(res, "concurrent-secret") {
+				t.Errorf("secret leaked under concurrency")
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/runner.go
+++ b/runner.go
@@ -923,22 +923,22 @@ func (r *runner) executeOneToolInternal(ctx context.Context, session Session, ca
 	case "load_skill":
 		toolStart := r.fireToolHooks(toolCtx, *def, args)
 		msg := r.executeLoadSkill(toolCtx, call)
-		r.fireToolHooksEnd(toolCtx, *def, args, msg.Content, toolStart, nil)
+		msg.Content, _ = r.fireToolHooksEnd(toolCtx, *def, args, msg.Content, toolStart, nil)
 		return msg
 	case "reload_skills":
 		toolStart := r.fireToolHooks(toolCtx, *def, args)
 		msg := r.executeReloadSkills(toolCtx, call)
-		r.fireToolHooksEnd(toolCtx, *def, args, msg.Content, toolStart, nil)
+		msg.Content, _ = r.fireToolHooksEnd(toolCtx, *def, args, msg.Content, toolStart, nil)
 		return msg
 	case "recall":
 		toolStart := r.fireToolHooks(toolCtx, *def, args)
 		msg := r.executeRecall(toolCtx, session, call)
-		r.fireToolHooksEnd(toolCtx, *def, args, msg.Content, toolStart, nil)
+		msg.Content, _ = r.fireToolHooksEnd(toolCtx, *def, args, msg.Content, toolStart, nil)
 		return msg
 	case "subagent":
 		toolStart := r.fireToolHooks(toolCtx, *def, args)
 		msg := r.executeSubAgent(toolCtx, session, call, ch)
-		r.fireToolHooksEnd(toolCtx, *def, args, msg.Content, toolStart, nil)
+		msg.Content, _ = r.fireToolHooksEnd(toolCtx, *def, args, msg.Content, toolStart, nil)
 		return msg
 	}
 
@@ -956,6 +956,16 @@ func (r *runner) executeOneToolInternal(ctx context.Context, session Session, ca
 
 	// ── Streaming path (optional interface) ──
 	if se, ok := tool.(StreamExecutor); ok {
+		// If the active hook mutates results (e.g. redact), we must NOT
+		// stream raw chunks to the client — the hook only runs after the
+		// full result is collected, so live chunks would leak secrets
+		// before redaction. Buffer instead and emit one final event.
+		bufferOnly := false
+		if r.agent.Hooks != nil {
+			if b, ok := r.agent.Hooks.(ResultBufferingHook); ok && b.BufferToolResult() {
+				bufferOnly = true
+			}
+		}
 		toolCh := se.ExecuteStream(toolCtx, args)
 		var buf strings.Builder
 		// Rate-limit: some tools (shell) produce hundreds of chunks/sec.
@@ -966,7 +976,7 @@ func (r *runner) executeOneToolInternal(ctx context.Context, session Session, ca
 		defer ticker.Stop()
 		var pending string
 		flush := func() {
-			if pending != "" && ch != nil {
+			if pending != "" && ch != nil && !bufferOnly {
 				select {
 				case ch <- StreamEvent{
 					Type:       StreamToolProgress,
@@ -1040,11 +1050,22 @@ func (r *runner) fireToolHooks(ctx context.Context, def FunctionDefinition, args
 }
 
 // fireToolHooksEnd emits observer leave + OnToolEnd for built-in tools.
-func (r *runner) fireToolHooksEnd(ctx context.Context, def FunctionDefinition, args json.RawMessage, output string, tc toolHookCtx, err error) {
+// It returns the (possibly hook-mutated) output and err so callers can write
+// them back into the message — OnToolEnd receives result/err as pointers and
+// may redact or truncate them, but Go's pass-by-value means the mutation is
+// lost unless we surface it.
+//
+// The observer "leave" event is emitted BEFORE OnToolEnd with the pre-hook
+// err. This means an observer that records err.Error() would see the raw
+// (unredacted) error. Redact does not protect the observer channel; observer
+// implementations must avoid logging err/result content. See hooks/redact
+// package doc.
+func (r *runner) fireToolHooksEnd(ctx context.Context, def FunctionDefinition, args json.RawMessage, output string, tc toolHookCtx, err error) (string, error) {
 	r.observe(ctx, StageToolExecute, "leave", map[string]any{"tool": def.Name}, tc.start, err)
 	if r.agent.Hooks != nil {
 		r.agent.Hooks.OnToolEnd(ctx, def, args, &output, &err, tc.hookState)
 	}
+	return output, err
 }
 
 // built-in skill tool definitions — single source of truth used by both

--- a/runner.go
+++ b/runner.go
@@ -923,22 +923,22 @@ func (r *runner) executeOneToolInternal(ctx context.Context, session Session, ca
 	case "load_skill":
 		toolStart := r.fireToolHooks(toolCtx, *def, args)
 		msg := r.executeLoadSkill(toolCtx, call)
-		msg.Content, _ = r.fireToolHooksEnd(toolCtx, *def, args, msg.Content, toolStart, nil)
+		r.fireToolHooksEnd(toolCtx, *def, args, &msg.Content, toolStart, nil)
 		return msg
 	case "reload_skills":
 		toolStart := r.fireToolHooks(toolCtx, *def, args)
 		msg := r.executeReloadSkills(toolCtx, call)
-		msg.Content, _ = r.fireToolHooksEnd(toolCtx, *def, args, msg.Content, toolStart, nil)
+		r.fireToolHooksEnd(toolCtx, *def, args, &msg.Content, toolStart, nil)
 		return msg
 	case "recall":
 		toolStart := r.fireToolHooks(toolCtx, *def, args)
 		msg := r.executeRecall(toolCtx, session, call)
-		msg.Content, _ = r.fireToolHooksEnd(toolCtx, *def, args, msg.Content, toolStart, nil)
+		r.fireToolHooksEnd(toolCtx, *def, args, &msg.Content, toolStart, nil)
 		return msg
 	case "subagent":
 		toolStart := r.fireToolHooks(toolCtx, *def, args)
 		msg := r.executeSubAgent(toolCtx, session, call, ch)
-		msg.Content, _ = r.fireToolHooksEnd(toolCtx, *def, args, msg.Content, toolStart, nil)
+		r.fireToolHooksEnd(toolCtx, *def, args, &msg.Content, toolStart, nil)
 		return msg
 	}
 
@@ -956,16 +956,13 @@ func (r *runner) executeOneToolInternal(ctx context.Context, session Session, ca
 
 	// ── Streaming path (optional interface) ──
 	if se, ok := tool.(StreamExecutor); ok {
-		// If the active hook mutates results (e.g. redact), we must NOT
-		// stream raw chunks to the client — the hook only runs after the
-		// full result is collected, so live chunks would leak secrets
-		// before redaction. Buffer instead and emit one final event.
-		bufferOnly := false
-		if r.agent.Hooks != nil {
-			if b, ok := r.agent.Hooks.(ResultBufferingHook); ok && b.BufferToolResult() {
-				bufferOnly = true
-			}
-		}
+		// Streaming chunks are forwarded to the client as
+		// StreamToolProgress for live UX. They do NOT enter the model
+		// context — only the final, post-OnToolEnd result is appended to
+		// the working message history (see the append below). A redaction
+		// hook therefore never needs to buffer: the model sees only the
+		// redacted final result, while the user sees live (possibly
+		// raw) progress, which is the point of streaming.
 		toolCh := se.ExecuteStream(toolCtx, args)
 		var buf strings.Builder
 		// Rate-limit: some tools (shell) produce hundreds of chunks/sec.
@@ -976,7 +973,7 @@ func (r *runner) executeOneToolInternal(ctx context.Context, session Session, ca
 		defer ticker.Stop()
 		var pending string
 		flush := func() {
-			if pending != "" && ch != nil && !bufferOnly {
+			if pending != "" && ch != nil {
 				select {
 				case ch <- StreamEvent{
 					Type:       StreamToolProgress,
@@ -1050,22 +1047,24 @@ func (r *runner) fireToolHooks(ctx context.Context, def FunctionDefinition, args
 }
 
 // fireToolHooksEnd emits observer leave + OnToolEnd for built-in tools.
-// It returns the (possibly hook-mutated) output and err so callers can write
-// them back into the message — OnToolEnd receives result/err as pointers and
-// may redact or truncate them, but Go's pass-by-value means the mutation is
-// lost unless we surface it.
+// It mutates *output and *err in place: OnToolEnd receives them as pointers
+// and may redact or truncate them, so we pass the caller's pointers straight
+// through rather than copying by value.
 //
 // The observer "leave" event is emitted BEFORE OnToolEnd with the pre-hook
 // err. This means an observer that records err.Error() would see the raw
 // (unredacted) error. Redact does not protect the observer channel; observer
 // implementations must avoid logging err/result content. See hooks/redact
 // package doc.
-func (r *runner) fireToolHooksEnd(ctx context.Context, def FunctionDefinition, args json.RawMessage, output string, tc toolHookCtx, err error) (string, error) {
-	r.observe(ctx, StageToolExecute, "leave", map[string]any{"tool": def.Name}, tc.start, err)
-	if r.agent.Hooks != nil {
-		r.agent.Hooks.OnToolEnd(ctx, def, args, &output, &err, tc.hookState)
+func (r *runner) fireToolHooksEnd(ctx context.Context, def FunctionDefinition, args json.RawMessage, output *string, tc toolHookCtx, err *error) {
+	var errVal error
+	if err != nil {
+		errVal = *err
 	}
-	return output, err
+	r.observe(ctx, StageToolExecute, "leave", map[string]any{"tool": def.Name}, tc.start, errVal)
+	if r.agent.Hooks != nil {
+		r.agent.Hooks.OnToolEnd(ctx, def, args, output, err, tc.hookState)
+	}
 }
 
 // built-in skill tool definitions — single source of truth used by both

--- a/stream_test.go
+++ b/stream_test.go
@@ -356,3 +356,83 @@ func TestStreamExecutorCancellation(t *testing.T) {
 		t.Error("should have received at least one progress event before cancel")
 	}
 }
+
+// minRedactHook is a minimal RunHooks that replaces a single secret value in
+// the tool result with "[REDACTED]". It lives in the root package test so we
+// can exercise the runner's streaming path + hook pipeline without importing
+// hooks/redact (which would create an import cycle: hooks/redact imports
+// openagent). This is a test double, not the real hook.
+type minRedactHook struct {
+	secret string
+}
+
+func (h *minRedactHook) OnAgentStart(ctx context.Context, req ChatCompletionRequest) (any, error) {
+	return nil, nil
+}
+func (h *minRedactHook) OnAgentEnd(ctx context.Context, req ChatCompletionRequest, resp *ChatCompletionResponse, runErr error, startState any) {
+}
+func (h *minRedactHook) OnToolStart(ctx context.Context, tool FunctionDefinition, args json.RawMessage) (any, error) {
+	return nil, nil
+}
+func (h *minRedactHook) OnToolEnd(ctx context.Context, tool FunctionDefinition, args json.RawMessage, result *string, err *error, startState any) {
+	if result != nil && *result != "" {
+		*result = strings.ReplaceAll(*result, h.secret, "[REDACTED]")
+	}
+}
+
+func TestStreamingWithRedactHook_FinalResultRedacted(t *testing.T) {
+	// A streaming tool emits chunks containing a secret. The user sees live
+	// StreamToolProgress (possibly raw — that's the point of streaming and
+	// the model never sees those), but the final StreamToolResult that
+	// enters the model's context must be redacted by OnToolEnd.
+	const secret = "supersecret-token-value"
+	streamTool := &streamingTestTool{
+		name: "stream_tool",
+		// Secret split across chunks to mimic realistic streaming.
+		chunks: []string{"prefix-", secret, "-suffix"},
+		delay:  0,
+	}
+	model := &fakeModelWithToolCall{
+		toolName: "stream_tool",
+		toolArgs: `{}`,
+		callID:   "call_redact",
+	}
+	agent := NewAgent("test",
+		WithModel(model),
+		WithTools(streamTool),
+		WithMaxTurns(1),
+		WithRunHooks(&minRedactHook{secret: secret}),
+	)
+
+	ch := agent.RunStream(context.Background(), Session{ID: "test"}, UserMessage("go"))
+
+	var toolResultEvent *StreamEvent
+	var gotDone bool
+	for evt := range ch {
+		switch evt.Type {
+		case StreamToolResult:
+			evtCopy := evt
+			toolResultEvent = &evtCopy
+		case StreamDone:
+			gotDone = true
+		case StreamError:
+			t.Fatalf("unexpected error: %v", evt.Error)
+		case StreamAborted:
+			t.Fatalf("unexpected abort: %v", evt.Error)
+		}
+	}
+
+	if !gotDone {
+		t.Fatal("missing StreamDone")
+	}
+	if toolResultEvent == nil {
+		t.Fatal("missing StreamToolResult")
+	}
+	content := toolResultEvent.Message.Content
+	if strings.Contains(content, secret) {
+		t.Fatalf("secret leaked into final tool result: %q", content)
+	}
+	if !strings.Contains(content, "[REDACTED]") {
+		t.Fatalf("final result not redacted: %q", content)
+	}
+}


### PR DESCRIPTION
Add a built-in `redact` RunHooks that masks sensitive environment-variable values in tool results. Configured env-var names are resolved lazily via `os.Getenv` at redaction time; when a value appears in a tool result or error, every occurrence is replaced with `[REDACTED]` and a hint is appended telling the model not to reconstruct it.

## Config

```json
{
  "sensitive": { "env": ["AWS_SECRET_ACCESS_KEY", "DB_PASSWORD"] }
}
```

`Sensitive.Env` holds env-var **names** (not values). Secrets never live in the config file or hook struct state.

## Wiring

`buildOpts` now takes `config.SensitiveConfig` and stacks hooks as `redact → slog → artifact` (redact first so logs and artifact files never see raw secrets). ACP and REST pass `cfg.Sensitive`. redact rides the existing `--hooks` capability.

## Streaming leak fix

A `StreamExecutor` tool's raw chunks previously reached the client as `StreamToolProgress` before `OnToolEnd` ran, so redaction was too late for streaming tools. Added the `ResultBufferingHook` optional interface: when the active hook implements it and returns true, the runner suppresses `StreamToolProgress` and only emits the final, post-hook result. `redact.Hook` implements it; `MultiHooks` forwards (any child true → true). `slog`/`artifact` do not implement it, so their streaming tools keep live progress.

## runner bug fix

`fireToolHooksEnd` took `output` by value, so `OnToolEnd` mutations were silently dropped for the four built-in tools (`load_skill`/`reload_skills`/`recall`/`subagent`). It now returns `(string, error)` and call sites write both back into the message.

## Coverage scope

This hook redacts **only** the tool result (output) and error. It does **not** redact:
- tool call arguments (`args`) — the LLM may place secrets in args; those flow to memory and client unredacted (`OnToolStart` cannot return modified args by interface contract).
- unregistered secrets — only the exact value of a named env var is matched (plain substring, no regex). PII, cards, AWS keys, private keys, JWTs etc. are not detected.
- JSON-escaped secret values — when the result is JSON and the secret value contains `"`, `\`, or control chars, the byte-level substring match silently fails (text-level limitation, documented).

These limits are documented in the `hooks/redact` package doc and the `SensitiveConfig` comment.

## Edge cases handled

- empty result short-circuit
- idempotent hint (no stacking on reprocess)
- JSON results: trailing hint suppressed so JSON stays valid
- `NewHook` dedup/drop-empty
- concurrency safe (`-race`)

## Tests

`go test ./hooks/redact/... -race` — covers no-op, empty value, empty result, single/multiple hits, multiple secrets (hint once), no-hit, nil result, error redaction, lazy env resolution, JSON no-trailing-hint, idempotent hint, dedup, concurrency.