### PR TITLE
fix(hooks): nil *error deref in slog/otel OnToolEnd caused load_skill panic

### DIFF
--- a/hooks/otel/hooks.go
+++ b/hooks/otel/hooks.go
@@ -78,7 +78,7 @@ func (h *Hooks) OnToolEnd(ctx context.Context, tool openagent.FunctionDefinition
 	}
 	defer span.End()
 
-	if *err != nil {
+	if err != nil && *err != nil {
 		span.SetStatus(codes.Error, (*err).Error())
 		span.RecordError(*err)
 	}

--- a/hooks/slog/hooks.go
+++ b/hooks/slog/hooks.go
@@ -71,7 +71,7 @@ func (h *Hooks) OnToolEnd(ctx context.Context, tool openagent.FunctionDefinition
 		slog.String("tool", tool.Name),
 		slog.Duration("elapsed", elapsed),
 	}
-	if *err != nil {
+	if err != nil && *err != nil {
 		attrs = append(attrs, slog.String("error", (*err).Error()))
 		h.logger.LogAttrs(ctx, slog.LevelError, "tool end", attrs...)
 	} else {

--- a/runner.go
+++ b/runner.go
@@ -917,6 +917,12 @@ func (r *runner) executeOneToolInternal(ctx context.Context, session Session, ca
 		}
 	}
 
+	// noErr is a stable nil error value whose address is passed to
+	// fireToolHooksEnd for built-in tools that have no error to report.
+	// Passing a valid *error (pointing to nil) instead of a nil pointer
+	// prevents downstream hooks from nil-dereferencing err.
+	var noErr error
+
 	args := json.RawMessage(call.Function.Arguments)
 
 	// Inject session into ctx so tools and hooks can retrieve it via
@@ -928,22 +934,22 @@ func (r *runner) executeOneToolInternal(ctx context.Context, session Session, ca
 	case "load_skill":
 		toolStart := r.fireToolHooks(toolCtx, *def, args)
 		msg := r.executeLoadSkill(toolCtx, call)
-		r.fireToolHooksEnd(toolCtx, *def, args, &msg.Content, toolStart, nil)
+		r.fireToolHooksEnd(toolCtx, *def, args, &msg.Content, toolStart, &noErr)
 		return msg
 	case "reload_skills":
 		toolStart := r.fireToolHooks(toolCtx, *def, args)
 		msg := r.executeReloadSkills(toolCtx, call)
-		r.fireToolHooksEnd(toolCtx, *def, args, &msg.Content, toolStart, nil)
+		r.fireToolHooksEnd(toolCtx, *def, args, &msg.Content, toolStart, &noErr)
 		return msg
 	case "recall":
 		toolStart := r.fireToolHooks(toolCtx, *def, args)
 		msg := r.executeRecall(toolCtx, session, call)
-		r.fireToolHooksEnd(toolCtx, *def, args, &msg.Content, toolStart, nil)
+		r.fireToolHooksEnd(toolCtx, *def, args, &msg.Content, toolStart, &noErr)
 		return msg
 	case "subagent":
 		toolStart := r.fireToolHooks(toolCtx, *def, args)
 		msg := r.executeSubAgent(toolCtx, session, call, ch)
-		r.fireToolHooksEnd(toolCtx, *def, args, &msg.Content, toolStart, nil)
+		r.fireToolHooksEnd(toolCtx, *def, args, &msg.Content, toolStart, &noErr)
 		return msg
 	}
 


### PR DESCRIPTION
Built-in tools (load_skill/reload_skills/recall/subagent) called fireToolHooksEnd(..., nil) passing a nil *error. The slog and otel hooks unconditionally dereferenced *err, panicking with "runtime error: invalid memory address or nil pointer dereference" whenever a built-in tool was invoked (e.g. load_skill).

Root cause: runner.go passed nil as the *error argument to fireToolHooksEnd for all four built-in tools. slog.OnToolEnd did `if *err != nil` without first checking err != nil; otel.OnToolEnd had the identical defect. redact and artifact hooks were already safe.

Fix (two layers):
- runner.go: pass &noErr (a valid pointer to a nil error) instead of nil, eliminating the nil *error at the source for all downstream hooks.
- hooks/slog, hooks/otel: guard with `err != nil && *err != nil`, matching the redact hook's existing pattern. Defense-in-depth for the public RunHooks interface.

Note: the slog/otel guards are retained even though the runner no longer passes nil, because RunHooks is a public interface — third-party hooks or future call sites may pass nil.

Verified: go vet ./... clean; go test . and all hook packages pass.