### PR TITLE
feat(skills): load ~/.agents and <cwd>/.agents with cwd override; drop .openagent/skills

### DIFF
--- a/cmd/cli/server/buildopts_test.go
+++ b/cmd/cli/server/buildopts_test.go
@@ -24,7 +24,7 @@ func (mockModel) ChatCompletionStream(ctx context.Context, req openagent.ChatCom
 }
 func (mockModel) ContextWindow() int { return 0 }
 
-// chdirEmpty ensures openSkillLoader() finds no .openagent/skills by moving
+// chdirEmpty ensures openSkillLoader() finds no .agents/skills by moving
 // to a temp dir and pointing HOME elsewhere. Returns a restore func.
 func chdirEmpty(t *testing.T) func() {
 	t.Helper()
@@ -39,7 +39,7 @@ func chdirEmpty(t *testing.T) func() {
 	}
 }
 
-// chdirWithSkills creates .openagent/skills in a temp cwd so openSkillLoader
+// chdirWithSkills creates .agents/skills in a temp cwd so openSkillLoader
 // returns a non-nil loader.
 func chdirWithSkills(t *testing.T) func() {
 	t.Helper()
@@ -48,7 +48,7 @@ func chdirWithSkills(t *testing.T) func() {
 	tmp := t.TempDir()
 	os.Chdir(tmp)
 	os.Setenv("HOME", filepath.Join(tmp, "no-home"))
-	if err := os.MkdirAll(filepath.Join(tmp, ".openagent", "skills"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(tmp, ".agents", "skills"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	return func() {
@@ -118,7 +118,7 @@ func TestBuildOpts_Skills_NoDir(t *testing.T) {
 	restore := chdirEmpty(t)
 	defer restore()
 	on := true
-	// OnSkills=true but no .openagent/skills dir → loader stays nil.
+	// OnSkills=true but no .agents/skills dir → loader stays nil.
 	agent := applyOpts(Capabilities{Skills: &on}, mockModel{})
 	if agent.SkillLoader != nil {
 		t.Error("SkillLoader should be nil when no skills dir exists")

--- a/cmd/cli/server/shared.go
+++ b/cmd/cli/server/shared.go
@@ -248,32 +248,52 @@ func resolveProfileFile(profiles, cwd, filename, defaultText string) string {
 
 // ── Optional capability builders ──
 
-// openSkillLoader creates a file-system skill loader. Directories are tried
-// in priority order:
-//  1. <workspace>/.openagent/skills  (project-level)
-//  2. ~/.openagent/skills            (user-level)
+// openSkillLoader creates a file-system skill loader spanning the skill
+// directories that exist. Roots are passed to fs.New in priority order
+// (least authoritative first), so skills in a later root override
+// same-name skills from an earlier root:
 //
-// Returns nil if no directory exists.
+//  1. ~/.agents/skills            (user-level)
+//  2. <workspace>/.agents/skills  (project-level, overrides user-level)
+//
+// Directories that do not exist are skipped. Returns nil if none exist.
 func openSkillLoader() openagent.SkillLoader {
+	var roots []string
 	for _, dir := range skillDirs() {
 		if info, err := os.Stat(dir); err == nil && info.IsDir() {
-			return fs.New(dir)
+			roots = append(roots, dir)
 		}
 	}
-	return nil
+	if len(roots) == 0 {
+		return nil
+	}
+	return fs.New(roots...)
 }
 
+// skillDirs returns the skill directory candidates in override order:
+// least authoritative first (~/.agents/skills), then most authoritative
+// last (<cwd>/.agents/skills). When home equals cwd the two resolve to
+// the same path and only one entry is returned.
 func skillDirs() []string {
 	var dirs []string
+	seen := make(map[string]struct{})
+
 	home, err := os.UserHomeDir()
 	if err == nil {
-		dirs = append(dirs, filepath.Join(home, ".openagent", "skills"))
-		dirs = append(dirs, filepath.Join(home, ".agents", "skills"))
+		d := filepath.Join(home, ".agents", "skills")
+		if _, ok := seen[d]; !ok {
+			seen[d] = struct{}{}
+			dirs = append(dirs, d)
+		}
 	}
+
 	cwd, err := os.Getwd()
-	if err == nil && home != cwd {
-		dirs = append(dirs, filepath.Join(cwd, ".agents", "skills"))
-		dirs = append(dirs, filepath.Join(cwd, ".openagent", "skills"))
+	if err == nil {
+		d := filepath.Join(cwd, ".agents", "skills")
+		if _, ok := seen[d]; !ok {
+			seen[d] = struct{}{}
+			dirs = append(dirs, d)
+		}
 	}
 	return dirs
 }

--- a/cmd/cli/server/shared_test.go
+++ b/cmd/cli/server/shared_test.go
@@ -15,14 +15,14 @@ func TestSkillDirs_Priority(t *testing.T) {
 	if len(dirs) < 1 {
 		t.Fatal("skillDirs returned empty list")
 	}
-	// First entry should be project-level (cwd-based).
-	if !strings.Contains(dirs[0], ".openagent") || !strings.Contains(dirs[0], "skills") {
-		t.Errorf("unexpected project dir: %q", dirs[0])
+	// First entry should be user-level (~/.agents/skills).
+	if !strings.Contains(dirs[0], ".agents") || !strings.Contains(dirs[0], "skills") {
+		t.Errorf("unexpected user dir: %q", dirs[0])
 	}
-	// Second, if present, should be user-level (home-based).
+	// Second, if present, should be project-level (<cwd>/.agents/skills).
 	if len(dirs) >= 2 {
-		if !strings.Contains(dirs[1], ".openagent") || !strings.Contains(dirs[1], "skills") {
-			t.Errorf("unexpected home dir: %q", dirs[1])
+		if !strings.Contains(dirs[1], ".agents") || !strings.Contains(dirs[1], "skills") {
+			t.Errorf("unexpected project dir: %q", dirs[1])
 		}
 	}
 }
@@ -39,7 +39,7 @@ func TestOpenSkillLoader_NoDirs(t *testing.T) {
 
 	sl := openSkillLoader()
 	if sl != nil {
-		t.Error("openSkillLoader should return nil when no .openagent/skills exists")
+		t.Error("openSkillLoader should return nil when no .agents/skills exists")
 	}
 }
 
@@ -49,14 +49,117 @@ func TestOpenSkillLoader_FindsDir(t *testing.T) {
 	os.Chdir(tmp)
 	defer os.Chdir(origWd)
 
-	skillsDir := filepath.Join(tmp, ".openagent", "skills")
+	skillsDir := filepath.Join(tmp, ".agents", "skills")
 	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
 	sl := openSkillLoader()
 	if sl == nil {
-		t.Fatal("openSkillLoader should find .openagent/skills directory")
+		t.Fatal("openSkillLoader should find .agents/skills directory")
+	}
+}
+
+// writeSkillFile creates <root>/<name>/SKILL.md with the given frontmatter.
+func writeSkillFile(t *testing.T, root, name, desc string) {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "---\nname: " + name + "\ndescription: " + desc + "\n---\nbody of " + name + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestOpenSkillLoader_MergesHomeAndCwd is the end-to-end assembly guarantee:
+// when both ~/.agents/skills and <cwd>/.agents/skills exist with a same-name
+// skill, openSkillLoader must load BOTH directories and the cwd copy wins.
+// This exercises skillDirs ordering + stat filtering + fs.New(roots...)
+// together — the behaviour that was previously "first hit wins, single dir".
+func TestOpenSkillLoader_MergesHomeAndCwd(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	origWd, _ := os.Getwd()
+	tmp := t.TempDir()
+	homeDir := filepath.Join(tmp, "home")
+	cwdDir := filepath.Join(tmp, "cwd")
+	if err := os.MkdirAll(homeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(cwdDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	os.Setenv("HOME", homeDir)
+	os.Chdir(cwdDir)
+	defer func() {
+		os.Chdir(origWd)
+		os.Setenv("HOME", origHome)
+	}()
+
+	homeSkills := filepath.Join(homeDir, ".agents", "skills")
+	cwdSkills := filepath.Join(cwdDir, ".agents", "skills")
+	writeSkillFile(t, homeSkills, "shared", "from home")
+	writeSkillFile(t, homeSkills, "home-only", "home exclusive")
+	writeSkillFile(t, cwdSkills, "shared", "from cwd")
+	writeSkillFile(t, cwdSkills, "cwd-only", "cwd exclusive")
+
+	sl := openSkillLoader()
+	if sl == nil {
+		t.Fatal("openSkillLoader should be non-nil when skill dirs exist")
+	}
+	skills, err := sl.Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	byName := make(map[string]openagent.SkillInfo)
+	for _, s := range skills {
+		byName[s.Name] = s
+	}
+
+	// All four names present (both dirs loaded).
+	for _, want := range []string{"shared", "home-only", "cwd-only"} {
+		if _, ok := byName[want]; !ok {
+			t.Errorf("skill %q missing from merged result: %+v", want, skills)
+		}
+	}
+	if len(skills) != 3 {
+		t.Errorf("got %d skills, want 3 (shared merged, not duplicated): %+v", len(skills), skills)
+	}
+
+	// shared must be the cwd copy (override).
+	shared := byName["shared"]
+	if shared.Description != "from cwd" {
+		t.Errorf("shared description = %q, want %q (cwd should override home)", shared.Description, "from cwd")
+	}
+	if shared.Path != filepath.Join(cwdSkills, "shared") {
+		t.Errorf("shared Path = %q, want %q", shared.Path, filepath.Join(cwdSkills, "shared"))
+	}
+}
+
+// TestSkillDirs_HomeEqualsCwd_Deduped verifies that when home and cwd
+// resolve to the same directory, skillDirs returns a single entry
+// instead of duplicating the path (which would make Discover scan the
+// same tree twice).
+func TestSkillDirs_HomeEqualsCwd_Deduped(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	origWd, _ := os.Getwd()
+	tmp := t.TempDir()
+	os.Setenv("HOME", tmp)
+	os.Chdir(tmp)
+	defer func() {
+		os.Chdir(origWd)
+		os.Setenv("HOME", origHome)
+	}()
+
+	dirs := skillDirs()
+	if len(dirs) != 1 {
+		t.Fatalf("got %d dirs, want 1 (home==cwd dedup): %v", len(dirs), dirs)
+	}
+	want := filepath.Join(tmp, ".agents", "skills")
+	if dirs[0] != want {
+		t.Errorf("dirs[0] = %q, want %q", dirs[0], want)
 	}
 }
 

--- a/runner.go
+++ b/runner.go
@@ -22,6 +22,7 @@ type runner struct {
 	agent *Agent
 
 	// Cached state
+	skillsMu     sync.RWMutex         // protects skills and loadedSkills
 	skills       []SkillInfo          // Discover result, refreshed by reload_skills
 	loadedSkills map[string]string    // name → body, populated by load_skill
 	builtinTools []FunctionDefinition // auto-injected tools (load_skill, reload_skills)
@@ -74,8 +75,10 @@ func (r *runner) run(ctx context.Context, session Session, prefix []Message, inp
 	// Init: cache skills if loader present
 	if r.agent.SkillLoader != nil {
 		skills, _ := r.agent.SkillLoader.Discover(ctx)
+		r.skillsMu.Lock()
 		r.skills = skills
 		r.loadedSkills = make(map[string]string)
+		r.skillsMu.Unlock()
 		r.builtinTools = builtinSkillToolDefs()
 	}
 	if r.agent.Memory != nil {
@@ -637,12 +640,14 @@ func (r *runner) estimatePromptOverhead(ctx context.Context, session Session, mo
 	}
 
 	// Dynamic context — same assembly order as buildPrompt.
+	r.skillsMu.RLock()
 	if len(r.skills) > 0 {
 		n += tokenizer.Count(modelID, buildSkillsSection(r.skills)) + 4
 	}
 	for name, body := range r.loadedSkills {
 		n += tokenizer.Count(modelID, "## Loaded Skill: "+name+"\n\n"+body) + 4
 	}
+	r.skillsMu.RUnlock()
 	if session.DynamicContext != "" {
 		n += tokenizer.Count(modelID, session.DynamicContext) + 4
 	}
@@ -684,6 +689,7 @@ Date: %s
 `, runtime.GOOS, runtime.GOARCH, time.Now().Format("2006-01-02")))
 
 	// Skills catalog + loaded skill bodies.
+	r.skillsMu.RLock()
 	if len(r.skills) > 0 {
 		dynamicParts = append(dynamicParts, buildSkillsSection(r.skills))
 	} else {
@@ -696,6 +702,7 @@ Date: %s
 	for name, body := range r.loadedSkills {
 		dynamicParts = append(dynamicParts, "## Loaded Skill: "+name+"\n\n"+body)
 	}
+	r.skillsMu.RUnlock()
 
 	// ACP / plan-mode context (injected by Session.DynamicContext).
 	if session.DynamicContext != "" {
@@ -1436,7 +1443,9 @@ func (r *runner) executeLoadSkill(ctx context.Context, call ToolCall) Message {
 	}
 
 	// Idempotent: return cached
+	r.skillsMu.RLock()
 	if body, ok := r.loadedSkills[args.Name]; ok {
+		r.skillsMu.RUnlock()
 		return Message{Role: RoleTool, ToolCallID: call.ID, Content: body}
 	}
 
@@ -1450,6 +1459,7 @@ func (r *runner) executeLoadSkill(ctx context.Context, call ToolCall) Message {
 			break
 		}
 	}
+	r.skillsMu.RUnlock()
 	if !found {
 		return Message{
 			Role:       RoleTool,
@@ -1468,7 +1478,9 @@ func (r *runner) executeLoadSkill(ctx context.Context, call ToolCall) Message {
 	}
 
 	full := "**Directory:** " + info.Path + "\n\n" + body
+	r.skillsMu.Lock()
 	r.loadedSkills[args.Name] = full
+	r.skillsMu.Unlock()
 
 	return Message{Role: RoleTool, ToolCallID: call.ID, Content: full}
 }
@@ -1483,6 +1495,7 @@ func (r *runner) executeReloadSkills(ctx context.Context, call ToolCall) Message
 		}
 	}
 
+	r.skillsMu.Lock()
 	r.skills = skills
 
 	// Prune loaded skills that have been removed from disk
@@ -1504,6 +1517,7 @@ func (r *runner) executeReloadSkills(ctx context.Context, call ToolCall) Message
 		}
 		summary += fmt.Sprintf(", %d loaded: %v", len(r.loadedSkills), names)
 	}
+	r.skillsMu.Unlock()
 
 	return Message{Role: RoleTool, ToolCallID: call.ID, Content: summary}
 }

--- a/skill/fs/loader.go
+++ b/skill/fs/loader.go
@@ -26,51 +26,74 @@ import (
 	openagent "github.com/yusheng-g/openagent-go"
 )
 
-// Loader discovers and loads skills from a directory tree.
+// Loader discovers and loads skills from one or more directory trees.
+// When multiple roots are given, Discover scans them in order and skills
+// in later roots override same-name skills from earlier roots (the
+// earlier entry keeps its position in the result, only its content is
+// replaced). This lets a project-level root (<cwd>/.agents/skills) take
+// priority over a user-level root (~/.agents/skills) when the project
+// root is passed last.
 type Loader struct {
-	root string
+	roots []string
 }
 
-// New creates a Loader rooted at the given directory.
-func New(root string) *Loader {
-	return &Loader{root: root}
+// New creates a Loader rooted at the given directories. With a single
+// root it behaves as a classic single-tree loader; passing multiple
+// roots enables the override semantics described on Loader.
+func New(roots ...string) *Loader {
+	return &Loader{roots: roots}
 }
 
-// Discover scans root for subdirectories containing SKILL.md, reads each
-// file's YAML frontmatter, and returns a SkillInfo for each valid skill.
-// Skills missing name or description are skipped.
+// Discover scans each root for subdirectories containing SKILL.md, reads
+// each file's YAML frontmatter, and returns a SkillInfo for each valid
+// skill. Roots are processed in order; a skill from a later root with
+// the same name as one from an earlier root replaces the earlier entry
+// in place (preserving its position), while skills with new names are
+// appended. Skills missing name or description are skipped. A root that
+// cannot be read is treated as empty rather than failing the whole call.
 func (l *Loader) Discover(ctx context.Context) ([]openagent.SkillInfo, error) {
-	entries, err := os.ReadDir(l.root)
-	if err != nil {
-		return nil, fmt.Errorf("read skills dir: %w", err)
-	}
-
 	var skills []openagent.SkillInfo
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		skillDir := filepath.Join(l.root, entry.Name())
-		mdPath := filepath.Join(skillDir, "SKILL.md")
+	indexByName := make(map[string]int)
 
-		fm, body, err := parseFrontmatter(mdPath)
+	for _, root := range l.roots {
+		entries, err := os.ReadDir(root)
 		if err != nil {
+			// Missing/unreadable root contributes nothing.
 			continue
 		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			skillDir := filepath.Join(root, entry.Name())
+			mdPath := filepath.Join(skillDir, "SKILL.md")
 
-		name, _ := fm["name"].(string)
-		desc, _ := fm["description"].(string)
-		if name == "" || desc == "" {
-			continue
+			fm, body, err := parseFrontmatter(mdPath)
+			if err != nil {
+				continue
+			}
+
+			name, _ := fm["name"].(string)
+			desc, _ := fm["description"].(string)
+			if name == "" || desc == "" {
+				continue
+			}
+
+			info := openagent.SkillInfo{
+				Name:        name,
+				Description: desc,
+				Frontmatter: fm,
+				Path:        skillDir,
+			}
+			_ = body
+
+			if idx, ok := indexByName[name]; ok {
+				skills[idx] = info // override in place, keep position
+			} else {
+				indexByName[name] = len(skills)
+				skills = append(skills, info)
+			}
 		}
-
-		skills = append(skills, openagent.SkillInfo{
-			Name:        name,
-			Description: desc,
-			Frontmatter: fm,
-			Path:        skillDir,
-		})
-		_ = body
 	}
 
 	return skills, nil

--- a/skill/fs/loader_test.go
+++ b/skill/fs/loader_test.go
@@ -1,0 +1,182 @@
+package fs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	openagent "github.com/yusheng-g/openagent-go"
+)
+
+// writeSkill creates <root>/<name>/SKILL.md with the given name and
+// description. The directory tree is created on demand.
+func writeSkill(t *testing.T, root, name, desc string) {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "---\nname: " + name + "\ndescription: " + desc + "\n---\nbody of " + name + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func namesOf(skills []openagent.SkillInfo) []string {
+	out := make([]string, len(skills))
+	for i, s := range skills {
+		out[i] = s.Name
+	}
+	return out
+}
+
+// TestLoader_SingleRoot mirrors the classic single-tree behaviour.
+func TestLoader_SingleRoot(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "alpha", "first")
+	writeSkill(t, root, "beta", "second")
+
+	skills, err := New(root).Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := namesOf(skills); len(got) != 2 {
+		t.Errorf("got %d skills, want 2: %v", len(got), got)
+	}
+}
+
+// TestLoader_NoRoots ensures an empty roots list yields no skills and no error.
+func TestLoader_NoRoots(t *testing.T) {
+	skills, err := New().Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skills) != 0 {
+		t.Errorf("got %d skills, want 0", len(skills))
+	}
+}
+
+// TestLoader_UnreadableRootSkipped verifies a missing root contributes
+// nothing instead of failing the whole Discover.
+func TestLoader_UnreadableRootSkipped(t *testing.T) {
+	good := t.TempDir()
+	writeSkill(t, good, "alpha", "first")
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+
+	skills, err := New(missing, good).Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := namesOf(skills); len(got) != 1 || got[0] != "alpha" {
+		t.Errorf("got %v, want [alpha]", got)
+	}
+}
+
+// TestLoader_OverrideSameName is the core guarantee: a skill in a later
+// root overrides the same-name skill from an earlier root, keeping the
+// original position and pointing Path at the later root's copy.
+func TestLoader_OverrideSameName(t *testing.T) {
+	home := t.TempDir() // earlier, less authoritative
+	cwd := t.TempDir()  // later, more authoritative
+	writeSkill(t, home, "shared", "from home")
+	writeSkill(t, cwd, "shared", "from cwd")
+	writeSkill(t, home, "only-home", "home exclusive")
+
+	skills, err := New(home, cwd).Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skills) != 2 {
+		t.Fatalf("got %d skills, want 2: %+v", len(skills), skills)
+	}
+
+	// Locate "shared" by name; its position is whatever ReadDir gave it
+	// on first discovery — what matters is that the entry was overridden
+	// in place (not appended as a duplicate).
+	var shared *openagent.SkillInfo
+	sharedCount := 0
+	for i := range skills {
+		if skills[i].Name == "shared" {
+			shared = &skills[i]
+			sharedCount++
+		}
+	}
+	if sharedCount != 1 {
+		t.Fatalf("found %d entries named shared, want 1 (override must not duplicate)", sharedCount)
+	}
+	// Content: overridden by cwd's copy.
+	if shared.Description != "from cwd" {
+		t.Errorf("shared description = %q, want %q", shared.Description, "from cwd")
+	}
+	// Path must point into cwd, the overriding root.
+	if shared.Path != filepath.Join(cwd, "shared") {
+		t.Errorf("shared Path = %q, want %q", shared.Path, filepath.Join(cwd, "shared"))
+	}
+
+	// only-home must still be present, untouched.
+	foundOnlyHome := false
+	for _, s := range skills {
+		if s.Name == "only-home" {
+			foundOnlyHome = true
+			if s.Description != "home exclusive" {
+				t.Errorf("only-home description = %q, want %q", s.Description, "home exclusive")
+			}
+		}
+	}
+	if !foundOnlyHome {
+		t.Error("only-home missing from result")
+	}
+}
+
+// TestLoader_DisjointNames keeps both skills when names differ.
+func TestLoader_DisjointNames(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	writeSkill(t, home, "home-skill", "home only")
+	writeSkill(t, cwd, "cwd-skill", "cwd only")
+
+	skills, err := New(home, cwd).Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skills) != 2 {
+		t.Fatalf("got %d skills, want 2: %+v", len(skills), skills)
+	}
+	got := map[string]bool{skills[0].Name: true, skills[1].Name: true}
+	if !got["home-skill"] || !got["cwd-skill"] {
+		t.Errorf("names = %v, want both home-skill and cwd-skill", skills)
+	}
+}
+
+// TestLoader_OnlyHomeRoot verifies a single existing home root works on
+// its own (cwd root absent).
+func TestLoader_OnlyHomeRoot(t *testing.T) {
+	home := t.TempDir()
+	writeSkill(t, home, "alpha", "first")
+	cwdMissing := filepath.Join(t.TempDir(), "nope")
+
+	skills, err := New(home, cwdMissing).Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := namesOf(skills); len(got) != 1 || got[0] != "alpha" {
+		t.Errorf("got %v, want [alpha]", got)
+	}
+}
+
+// TestLoader_OnlyCwdRoot verifies a single existing cwd root works on
+// its own (home root absent).
+func TestLoader_OnlyCwdRoot(t *testing.T) {
+	homeMissing := filepath.Join(t.TempDir(), "nope")
+	cwd := t.TempDir()
+	writeSkill(t, cwd, "beta", "second")
+
+	skills, err := New(homeMissing, cwd).Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := namesOf(skills); len(got) != 1 || got[0] != "beta" {
+		t.Errorf("got %v, want [beta]", got)
+	}
+}


### PR DESCRIPTION
## Changes

Switch skills loading from "first existing dir wins, single root" to "load both `~/.agents/skills` and `<cwd>/.agents/skills`, with `<cwd>` overriding `~/` on name clash", and drop all `.openagent/skills` logic.

### skill/fs/loader.go
- `fs.New(root string)` -> `fs.New(roots ...string)`; `Loader.root` -> `Loader.roots []string`
- `Discover` scans roots in order; a skill in a later root overrides a same-name skill from an earlier root in place (keeping position, replacing content); new names append. Unreadable roots are skipped.
- `Load` unchanged (uses `skill.Path`, root-independent)
- Single-root callers (`examples/iac`, `rest/handler.go`, `wasm/manager.go`, `iac-server`) need no changes thanks to the variadic signature.

### cmd/cli/server/shared.go
- `skillDirs()` now yields only `[~/.agents/skills, <cwd>/.agents/skills]` (home first, cwd last so cwd overrides); `.openagent/skills` entries removed; `home==cwd` deduplicated via a seen map.
- `openSkillLoader()` stats each candidate, passes the existing ones to `fs.New(roots...)`; returns nil when none exist.

### runner.go
- Add `skillsMu sync.RWMutex` guarding `r.skills`/`r.loadedSkills` against concurrent tool execution. `executeTools` dispatches approved tool calls with a WaitGroup; `load_skill`/`reload_skills` are built-in tools that read/write these fields concurrently, so the lock prevents concurrent map read/write fatal and data races.

## Tests
- `skill/fs/loader_test.go` (new): override-keeps-position-no-dup, disjoint names, single root, no roots, unreadable root skipped, only-home, only-cwd.
- `shared_test.go`: `TestOpenSkillLoader_MergesHomeAndCwd` exercises the full skillDirs->stat->fs.New->Discover chain with both dirs present and a same-name skill (cwd wins, both loaded, no duplicate); `TestSkillDirs_HomeEqualsCwd_Deduped` covers the dedup branch; existing `.openagent` assertions updated to `.agents`.
- `buildopts_test.go`: `.openagent/skills` -> `.agents/skills`.
- `go build ./...` + `go test -race -count=1 ./...` all green.