### PR TITLE
BugFix: persist totalTokens && suppress plugin log when using keyring && normalize CRLF

### DIFF
--- a/acp/server.go
+++ b/acp/server.go
@@ -587,6 +587,46 @@ func (s *AgentServer) saveConfig(ctx context.Context, sessionID string) {
 	}
 }
 
+// saveTotalTokens persists the accumulated total token count to
+// SessionStore._meta["total_tokens"]. Called after each prompt completes
+// so /context survives server restarts.
+func (s *AgentServer) saveTotalTokens(ctx context.Context, sessionID string, n int) {
+	if s.SessionStore == nil {
+		return
+	}
+	info, err := s.SessionStore.Get(ctx, sessionID)
+	if err != nil || info == nil {
+		return
+	}
+	info.SetMeta("total_tokens", n)
+	info.UpdatedAt = time.Now()
+	_ = s.SessionStore.Save(ctx, *info)
+}
+
+// loadTotalTokens reads the persisted accumulated total token count from
+// SessionStore._meta["total_tokens"]. Returns 0 if unset or unavailable.
+func (s *AgentServer) loadTotalTokens(ctx context.Context, sessionID string) int {
+	if s.SessionStore == nil {
+		return 0
+	}
+	info, err := s.SessionStore.Get(ctx, sessionID)
+	if err != nil || info == nil || info.Meta == nil {
+		return 0
+	}
+	raw, ok := info.Meta["total_tokens"]
+	if !ok {
+		return 0
+	}
+	// JSON round-trip may yield float64; handle both int and float64.
+	switch v := raw.(type) {
+	case int:
+		return v
+	case float64:
+		return int(v)
+	}
+	return 0
+}
+
 // connectMCP connects to all configured MCP servers and returns the sessions.
 // Tools are listed once at connect time and cached — the connection is
 // long-lived (one connection per session lifetime).
@@ -799,6 +839,9 @@ func (s *AgentServer) OnLoadSession(ctx context.Context, req openacp.LoadSession
 		s.putSession(req.SessionID, ss)
 	}
 
+	// Restore accumulated token count so /context survives server restarts.
+	ss.totalTokens = s.loadTotalTokens(ctx, string(req.SessionID))
+
 	// Replay history from Memory if available.
 	if s.Mem != nil {
 		s.replayHistory(ctx, req.SessionID, sender)
@@ -942,6 +985,8 @@ func (s *AgentServer) OnResumeSession(ctx context.Context, req openacp.ResumeSes
 		ss.rt = s.buildRuntimeForSession(req.SessionID, ss)
 		s.putSession(req.SessionID, ss)
 	}
+	// Restore accumulated token count so /context survives server restarts.
+	ss.totalTokens = s.loadTotalTokens(ctx, string(req.SessionID))
 	// Load persisted plan into memory (no replay per ACP spec:
 	// session/resume MUST NOT replay history).
 	if ss.PlanEntries() == nil {
@@ -1417,6 +1462,7 @@ func (s *AgentServer) OnPrompt(ctx context.Context, req openacp.PromptRequest, s
 	}
 
 	ss.totalTokens += usage.TotalTokens
+	s.saveTotalTokens(ctx, string(req.SessionID), ss.totalTokens)
 
 	// Report *current* context usage (this turn's PromptTokens), not
 	// accumulated total. Per ACP spec, `used` means "tokens currently
@@ -1951,6 +1997,7 @@ func (s *AgentServer) buildSlashContext(ctx context.Context, sid openacp.Session
 				}
 			}
 			ss.totalTokens = 0
+			s.saveTotalTokens(ctx, string(sid), 0)
 			ss.ClearPlanEntries()
 			s.savePlan(ctx, string(sid), nil)
 			return nil

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -50,57 +50,19 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
-	wasmRuntime, err := cliwasm.NewRuntime(ctx)
-	if err != nil {
-		log.Fatalf("wasm runtime: %v", err)
-	}
-	defer wasmRuntime.Close(ctx)
-
 	// 4. Load every .wasm and route capabilities.
 	settings := raw
 	if len(settings) == 0 {
 		settings = []byte("{}")
 	}
-	mgr := plugin.NewManager(pluginPaths)
 	hub := &cliwasm.ObserverHub{}
-	for _, p := range pluginPaths {
-		files, _ := mgr.ResolveWasmFiles(p)
-		for _, f := range files {
-			wasmBytes, err := os.ReadFile(f)
-			if err != nil {
-				log.Printf("plugin: read %s: %v", f, err)
-				continue
-			}
-			mod, meta, err := wasmRuntime.Instantiate(ctx, wasmBytes, f)
-			if err != nil {
-				log.Printf("plugin: load %s: %v", f, err)
-				continue
-			}
 
-			log.Printf("plugin: loaded %s (%s) type=%s", meta.Name, meta.Description, meta.Type)
-
-			if meta.Is("settings") {
-				merged, err := mod.CallInit(ctx, settings)
-				if err != nil {
-					log.Printf("plugin %s init: %v", meta.Name, err)
-					continue
-				}
-				settings = merged
-			}
-
-			if meta.Is("commands") {
-				cmds, err := mod.ReadCommands(ctx)
-				if err != nil {
-					log.Printf("plugin %s commands: %v", meta.Name, err)
-					continue
-				}
-				registerCommands(rootCmd, cmds)
-			}
-
-			if meta.Is("observers") {
-				hub.Add(mod)
-			}
-		}
+	// keyring subcommands don't use plugins; skip loading to avoid
+	// plugin log noise on stdout/stderr.
+	if !isKeyringCmd(os.Args) {
+		var cleanup func()
+		settings, cleanup = loadPlugins(ctx, pluginPaths, settings, hub)
+		defer cleanup()
 	}
 
 	// 5. Parse final merged config.
@@ -387,6 +349,71 @@ func keyringOrFail() plugin.Keyring {
 			"fallback; original error: %v", err)
 	}
 	return sysKr
+}
+
+// isKeyringCmd reports whether the first non-flag argument is "keyring",
+// so plugin loading can be skipped for keyring subcommands.
+func isKeyringCmd(args []string) bool {
+	for _, a := range args[1:] {
+		if strings.HasPrefix(a, "-") {
+			continue
+		}
+		return a == "keyring"
+	}
+	return false
+}
+
+// loadPlugins instantiates the WASM runtime, loads every .wasm under
+// pluginPaths, and routes capabilities (settings merge, command
+// registration, observer wiring). Returns the possibly merged settings
+// and a cleanup func that closes the WASM runtime.
+func loadPlugins(ctx context.Context, pluginPaths []string, settings []byte, hub *cliwasm.ObserverHub) ([]byte, func()) {
+	wasmRuntime, err := cliwasm.NewRuntime(ctx)
+	if err != nil {
+		log.Fatalf("wasm runtime: %v", err)
+	}
+
+	mgr := plugin.NewManager(pluginPaths)
+	for _, p := range pluginPaths {
+		files, _ := mgr.ResolveWasmFiles(p)
+		for _, f := range files {
+			wasmBytes, err := os.ReadFile(f)
+			if err != nil {
+				log.Printf("plugin: read %s: %v", f, err)
+				continue
+			}
+			mod, meta, err := wasmRuntime.Instantiate(ctx, wasmBytes, f)
+			if err != nil {
+				log.Printf("plugin: load %s: %v", f, err)
+				continue
+			}
+
+			log.Printf("plugin: loaded %s (%s) type=%s", meta.Name, meta.Description, meta.Type)
+
+			if meta.Is("settings") {
+				merged, err := mod.CallInit(ctx, settings)
+				if err != nil {
+					log.Printf("plugin %s init: %v", meta.Name, err)
+					continue
+				}
+				settings = merged
+			}
+
+			if meta.Is("commands") {
+				cmds, err := mod.ReadCommands(ctx)
+				if err != nil {
+					log.Printf("plugin %s commands: %v", meta.Name, err)
+					continue
+				}
+				registerCommands(rootCmd, cmds)
+			}
+
+			if meta.Is("observers") {
+				hub.Add(mod)
+			}
+		}
+	}
+	return settings, func() { wasmRuntime.Close(ctx) }
 }
 
 var keyringCmd = &cobra.Command{Use: "keyring", Short: "Manage credentials in the system keyring"}

--- a/skill/fs/loader.go
+++ b/skill/fs/loader.go
@@ -92,7 +92,11 @@ func parseFrontmatter(path string) (map[string]any, string, error) {
 		return nil, "", err
 	}
 
-	text := string(data)
+	// Normalize CRLF → LF so that SKILL.md files with Windows line
+	// endings are handled identically to Unix ones. This is an in-memory
+	// operation; the file on disk is not modified. LF-only files are
+	// unaffected (no \r\n sequences to replace).
+	text := strings.ReplaceAll(string(data), "\r\n", "\n")
 	if !strings.HasPrefix(text, "---\n") {
 		return nil, "", fmt.Errorf("no frontmatter")
 	}


### PR DESCRIPTION
[fix(acp): persist totalTokens so /context survives server restart](https://github.com/yusheng-g/openagent-go/commit/2e7814ae1bdce40b093bd27d0c16b1abb02b7218)
-- solve the problem that /context always print 0 after restart

[fix(cli): skip plugin loading for keyring subcommands to suppress plugin logs](https://github.com/yusheng-g/openagent-go/commit/c0354fc91c2ec98455b4c30c9741037605a1ecec)
-- irrelevant plugin log pollutes acp log when setting keyring

[fix: normalize CRLF line endings in SKILL.md frontmatter parsing](https://github.com/yusheng-g/openagent-go/pull/60/commits/09483f6d28d2d0e97e6153bc08317a1216ed2fee)
-- solve skill load problem when there is crlf not normalized