### PR TITLE
fix(tool): add system context to profiles and require user approval for we…

### DIFF
--- a/cmd/cli/server/shared.go
+++ b/cmd/cli/server/shared.go
@@ -6,7 +6,9 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"time"
 
 	openagent "github.com/yusheng-g/openagent-go"
 	"github.com/yusheng-g/openagent-go/guard/llm"
@@ -207,7 +209,14 @@ func resolveProfilesDir(profiles string) string {
 func resolveProfiles(profiles, cwd string) []string {
 	return []string{
 		resolveProfileFile(profiles, cwd, "SOUL.md", personaAndLimitsPrompt),
-		resolveProfileFile(profiles, cwd, "SYSTEM.md", systemContextPrompt),
+		fmt.Sprintf(`
+%s
+
+OS: %s
+Arch: %s
+Date: %s
+
+`, resolveProfileFile(profiles, cwd, "SYSTEM.md", systemContextPrompt), runtime.GOOS, runtime.GOARCH, time.Now().Format("2006-01-02")),
 		resolveProfileFile(profiles, cwd, "AGENTS.md", methodologyAndRulesPrompt),
 	}
 }

--- a/tool/webfetch.go
+++ b/tool/webfetch.go
@@ -279,7 +279,7 @@ func (t *WebFetch) Definition() openagent.FunctionDefinition {
 	}
 }
 
-func (t *WebFetch) CanSelfApprove(_ json.RawMessage) bool { return true }
+func (t *WebFetch) CanSelfApprove(_ json.RawMessage) bool { return false }
 
 func (t *WebFetch) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var params struct {

--- a/tool/websearch.go
+++ b/tool/websearch.go
@@ -198,7 +198,7 @@ func (t *WebSearch) Definition() openagent.FunctionDefinition {
 	}
 }
 
-func (t *WebSearch) CanSelfApprove(_ json.RawMessage) bool { return true }
+func (t *WebSearch) CanSelfApprove(_ json.RawMessage) bool { return false }
 
 func (t *WebSearch) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	switch t.engine {


### PR DESCRIPTION
…b tools

- Add OS, Arch, and Date to SYSTEM.md profile prompt context so agents have awareness of the execution environment at startup
- Change WebFetch.CanSelfApprove to false: web fetches now require explicit user approval before proceeding, preventing agents from autonomously accessing arbitrary URLs
- Change WebSearch.CanSelfApprove to false: web searches now require explicit user approval before proceeding, preventing agents from autonomously searching the web

These changes improve safety and transparency by ensuring web-facing tools cannot run without user consent, and provide agents with useful runtime context (OS, architecture, current date) via the profile system.