### PR TITLE
feat(model): per-model context_window/max_tokens config + tool definition token overhead

### DIFF
--- a/acp/server.go
+++ b/acp/server.go
@@ -587,6 +587,46 @@ func (s *AgentServer) saveConfig(ctx context.Context, sessionID string) {
 	}
 }
 
+// saveTotalTokens persists the accumulated total token count to
+// SessionStore._meta["total_tokens"]. Called after each prompt completes
+// so /context survives server restarts.
+func (s *AgentServer) saveTotalTokens(ctx context.Context, sessionID string, n int) {
+	if s.SessionStore == nil {
+		return
+	}
+	info, err := s.SessionStore.Get(ctx, sessionID)
+	if err != nil || info == nil {
+		return
+	}
+	info.SetMeta("total_tokens", n)
+	info.UpdatedAt = time.Now()
+	_ = s.SessionStore.Save(ctx, *info)
+}
+
+// loadTotalTokens reads the persisted accumulated total token count from
+// SessionStore._meta["total_tokens"]. Returns 0 if unset or unavailable.
+func (s *AgentServer) loadTotalTokens(ctx context.Context, sessionID string) int {
+	if s.SessionStore == nil {
+		return 0
+	}
+	info, err := s.SessionStore.Get(ctx, sessionID)
+	if err != nil || info == nil || info.Meta == nil {
+		return 0
+	}
+	raw, ok := info.Meta["total_tokens"]
+	if !ok {
+		return 0
+	}
+	// JSON round-trip may yield float64; handle both int and float64.
+	switch v := raw.(type) {
+	case int:
+		return v
+	case float64:
+		return int(v)
+	}
+	return 0
+}
+
 // connectMCP connects to all configured MCP servers and returns the sessions.
 // Tools are listed once at connect time and cached — the connection is
 // long-lived (one connection per session lifetime).
@@ -799,6 +839,9 @@ func (s *AgentServer) OnLoadSession(ctx context.Context, req openacp.LoadSession
 		s.putSession(req.SessionID, ss)
 	}
 
+	// Restore accumulated token count so /context survives server restarts.
+	ss.totalTokens = s.loadTotalTokens(ctx, string(req.SessionID))
+
 	// Replay history from Memory if available.
 	if s.Mem != nil {
 		s.replayHistory(ctx, req.SessionID, sender)
@@ -942,6 +985,8 @@ func (s *AgentServer) OnResumeSession(ctx context.Context, req openacp.ResumeSes
 		ss.rt = s.buildRuntimeForSession(req.SessionID, ss)
 		s.putSession(req.SessionID, ss)
 	}
+	// Restore accumulated token count so /context survives server restarts.
+	ss.totalTokens = s.loadTotalTokens(ctx, string(req.SessionID))
 	// Load persisted plan into memory (no replay per ACP spec:
 	// session/resume MUST NOT replay history).
 	if ss.PlanEntries() == nil {
@@ -1417,6 +1462,7 @@ func (s *AgentServer) OnPrompt(ctx context.Context, req openacp.PromptRequest, s
 	}
 
 	ss.totalTokens += usage.TotalTokens
+	s.saveTotalTokens(ctx, string(req.SessionID), ss.totalTokens)
 
 	// Report *current* context usage (this turn's PromptTokens), not
 	// accumulated total. Per ACP spec, `used` means "tokens currently
@@ -1951,6 +1997,7 @@ func (s *AgentServer) buildSlashContext(ctx context.Context, sid openacp.Session
 				}
 			}
 			ss.totalTokens = 0
+			s.saveTotalTokens(ctx, string(sid), 0)
 			ss.ClearPlanEntries()
 			s.savePlan(ctx, string(sid), nil)
 			return nil

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -50,57 +50,19 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
-	wasmRuntime, err := cliwasm.NewRuntime(ctx)
-	if err != nil {
-		log.Fatalf("wasm runtime: %v", err)
-	}
-	defer wasmRuntime.Close(ctx)
-
 	// 4. Load every .wasm and route capabilities.
 	settings := raw
 	if len(settings) == 0 {
 		settings = []byte("{}")
 	}
-	mgr := plugin.NewManager(pluginPaths)
 	hub := &cliwasm.ObserverHub{}
-	for _, p := range pluginPaths {
-		files, _ := mgr.ResolveWasmFiles(p)
-		for _, f := range files {
-			wasmBytes, err := os.ReadFile(f)
-			if err != nil {
-				log.Printf("plugin: read %s: %v", f, err)
-				continue
-			}
-			mod, meta, err := wasmRuntime.Instantiate(ctx, wasmBytes, f)
-			if err != nil {
-				log.Printf("plugin: load %s: %v", f, err)
-				continue
-			}
 
-			log.Printf("plugin: loaded %s (%s) type=%s", meta.Name, meta.Description, meta.Type)
-
-			if meta.Is("settings") {
-				merged, err := mod.CallInit(ctx, settings)
-				if err != nil {
-					log.Printf("plugin %s init: %v", meta.Name, err)
-					continue
-				}
-				settings = merged
-			}
-
-			if meta.Is("commands") {
-				cmds, err := mod.ReadCommands(ctx)
-				if err != nil {
-					log.Printf("plugin %s commands: %v", meta.Name, err)
-					continue
-				}
-				registerCommands(rootCmd, cmds)
-			}
-
-			if meta.Is("observers") {
-				hub.Add(mod)
-			}
-		}
+	// keyring subcommands don't use plugins; skip loading to avoid
+	// plugin log noise on stdout/stderr.
+	if !isKeyringCmd(os.Args) {
+		var cleanup func()
+		settings, cleanup = loadPlugins(ctx, pluginPaths, settings, hub)
+		defer cleanup()
 	}
 
 	// 5. Parse final merged config.
@@ -387,6 +349,71 @@ func keyringOrFail() plugin.Keyring {
 			"fallback; original error: %v", err)
 	}
 	return sysKr
+}
+
+// isKeyringCmd reports whether the first non-flag argument is "keyring",
+// so plugin loading can be skipped for keyring subcommands.
+func isKeyringCmd(args []string) bool {
+	for _, a := range args[1:] {
+		if strings.HasPrefix(a, "-") {
+			continue
+		}
+		return a == "keyring"
+	}
+	return false
+}
+
+// loadPlugins instantiates the WASM runtime, loads every .wasm under
+// pluginPaths, and routes capabilities (settings merge, command
+// registration, observer wiring). Returns the possibly merged settings
+// and a cleanup func that closes the WASM runtime.
+func loadPlugins(ctx context.Context, pluginPaths []string, settings []byte, hub *cliwasm.ObserverHub) ([]byte, func()) {
+	wasmRuntime, err := cliwasm.NewRuntime(ctx)
+	if err != nil {
+		log.Fatalf("wasm runtime: %v", err)
+	}
+
+	mgr := plugin.NewManager(pluginPaths)
+	for _, p := range pluginPaths {
+		files, _ := mgr.ResolveWasmFiles(p)
+		for _, f := range files {
+			wasmBytes, err := os.ReadFile(f)
+			if err != nil {
+				log.Printf("plugin: read %s: %v", f, err)
+				continue
+			}
+			mod, meta, err := wasmRuntime.Instantiate(ctx, wasmBytes, f)
+			if err != nil {
+				log.Printf("plugin: load %s: %v", f, err)
+				continue
+			}
+
+			log.Printf("plugin: loaded %s (%s) type=%s", meta.Name, meta.Description, meta.Type)
+
+			if meta.Is("settings") {
+				merged, err := mod.CallInit(ctx, settings)
+				if err != nil {
+					log.Printf("plugin %s init: %v", meta.Name, err)
+					continue
+				}
+				settings = merged
+			}
+
+			if meta.Is("commands") {
+				cmds, err := mod.ReadCommands(ctx)
+				if err != nil {
+					log.Printf("plugin %s commands: %v", meta.Name, err)
+					continue
+				}
+				registerCommands(rootCmd, cmds)
+			}
+
+			if meta.Is("observers") {
+				hub.Add(mod)
+			}
+		}
+	}
+	return settings, func() { wasmRuntime.Close(ctx) }
 }
 
 var keyringCmd = &cobra.Command{Use: "keyring", Short: "Manage credentials in the system keyring"}


### PR DESCRIPTION
Problem: When switching from a large-context model (e.g. glm-5.2) to a smaller one on Huawei Cloud MAAS, the API returns 400 because the prompt exceeds the platform's 131K input limit. Root causes:
  1. Context window lookup table returns model-native values, not MAAS platform limits — no way to override per model.
  2. Tool definition tokens (~5-10K) not counted in estimatePromptOverhead, causing the working token budget to be overestimated.
  3. No per-model max_tokens config — session.MaxTokens is the only source.

Changes:
- config: ProviderConfig.Models changed from []string to ModelList (custom UnmarshalJSON accepts both legacy ["id"] and new [{"model_id":"...","context_window":N,"max_tokens":N}] formats)
- model/openai: add maxTokens field + WithMaxTokens/MaxTokens methods
- model: add MaxTokensModeler optional interface
- shared.go: buildModels applies WithContextWindow/WithMaxTokens from config
- runner.go: buildModelRequest falls back to model MaxTokens when session MaxTokens is 0; estimatePromptOverhead now counts tool definitions (name+description+parameters) and buildPrompt preamble/fallback text
- wasmhost: SetModel signature extended with contextWindow/maxTokens; runtimeSetModelConfig parses the new fields from plugin JSON
- acp/server + rest/handler: SetModel applies WithContextWindow/WithMaxTokens