### PR TITLE
fix(acp): session title garbled when truncated at multi-byte UTF-8 boundary

### DIFF
--- a/acp/server.go
+++ b/acp/server.go
@@ -2118,8 +2118,9 @@ func firstLine(s string, maxLen int) string {
 	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
 		s = s[:idx]
 	}
-	if len(s) > maxLen {
-		return s[:maxLen] + "..."
+	runes := []rune(s)
+	if len(runes) > maxLen {
+		return string(runes[:maxLen]) + "..."
 	}
 	return s
 }


### PR DESCRIPTION
fix(acp): session title garbled when truncated at multi-byte UTF-8 boundary
The /sessions command displays garbled characters ( ) when a session
auto-title derived from the first user message contains multi-byte UTF-8
characters (e.g., Chinese) and exceeds the 80-rune limit.

Root cause: firstLine() in acp/server.go used byte-level slicing (
s[:maxLen]) to truncate the title string. In Go, len(s) returns the byte
count, not character count, and s[:maxLen] slices at a byte boundary.
When maxLen falls in the middle of a multi-byte UTF-8 sequence (Chinese
characters are 3 bytes each), it produces invalid UTF-8 output rendered
as replacement characters.

Fix: convert the string to []rune before truncating, matching the
existing pattern used by truncateStr in tool/shell.go, orchestrator/
planner.go, and summarizer/llm.go.

Changed file: acp/server.go - firstLine() function