### PR TITLE
fix(runner): account for tool definition tokens and use conservative margins for unknown tokenizers

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -491,6 +491,12 @@ Errors discarded without logging:
 
 ---
 
+### [DEBT] Config does not support per-model `context_window` override
+
+[cmd/cli/config/config.go](cmd/cli/config/config.go): `ProviderConfig.Models` is `[]string`, so there is no way to specify `context_window` or `max_tokens` per model. For castrated MAAS models (e.g. GLM-5.2 on Huawei Cloud: official ctx=1,980,000 but MAAS enforces 131,072), users cannot configure the effective limit in config. The code falls back to the lookup table (`Window128K = 128,000`), which is close but cannot be tuned. Fix: extend `ProviderConfig` with a `model_config` map (`{model_id: {context_window, max_tokens}}`) and apply `WithContextWindow` in `buildModels`.
+
+---
+
 ## Legend
 
 | Tag | Meaning |

--- a/runner.go
+++ b/runner.go
@@ -514,17 +514,23 @@ func (r *runner) run(ctx context.Context, session Session, prefix []Message, inp
 // ── Internal helpers ──
 
 // workingTokenBudget returns the token budget for the working message set.
-// If MaxWorkingTokens is set explicitly, use it. Otherwise, use 70% of the
-// model's context window. Falls back to 20000 if the model doesn't report
-// its context window.
+// If MaxWorkingTokens is set explicitly, use it. Otherwise, use a percentage
+// of the model's context window: 70% for models with a known tiktoken
+// encoding, 50% for unknown models (cl100k_base fallback) where token
+// estimates may diverge significantly from the model's actual tokenizer.
+// Falls back to 20000 if the model doesn't report its context window.
 func (r *runner) workingTokenBudget() int {
 	if r.agent.MaxWorkingTokens > 0 {
 		return r.agent.MaxWorkingTokens
 	}
-	if cw := r.runModel.ContextWindow(); cw > 0 {
+	cw := r.runModel.ContextWindow()
+	if cw <= 0 {
+		return 20000
+	}
+	if tokenizer.IsKnownModel(tokenizerModelID(r.runModel)) {
 		return cw * 7 / 10 // 70%
 	}
-	return 20000
+	return cw / 2 // 50% — cl100k_base fallback, larger safety margin
 }
 
 // prepareMemory fetches the working message set, triggers token-based
@@ -636,8 +642,16 @@ func (r *runner) estimatePromptOverhead(ctx context.Context, session Session, mo
 	}
 
 	// Dynamic context — same assembly order as buildPrompt.
+	// Preamble is always present in buildPrompt.
+	n += tokenizer.Count(modelID,
+		"\nIMPORTANT: The context below is generated fresh for this turn. "+
+			"If it conflicts with static instructions or earlier conversation, the latest context here is authoritative. "+
+			"Earlier summaries, skill lists, semantic memory, or plan state may be outdated.\n") + 4
+
 	if len(r.skills) > 0 {
 		n += tokenizer.Count(modelID, buildSkillsSection(r.skills)) + 4
+	} else {
+		n += tokenizer.Count(modelID, "\nIMPORTANT: No available skills.") + 4
 	}
 	for name, body := range r.loadedSkills {
 		n += tokenizer.Count(modelID, "## Loaded Skill: "+name+"\n\n"+body) + 4
@@ -655,9 +669,28 @@ func (r *runner) estimatePromptOverhead(ctx context.Context, session Session, mo
 		}
 	}
 
-	// Compressed summary + hints.
+	// Compressed summary + hints (or fallback when empty).
 	if cc, err := r.agent.Memory.Compressed(ctx, session.ID); err == nil && cc != nil && cc.Summary != "" {
 		n += tokenizer.Count(modelID, buildCompressedSection(cc)) + 4
+	} else {
+		n += tokenizer.Count(modelID, "## Conversation Summary\n\n(no prior conversation history)") + 4
+	}
+
+	// Tool definitions — sent as part of the API request (ChatCompletionRequest.Tools)
+	// but not included in messages. These consume prompt tokens on the model side.
+	// With 15+ tools (shell, read, write, ls, grep, websearch, webfetch, ACP tools,
+	// plan tools, builtins), this is typically 5-10K tokens.
+	for _, td := range toolDefinitions(r.agent.SnapshotTools()) {
+		n += tokenizer.Count(modelID, td.Name)
+		n += tokenizer.Count(modelID, td.Description)
+		n += tokenizer.Count(modelID, string(td.Parameters))
+		n += 4
+	}
+	for _, td := range r.builtinTools {
+		n += tokenizer.Count(modelID, td.Name)
+		n += tokenizer.Count(modelID, td.Description)
+		n += tokenizer.Count(modelID, string(td.Parameters))
+		n += 4
 	}
 
 	return n
@@ -1211,8 +1244,15 @@ func trimToContextWindow(modelID string, messages []Message, window int) []Messa
 		}
 	}
 
-	// 5% safety margin — tiktoken is accurate but not exact.
-	budget := window * 95 / 100
+	// Safety margin — tiktoken is accurate but not exact for known models.
+	// For unknown models (cl100k_base fallback), the estimate may diverge
+	// significantly from the model's actual tokenizer (e.g. GLM, Qwen),
+	// so use a larger margin to avoid 400 "prompt too long" errors.
+	margin := 90
+	if !tokenizer.IsKnownModel(modelID) {
+		margin = 75
+	}
+	budget := window * margin / 100
 	sysTokens := countMessages(modelID, sys)
 	budget -= sysTokens
 	if budget <= 0 {

--- a/tokenizer/tokenizer.go
+++ b/tokenizer/tokenizer.go
@@ -81,6 +81,16 @@ func Count(modelID, text string) (n int) {
 	return len(tke.EncodeOrdinary(text))
 }
 
+// IsKnownModel reports whether tiktoken has a model-specific encoding for
+// the given model ID. When false, ForModel falls back to cl100k_base and
+// token estimates may diverge significantly from the model's actual
+// tokenizer (especially for Chinese models like GLM, Qwen, etc.). Callers
+// use this to apply larger safety margins for unknown tokenizers.
+func IsKnownModel(modelID string) bool {
+	_, err := tiktoken.EncodingForModel(modelID)
+	return err == nil
+}
+
 // heuristicCount is a fast fallback (~4 chars/token, conservative for CJK).
 func heuristicCount(text string) int {
 	n := 0


### PR DESCRIPTION
When switching to a model with a smaller context window (e.g. GLM-5.2 on Huawei Cloud MAAS, ctx=128K), the prompt could exceed the model's actual input limit and trigger a 400 error. Two root causes:

1. estimatePromptOverhead did not count tool definition tokens (~5-10K with 15+ tools) or buildPrompt's dynamic context preamble/fallbacks, so prepareMemory's budget was too generous.

2. For non-OpenAI models, tiktoken falls back to cl100k_base which significantly underestimates token counts vs the model's actual tokenizer (30-50% for Chinese models like GLM, Qwen). The 95% safety margin in trimToContextWindow and 70% budget in workingTokenBudget were insufficient to cover this divergence.

Fix:
- estimatePromptOverhead: count tool definitions + preamble + fallbacks
- tokenizer.IsKnownModel(): detect cl100k_base fallback (cached)
- workingTokenBudget: 50% (was 70%) for unknown tokenizers
- trimToContextWindow: 75% margin (was 95%) for unknown tokenizers

DEBT: config does not support per-model context_window override (documented in BUGS.md).