### PR TITLE
fix(acp): model switch uses stale base_url — oaSession.Model defeats SetModel

### DIFF
--- a/acp/server.go
+++ b/acp/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/yusheng-g/openagent-go/process"
 	"github.com/yusheng-g/openagent-go/session"
 	"github.com/yusheng-g/openagent-go/slash"
+	"github.com/yusheng-g/openagent-go/summarizer"
 	opentool "github.com/yusheng-g/openagent-go/tool"
 	"github.com/yusheng-g/openagent-go/utils"
 )
@@ -85,6 +86,13 @@ type AgentServer struct {
 	// Plugin manager and model config backup for runtime_set_model_config.
 	PluginMgr    *wasm.Manager
 	modelConfigs map[string]ModelConfig // "provider/modelID" → original config
+
+	// Summarizer and extractor are updated alongside the session runtime
+	// when the user switches models, so background compression and
+	// knowledge extraction use the current provider instead of the
+	// first-configured one.
+	Summarizer *summarizer.Compressor
+	Extractor  *ctxpkg.AsyncExtractor
 
 	// approvalMemory persists session-scoped "allow always" decisions.
 	approvalMemory governance.ApprovalMemory
@@ -596,6 +604,37 @@ func (s *AgentServer) resolveModelConfig(ss *agentSession) (provider, modelID st
 		return mc.Provider, mc.ModelID
 	}
 	return "", key
+}
+
+// resolveSessionModel returns the model for the session's current config
+// (session "model" config value wins over the server default). Unlike
+// Runtime.Model() which returns the previous run's snapshot (runModel),
+// this reads from the registry so it reflects SetModel updates —
+// critical for oaSession.Model in OnPrompt so run()'s session.Model
+// override does not defeat a mid-session model switch.
+func (s *AgentServer) resolveSessionModel(ss *agentSession) openagent.Model {
+	key := s.getDefaultModelID()
+	if val, ok := ss.ConfigString("model"); ok {
+		key = val
+	}
+	m, _ := s.lookupModel(key)
+	return m
+}
+
+// switchSessionModel updates the session runtime, summarizer, and
+// extractor to the new model. Called from all model-switch entry points
+// (set_config_option "model", slash /model) so background components
+// stay in sync with the conversation model.
+func (s *AgentServer) switchSessionModel(ss *agentSession, m openagent.Model) {
+	if rt := ss.getRuntime(); rt != nil {
+		rt.SetModel(m)
+	}
+	if s.Summarizer != nil {
+		s.Summarizer.SetModel(m)
+	}
+	if s.Extractor != nil {
+		s.Extractor.SetModel(m)
+	}
 }
 
 // ── Client capability helpers ──
@@ -1406,7 +1445,7 @@ func (s *AgentServer) OnSetSessionConfigOption(ctx context.Context, req openacp.
 		case "model":
 			if v, ok := ss.ConfigString("model"); ok {
 				if m, ok := s.lookupModel(v); ok {
-					rt.SetModel(m)
+					s.switchSessionModel(ss, m)
 				} else {
 					// The requested model is not in the provider list —
 					// keep the current model, but don't stay silent.
@@ -1508,8 +1547,11 @@ func (s *AgentServer) OnPrompt(ctx context.Context, req openacp.PromptRequest, s
 		// (RunHooks via SessionFromContext, e.g. the artifact hook's
 		// context-window threshold) can read ContextWindow() without
 		// depending on every call site to re-resolve from ModelID.
-		// buildRuntimeForSession already set clone.Model to the selected model.
-		Model:     agent.Model(),
+		// Use resolveSessionModel (reads the registry) instead of
+		// agent.Model() (returns the previous run's runModel snapshot)
+		// so run()'s session.Model override does not defeat a
+		// mid-session SetModel update.
+		Model:     s.resolveSessionModel(ss),
 		CreatedAt: ss.createdAt,
 		Metadata: map[string]any{
 			"cwd":                   ss.cwd,
@@ -2183,9 +2225,7 @@ func (s *AgentServer) buildSlashContext(ctx context.Context, sid openacp.Session
 				return fmt.Errorf("unknown model: %s", modelID)
 			}
 			ss.SetConfigValue("model", modelID)
-			if rt := ss.getRuntime(); rt != nil {
-				rt.SetModel(m)
-			}
+			s.switchSessionModel(ss, m)
 			s.saveConfig(ctx, string(sid))
 			if s.updateSender != nil {
 				opts := s.buildConfigOptions(sid)

--- a/cmd/cli/server/acp.go
+++ b/cmd/cli/server/acp.go
@@ -82,8 +82,10 @@ func RunACP(ctx context.Context, cfg *config.Config, caps config.Capabilities) e
 		deps.MemoryProvider = knowledge
 	}
 
+	var sumz *summarizer.Compressor
 	if caps.OnMemory() && caps.OnSummarizer() && firstM != nil {
-		ms.WithSummarizer(summarizer.New(firstM).WithMaxTokens(agentCfg.MaxCompressedTokens))
+		sumz = summarizer.New(firstM).WithMaxTokens(agentCfg.MaxCompressedTokens)
+		ms.WithSummarizer(sumz)
 	}
 
 	// Plugin manager — loads agent:tools and agent:observers plugins.
@@ -113,8 +115,10 @@ func RunACP(ctx context.Context, cfg *config.Config, caps config.Capabilities) e
 	// AFTER applyContextProviders so the effective provider is used.
 	// Building it earlier would fork writes to the local sqlite store
 	// while Recall reads the OpenViking index (silent knowledge loss).
+	var extractor *ctxpkg.AsyncExtractor
 	if caps.OnMemory() && firstM != nil && deps.MemoryProvider != nil {
-		deps.Extractor = ctxpkg.NewAsyncExtractor(ctxpkg.NewLLMExtractor(firstM, deps.MemoryProvider))
+		extractor = ctxpkg.NewAsyncExtractor(ctxpkg.NewLLMExtractor(firstM, deps.MemoryProvider))
+		deps.Extractor = extractor
 	}
 	srv := acp.NewAgentServer(agentCfg, deps, sessionStore, modelMap)
 	srv.AgentName = version.Name
@@ -122,6 +126,8 @@ func RunACP(ctx context.Context, cfg *config.Config, caps config.Capabilities) e
 	srv.MCPEnabled = caps.OnMCP()
 	srv.DefaultMode = cfg.DefaultMode
 	srv.PluginMgr = pluginMgr
+	srv.Summarizer = sumz
+	srv.Extractor = extractor
 	srv.ProfileResolver = func(cwd string) []string {
 		return resolveProfiles(cfg.Profiles, cwd)
 	}

--- a/context/async_extractor.go
+++ b/context/async_extractor.go
@@ -46,6 +46,18 @@ func NewAsyncExtractor(inner Extractor) *AsyncExtractor {
 	return e
 }
 
+// SetModel updates the model on the inner LLMExtractor if present.
+// Safe to call concurrently with Extract; the next background pass
+// uses the new model.
+func (e *AsyncExtractor) SetModel(m openagent.Model) {
+	if e == nil {
+		return
+	}
+	if llm, ok := e.inner.(*LLMExtractor); ok {
+		llm.SetModel(m)
+	}
+}
+
 // Extract implements Extractor: enqueue (non-blocking, ~µs). The actual
 // extraction runs on the background worker.
 func (e *AsyncExtractor) Extract(ctx context.Context, scope ContextScope, messages []openagent.Message) {

--- a/context/extractor_llm.go
+++ b/context/extractor_llm.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 
 	openagent "github.com/yusheng-g/openagent-go"
 )
@@ -68,6 +69,7 @@ const maxKnowledgeItems = 10
 
 // LLMExtractor extracts knowledge with the runtime model.
 type LLMExtractor struct {
+	mu sync.RWMutex
 	// Model is the model used for extraction (the runtime's resolved model).
 	Model openagent.Model
 	// Provider stores extracted knowledge.
@@ -81,9 +83,20 @@ func NewLLMExtractor(model openagent.Model, p MemoryProvider) *LLMExtractor {
 	return &LLMExtractor{Model: model, Provider: p, MaxItems: maxKnowledgeItems}
 }
 
+// SetModel updates the model used for extraction. Safe to call
+// concurrently with Extract; the next call uses the new model.
+func (e *LLMExtractor) SetModel(m openagent.Model) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.Model = m
+}
+
 // Extract implements Extractor.
 func (e *LLMExtractor) Extract(ctx context.Context, scope ContextScope, messages []openagent.Message) {
-	if e == nil || e.Model == nil || e.Provider == nil || len(messages) == 0 {
+	e.mu.RLock()
+	model := e.Model
+	e.mu.RUnlock()
+	if e == nil || model == nil || e.Provider == nil || len(messages) == 0 {
 		return
 	}
 	max := e.MaxItems
@@ -114,7 +127,7 @@ func (e *LLMExtractor) Extract(ctx context.Context, scope ContextScope, messages
 	input := "Conversation:\n" + transcript +
 		"\n\nExisting knowledge:\n" + existingText.String()
 
-	resp, err := e.Model.ChatCompletion(ctx, openagent.ChatCompletionRequest{
+	resp, err := model.ChatCompletion(ctx, openagent.ChatCompletionRequest{
 		Messages: []openagent.Message{
 			{Role: openagent.RoleSystem, Content: extractionPrompt},
 			{Role: openagent.RoleUser, Content: input},

--- a/summarizer/llm.go
+++ b/summarizer/llm.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	openagent "github.com/yusheng-g/openagent-go"
 )
@@ -18,6 +19,7 @@ import (
 // Compressor implements openagent.Summarizer by calling the configured
 // Model to produce incremental summaries.
 type Compressor struct {
+	mu        sync.RWMutex
 	model     openagent.Model
 	maxTokens int // 0 = no hint; non-zero = prompt the model to keep the summary under this
 }
@@ -25,6 +27,14 @@ type Compressor struct {
 // New creates a Compressor backed by m.
 func New(m openagent.Model) *Compressor {
 	return &Compressor{model: m}
+}
+
+// SetModel updates the model used for summarization. Safe to call
+// concurrently with Summarize; the next call uses the new model.
+func (c *Compressor) SetModel(m openagent.Model) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.model = m
 }
 
 // WithMaxTokens sets a SOFT target for the summary size: the budget is
@@ -45,7 +55,10 @@ func (c *Compressor) WithMaxTokens(n int) *Compressor {
 // existing summary, producing an updated CompressedContext whose
 // ThroughIndex is left at zero (the caller sets it).
 func (c *Compressor) Summarize(ctx context.Context, messages []openagent.Message, previous *openagent.CompressedContext) (*openagent.CompressedContext, error) {
-	if c.model == nil {
+	c.mu.RLock()
+	model := c.model
+	c.mu.RUnlock()
+	if model == nil {
 		return nil, fmt.Errorf("summarizer: no model configured")
 	}
 	if len(messages) == 0 {
@@ -56,7 +69,7 @@ func (c *Compressor) Summarize(ctx context.Context, messages []openagent.Message
 	// No MaxTokens on purpose: a hard output cap truncates the JSON
 	// envelope mid-stream and parseSummary rejects it. Length control is
 	// the prompt hint below plus the prompt-side truncation in kernel.
-	resp, err := c.model.ChatCompletion(ctx, openagent.ChatCompletionRequest{
+	resp, err := model.ChatCompletion(ctx, openagent.ChatCompletionRequest{
 		Messages: []openagent.Message{
 			{Role: openagent.RoleSystem, Content: summarizeSystemPrompt},
 			{Role: openagent.RoleUser, Content: prompt},


### PR DESCRIPTION
OnPrompt set oaSession.Model to agent.Model() which returns rt.runModel (the previous run's snapshot), not rt.cfg.Model (current). In run(), session.Model (non-nil, stale) overrode the SetModel update, sending the new model ID to the old provider's base_url — a 400 mismatch.

Fix: resolve oaSession.Model from the registry via resolveSessionModel so it matches rt.cfg.Model; the session.Model override in run() becomes a no-op. Also sync summarizer and extractor on model switch via switchSessionModel so background compression/extraction follow the current provider instead of the first-configured one.