### PR TITLE
feat(model):  remember model selection + support plugin set model_config + remember slash command

### DIFF
--- a/acp/server.go
+++ b/acp/server.go
@@ -1339,6 +1339,10 @@ func (s *AgentServer) OnPrompt(ctx context.Context, req openacp.PromptRequest, s
 	// Must run BEFORE auto-title so slash commands don't get used as
 	// the session title (e.g. "/mode plan" would become the title).
 	if resp, handled := s.cmdRegistry.Handle(s.buildSlashContext(ctx, req.SessionID, ss), input.Content); handled {
+		if s.Mem != nil {
+			_ = s.Mem.Append(ctx, string(req.SessionID), input)
+			_ = s.Mem.Append(ctx, string(req.SessionID), openagent.Message{Role: openagent.RoleAssistant, Content: resp})
+		}
 		sender.SendAgentMessage(resp)
 		return &openacp.PromptResponse{StopReason: openacp.StopReasonEndTurn}, nil
 	}

--- a/acp/server.go
+++ b/acp/server.go
@@ -367,23 +367,44 @@ var _ openacp.AgentHandler = (*AgentServer)(nil)
 // runtime_set_model_config. When the model already exists, empty apiKey
 // or baseURL preserve the originals; when inserting a new model, values
 // are used as-is.
-func (s *AgentServer) SetModel(provider, modelID, apiKey, baseURL string) {
+func (s *AgentServer) SetModel(provider, modelID, apiKey, baseURL string, maxInputTokens, maxOutputTokens int) {
 	s.modelsMu.Lock()
 	defer s.modelsMu.Unlock()
 	key := provider + "/" + modelID
-	if old, ok := s.modelConfigs[key]; ok {
-		if apiKey == "" {
-			apiKey = old.APIKey
+	old, exists := s.modelConfigs[key]
+	if apiKey == "" {
+		apiKey = old.APIKey
+	}
+	if baseURL == "" {
+		baseURL = old.BaseURL
+	}
+	cw := maxInputTokens
+	if cw == 0 {
+		if oldModel, ok := s.Models[key]; ok {
+			cw = oldModel.ContextWindow()
 		}
-		if baseURL == "" {
-			baseURL = old.BaseURL
-		}
+	}
+	mot := maxOutputTokens
+	if mot == 0 {
+		mot = old.MaxOutputTokens
+	}
+	if exists {
 		slog.Info("acp updating model", "key", key)
 	} else {
 		slog.Info("acp inserting model", "key", key)
 	}
-	s.Models[key] = openai.New(apiKey, modelID, baseURL)
-	s.modelConfigs[key] = ModelConfig{Provider: provider, ModelID: modelID, APIKey: apiKey, BaseURL: baseURL}
+	m := openai.New(apiKey, modelID, baseURL)
+	if cw > 0 {
+		m = m.WithContextWindow(cw)
+	}
+	s.Models[key] = m
+	s.modelConfigs[key] = ModelConfig{
+		Provider: provider, ModelID: modelID, APIKey: apiKey, BaseURL: baseURL,
+		MaxOutputTokens:        mot,
+		InputCostPerToken:      old.InputCostPerToken,
+		InputCacheCostPerToken: old.InputCacheCostPerToken,
+		OutputCostPerToken:     old.OutputCostPerToken,
+	}
 }
 
 // SetDefaultModelID sets the default model used when a session has not
@@ -2014,10 +2035,15 @@ func (s *AgentServer) buildSlashContext(ctx context.Context, sid openacp.Session
 			return out, nil
 		},
 		SetModel: func(modelID string) error {
-			if _, ok := s.Models[modelID]; !ok {
+			m, ok := s.Models[modelID]
+			if !ok {
 				return fmt.Errorf("unknown model: %s", modelID)
 			}
 			ss.config["model"] = modelID
+			if ss.rt != nil {
+				ss.rt.SetModel(m)
+			}
+			s.saveConfig(ctx, string(sid))
 			if s.updateSender != nil {
 				opts := s.buildConfigOptions(sid)
 				s.updateSender.SendSessionUpdate(sid, openacp.SessionUpdate{

--- a/plugin/agent/wasm/abi.go
+++ b/plugin/agent/wasm/abi.go
@@ -106,7 +106,7 @@ const (
 // Agent config and Session. The Get/Set closures directly read/write
 // Agent and Session fields. setModel is called by runtime_set_model_config
 // to replace a model in the global registry; it may be nil.
-func BuildAgentRuntime(rt *kernel.Runtime, session *openagent.Session, setModel func(provider, modelID, apiKey, baseURL string)) *wasmhost.AgentRuntime {
+func BuildAgentRuntime(rt *kernel.Runtime, session *openagent.Session, setModel func(provider, modelID, apiKey, baseURL string, maxInputTokens, maxOutputTokens int)) *wasmhost.AgentRuntime {
 	return &wasmhost.AgentRuntime{
 		SetModel: setModel,
 		Get: func(key string) (string, bool) {

--- a/plugin/wasmhost/host_api.go
+++ b/plugin/wasmhost/host_api.go
@@ -61,7 +61,7 @@ type Logger interface {
 type AgentRuntime struct {
 	Get      func(key string) (string, bool)
 	Set      func(key string, value string) error
-	SetModel func(provider, modelID, apiKey, baseURL string)
+	SetModel func(provider, modelID, apiKey, baseURL string, maxInputTokens, maxOutputTokens int)
 }
 
 // Runtime key constants used by AgentRuntime.Get/Set.

--- a/plugin/wasmhost/host_module.go
+++ b/plugin/wasmhost/host_module.go
@@ -351,10 +351,12 @@ func (h *HostAPI) runtimeSetModelConfig(ctx context.Context, mod api.Module, raw
 		return WriteString(ctx, mod, b)
 	}
 	var mc struct {
-		Provider string `json:"provider"`
-		ModelID  string `json:"model_id"`
-		APIKey   string `json:"api_key"`
-		BaseURL  string `json:"base_url"`
+		Provider       string `json:"provider"`
+		ModelID        string `json:"model_id"`
+		APIKey         string `json:"api_key"`
+		BaseURL        string `json:"base_url"`
+		MaxInputTokens int    `json:"max_input_tokens"`
+		MaxOutputTokens int   `json:"max_output_tokens"`
 	}
 	if err := json.Unmarshal([]byte(raw), &mc); err != nil {
 		b, _ := json.Marshal(map[string]string{"error": err.Error()})
@@ -364,7 +366,7 @@ func (h *HostAPI) runtimeSetModelConfig(ctx context.Context, mod api.Module, raw
 		b, _ := json.Marshal(map[string]string{"error": "provider and model_id are required"})
 		return WriteString(ctx, mod, b)
 	}
-	rt.SetModel(mc.Provider, mc.ModelID, mc.APIKey, mc.BaseURL)
+	rt.SetModel(mc.Provider, mc.ModelID, mc.APIKey, mc.BaseURL, mc.MaxInputTokens, mc.MaxOutputTokens)
 	b, _ := json.Marshal(map[string]string{})
 	return WriteString(ctx, mod, b)
 }

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -125,11 +125,12 @@ func (h *Handler) RegisterModel(id string, model openagent.Model, provider, apiK
 // SetModel replaces or inserts a model in the registry. apiKey and baseURL
 // override the originals only when non-empty (update) or are used as-is
 // (insert). Used by runtime_set_model_config host export.
-func (h *Handler) SetModel(provider, modelID, apiKey, baseURL string) {
+func (h *Handler) SetModel(provider, modelID, apiKey, baseURL string, maxInputTokens, maxOutputTokens int) {
 	h.modelsMu.Lock()
 	defer h.modelsMu.Unlock()
 	key := provider + "/" + modelID
-	if old, ok := h.modelConfigs[key]; ok {
+	old, ok := h.modelConfigs[key]
+	if ok {
 		if apiKey == "" {
 			apiKey = old.APIKey
 		}
@@ -140,7 +141,17 @@ func (h *Handler) SetModel(provider, modelID, apiKey, baseURL string) {
 		// New model: add to modelList so /models endpoint includes it.
 		h.modelList = append(h.modelList, ModelInfo{ID: modelID, Provider: provider})
 	}
-	h.models[key] = openai.New(apiKey, modelID, baseURL)
+	cw := maxInputTokens
+	if cw == 0 {
+		if oldModel, ok := h.models[key]; ok {
+			cw = oldModel.ContextWindow()
+		}
+	}
+	m := openai.New(apiKey, modelID, baseURL)
+	if cw > 0 {
+		m = m.WithContextWindow(cw)
+	}
+	h.models[key] = m
 	h.modelConfigs[key] = ModelConfig{Provider: provider, ModelID: modelID, APIKey: apiKey, BaseURL: baseURL}
 }
 


### PR DESCRIPTION
- add max_input_tokens/max_output_tokens across SetModel signature, host_module JSON tags, and AgentRuntime to match ModelConfig's naming convention.
- SetModel now preserves old contextWindow/MaxOutputTokens/pricing when new values are 0 (runtime renewal no longer wipes limits).
- /model slash command now calls ss.rt.SetModel(m) for immediate base_url/model swap, matching the GUI dropdown path.
- /model now calls saveConfig to persist selection to session meta.
- add slash command to memory