### PR TITLE
fix(test): update CanSelfApprove tests for webfetch and websearch

### DIFF
--- a/tool/webfetch_test.go
+++ b/tool/webfetch_test.go
@@ -177,10 +177,10 @@ func TestWebFetchNon2xx(t *testing.T) {
 	t.Logf("✅ webfetch 404: %v", err)
 }
 
-func TestWebFetchSelfApproves(t *testing.T) {
+func TestWebFetchRequiresApproval(t *testing.T) {
 	f := NewWebFetch().withClient(newTestClient())
-	if !f.CanSelfApprove(nil) {
-		t.Error("WebFetch should self-approve")
+	if f.CanSelfApprove(nil) {
+		t.Error("WebFetch should require user approval")
 	}
 }
 

--- a/tool/websearch_test.go
+++ b/tool/websearch_test.go
@@ -102,10 +102,10 @@ func TestWebSearchNon2xx(t *testing.T) {
 	t.Logf("✅ 429 handled: %v", err)
 }
 
-func TestWebSearchSelfApproves(t *testing.T) {
+func TestWebSearchRequiresApproval(t *testing.T) {
 	s := NewWebSearch().withClient(newTestClient())
-	if !s.CanSelfApprove(nil) {
-		t.Error("WebSearch should self-approve")
+	if s.CanSelfApprove(nil) {
+		t.Error("WebSearch should require user approval")
 	}
 }
 


### PR DESCRIPTION
WebFetch and WebSearch now require user approval (CanSelfApprove changed from true to false). Update the corresponding test cases:
- TestWebFetchSelfApproves → TestWebFetchRequiresApproval
- TestWebSearchSelfApproves → TestWebSearchRequiresApproval
- Invert assertions from !CanSelfApprove to CanSelfApprove
- Update error messages accordingly