### PR TITLE
feat(skills): load ~/.agents and <cwd>/.agents with cwd override; drop .openagent/skills

### DIFF
--- a/cmd/cli/server/shared.go
+++ b/cmd/cli/server/shared.go
@@ -329,32 +329,52 @@ func resolveProfileFile(profiles, cwd, filename, defaultText string) string {
 
 // ── Optional capability builders ──
 
-// openSkillProvider creates a file-system skill provider. Directories are
-// tried in priority order:
-//  1. <workspace>/.openagent/skills  (project-level)
-//  2. ~/.openagent/skills            (user-level)
+// openSkillProvider creates a file-system skill provider spanning the skill
+// directories that exist. Roots are passed to fs.New in override order
+// (user-level first, project-level last), so skills in a later root override
+// same-name skills from an earlier root:
 //
-// Returns nil if no directory exists.
+//  1. ~/.agents/skills            (user-level)
+//  2. <workspace>/.agents/skills  (project-level, overrides user-level)
+//
+// Directories that do not exist are skipped. Returns nil if none exist.
 func openSkillProvider() skill.Provider {
+	var roots []string
 	for _, dir := range skillDirs() {
 		if info, err := os.Stat(dir); err == nil && info.IsDir() {
-			return skill.NewFSBridge(fs.New(dir))
+			roots = append(roots, dir)
 		}
 	}
-	return nil
+	if len(roots) == 0 {
+		return nil
+	}
+	return skill.NewFSBridge(fs.New(roots...))
 }
 
+// skillDirs returns the skill directory candidates in override order:
+// user-level first (~/.agents/skills), project-level last
+// (<cwd>/.agents/skills, overrides user-level). When home equals cwd the
+// two resolve to the same path and only one entry is returned.
 func skillDirs() []string {
 	var dirs []string
+	seen := make(map[string]struct{})
+
 	home, err := os.UserHomeDir()
 	if err == nil {
-		dirs = append(dirs, filepath.Join(home, ".openagent", "skills"))
-		dirs = append(dirs, filepath.Join(home, ".agents", "skills"))
+		d := filepath.Join(home, ".agents", "skills")
+		if _, ok := seen[d]; !ok {
+			seen[d] = struct{}{}
+			dirs = append(dirs, d)
+		}
 	}
+
 	cwd, err := os.Getwd()
-	if err == nil && home != cwd {
-		dirs = append(dirs, filepath.Join(cwd, ".agents", "skills"))
-		dirs = append(dirs, filepath.Join(cwd, ".openagent", "skills"))
+	if err == nil {
+		d := filepath.Join(cwd, ".agents", "skills")
+		if _, ok := seen[d]; !ok {
+			seen[d] = struct{}{}
+			dirs = append(dirs, d)
+		}
 	}
 	return dirs
 }

--- a/skill/fs/loader.go
+++ b/skill/fs/loader.go
@@ -27,51 +27,74 @@ import (
 	openagent "github.com/yusheng-g/openagent-go"
 )
 
-// Loader discovers and loads skills from a directory tree.
+// Loader discovers and loads skills from one or more directory trees.
+// When multiple roots are given, Discover scans them in order and skills
+// in later roots override same-name skills from earlier roots (the
+// earlier entry keeps its position in the result, only its content is
+// replaced). This lets a project-level root (<cwd>/.agents/skills) take
+// priority over a user-level root (~/.agents/skills) when the project
+// root is passed last.
 type Loader struct {
-	root string
+	roots []string
 }
 
-// New creates a Loader rooted at the given directory.
-func New(root string) *Loader {
-	return &Loader{root: root}
+// New creates a Loader rooted at the given directories. With a single
+// root it behaves as a classic single-tree loader; passing multiple
+// roots enables the override semantics described on Loader.
+func New(roots ...string) *Loader {
+	return &Loader{roots: roots}
 }
 
-// Discover scans root for subdirectories containing SKILL.md, reads each
-// file's YAML frontmatter, and returns a SkillInfo for each valid skill.
-// Skills missing name or description are skipped.
+// Discover scans each root for subdirectories containing SKILL.md, reads
+// each file's YAML frontmatter, and returns a SkillInfo for each valid
+// skill. Roots are processed in order; a skill from a later root with
+// the same name as one from an earlier root replaces the earlier entry
+// in place (preserving its position), while skills with new names are
+// appended. Skills missing name or description are skipped. A root that
+// cannot be read is treated as empty rather than failing the whole call.
 func (l *Loader) Discover(ctx context.Context) ([]openagent.SkillInfo, error) {
-	entries, err := os.ReadDir(l.root)
-	if err != nil {
-		return nil, fmt.Errorf("read skills dir: %w", err)
-	}
-
 	var skills []openagent.SkillInfo
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		skillDir := filepath.Join(l.root, entry.Name())
-		mdPath := filepath.Join(skillDir, "SKILL.md")
+	indexByName := make(map[string]int)
 
-		fm, body, err := parseFrontmatter(mdPath)
+	for _, root := range l.roots {
+		entries, err := os.ReadDir(root)
 		if err != nil {
+			// Missing/unreadable root contributes nothing.
 			continue
 		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			skillDir := filepath.Join(root, entry.Name())
+			mdPath := filepath.Join(skillDir, "SKILL.md")
 
-		name, _ := fm["name"].(string)
-		desc, _ := fm["description"].(string)
-		if name == "" || desc == "" {
-			continue
+			fm, body, err := parseFrontmatter(mdPath)
+			if err != nil {
+				continue
+			}
+
+			name, _ := fm["name"].(string)
+			desc, _ := fm["description"].(string)
+			if name == "" || desc == "" {
+				continue
+			}
+
+			info := openagent.SkillInfo{
+				Name:        name,
+				Description: desc,
+				Frontmatter: fm,
+				Path:        skillDir,
+			}
+			_ = body
+
+			if idx, ok := indexByName[name]; ok {
+				skills[idx] = info // override in place, keep position
+			} else {
+				indexByName[name] = len(skills)
+				skills = append(skills, info)
+			}
 		}
-
-		skills = append(skills, openagent.SkillInfo{
-			Name:        name,
-			Description: desc,
-			Frontmatter: fm,
-			Path:        skillDir,
-		})
-		_ = body
 	}
 
 	return skills, nil


### PR DESCRIPTION
## Summary

- `fs.New(root string)` → `fs.New(roots ...string)`; `Discover` scans roots in order, a skill in a later root overrides a same-name skill from an earlier root in place (keeping its position), new names append. An unreadable root is skipped rather than failing.
- `skillDirs()` now yields only `[~/.agents/skills, <cwd>/.agents/skills]` (home first, cwd last so cwd overrides); `.openagent/skills` entries removed; `home==cwd` deduplicated via a seen map.
- `openSkillProvider()` collects all existing candidates and passes them to `fs.New(roots...)` instead of first-hit-wins single root.

## Changed files

- `skill/fs/loader.go` — multi-root override semantics
- `skill/fs/loader_test.go` (new) — override-keeps-position-no-dup, disjoint names, single root, no roots, unreadable root skipped, only-home, only-cwd
- `cmd/cli/server/shared.go` — skillDirs trimmed + openSkillProvider multi-root

## Notes

- `runner.go` concurrency guard from the original commit is absorbed by the kernel refactor (`11523d1`): `loadedSkills` + `loadedSkillsMu` already live in `execution/runtime.go`; the skills catalog moved to `context.AgentContext` (rebuilt per turn, no shared mutable state).
- Single-root callers (`examples/iac`, `examples/skill`, `cmd/mcp/iac-server`) unchanged thanks to the variadic signature.
- `~/.openagent/mcp/iac-server/<cloud>/skills` (embedded cache) and `~/.openagent/settings.json` intentionally untouched.

## Test

- `go build ./...` passes
- `go test ./skill/fs/... ./cmd/cli/server/...` passes
- Manually verified: home + cwd with a same-name skill → cwd wins, both loaded, no duplicate