### PR TITLE
fix(cli): drop merged-settings log that leaked secrets

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -136,9 +136,6 @@ func main() {
 		defer logCleanup()
 	}
 
-	pretty, _ := json.MarshalIndent(&cfg, "", "  ")
-	log.Printf("Merged settings:\n%s", string(pretty))
-
 	// 6. Build cobra tree.
 	rootCmd.AddCommand(buildServeCmd(cfg))
 	rootCmd.AddCommand(buildRunCmd(cfg))


### PR DESCRIPTION
The startup log printed the full merged config, leaking provider api_key, env vars, and MCP server env. Remove the log line entirely rather than redacting.