### PR TITLE
fix: normalize CRLF line endings in SKILL.md frontmatter parsing

### DIFF
--- a/skill/fs/loader.go
+++ b/skill/fs/loader.go
@@ -91,7 +91,11 @@ func parseFrontmatter(path string) (map[string]any, string, error) {
 		return nil, "", err
 	}
 
-	text := string(data)
+	// Normalize CRLF → LF so that SKILL.md files with Windows line
+	// endings are handled identically to Unix ones. This is an in-memory
+	// operation; the file on disk is not modified. LF-only files are
+	// unaffected (no \r\n sequences to replace).
+	text := strings.ReplaceAll(string(data), "\r\n", "\n")
 	if !strings.HasPrefix(text, "---\n") {
 		return nil, "", fmt.Errorf("no frontmatter")
 	}


### PR DESCRIPTION
## Summary

Normalize CRLF (`\r\n`) line endings before parsing `SKILL.md` frontmatter to avoid parsing issues.

## Changes

- `skill/fs/loader.go`: normalize line endings before frontmatter parsing (+5/-1)

## Test

- Unit + regression tests passing