### PR TITLE
fix(plan): correct plan mode system prompts to accurately reflect available tools

### DIFF
--- a/acp/server.go
+++ b/acp/server.go
@@ -2113,16 +2113,18 @@ func (s *AgentServer) buildDynamicContext(ss *agentSession) string {
 	// ── Mode instruction ──
 	if mode == "plan" {
 		b.WriteString("## Plan Mode\n")
-		b.WriteString("You are in **plan mode**. You have NO execution tools — you cannot modify files, run shell commands, or create terminals. ")
+		b.WriteString("You are in **plan mode**. You have NO execution tools — you cannot modify files, run shell commands, or create terminals.\n\n")
+		b.WriteString("Your available tools:\n")
+		b.WriteString("- read, ls, grep — read and search workspace files\n")
+		b.WriteString("- webfetch, websearch — fetch web content and search the internet\n")
+		b.WriteString("- recall — search conversation history for details not covered by the summary\n")
+		b.WriteString("- load_skill, reload_skills — load and manage skill definitions\n")
 		if s.clientCanReadFile() {
-			b.WriteString("Your only tools are read-only inspection (read_client_file) and planning (plan_create, plan_update, exit_plan_mode).\n\n")
-			b.WriteString("**Workflow:**\n")
-			b.WriteString("1. Read and analyze relevant files to understand the task\n")
-		} else {
-			b.WriteString("Your only tools are planning (plan_create, plan_update, exit_plan_mode). You have no file-reading tools in this mode — base your plan on the user's description and any context already provided.\n\n")
-			b.WriteString("**Workflow:**\n")
-			b.WriteString("1. Analyze the task from the user's description and available context\n")
+			b.WriteString("- read_client_file — read files from your machine\n")
 		}
+		b.WriteString("- plan_create, plan_update, exit_plan_mode — create, update, and exit an execution plan\n")
+		b.WriteString("\n**Workflow:**\n")
+		b.WriteString("1. Explore — read relevant files, search the web, and recall context to understand the task\n")
 		b.WriteString("2. Call plan_create with concrete, actionable steps\n")
 		b.WriteString("3. Call exit_plan_mode to leave plan mode and begin execution\n\n")
 		b.WriteString("Create a complete plan before calling exit_plan_mode.\n")

--- a/plan/tool.go
+++ b/plan/tool.go
@@ -168,7 +168,7 @@ func (t *EnterTool) Definition() openagent.FunctionDefinition {
 		Name: "enter_plan_mode",
 		Description: `Enter plan mode to create a structured execution plan. Use this when the task is complex, involves multiple steps, spans multiple files, or requires careful sequencing.
 
-After entering plan mode, you will have access to plan_create, plan_update, and exit_plan_mode. Your execution tools (shell, file writes, terminal) will be temporarily unavailable — they will be restored when you call exit_plan_mode.
+After entering plan mode, your execution tools (shell, file writes, terminal) are temporarily removed. Your read-only tools (read, ls, grep, webfetch, websearch, recall, load_skill, reload_skills) remain available, and you gain access to plan_create, plan_update, and exit_plan_mode.
 
 Workflow: enter_plan_mode → plan_create → exit_plan_mode → execute`,
 		Parameters: openagent.SchemaOf[struct{}](),
@@ -184,7 +184,7 @@ func (t *EnterTool) Execute(ctx context.Context, args json.RawMessage) *openagen
 	if err := t.onEnter(); err != nil {
 		return openagent.ErrorResult(fmt.Errorf("enter_plan_mode: %w", err), false, "")
 	}
-	return &openagent.ToolResult{Content: "Entered plan mode. You now have access to plan_create and exit_plan_mode. Execution tools are disabled until you call exit_plan_mode. Create a plan with plan_create, then call exit_plan_mode when ready to execute.\n"}
+	return &openagent.ToolResult{Content: "Entered plan mode. Execution tools are disabled. You now have access to read-only tools (read, ls, grep, webfetch, websearch, recall, load_skill, reload_skills) and plan tools (plan_create, plan_update, exit_plan_mode). Create a plan with plan_create, then call exit_plan_mode when ready to execute.\n"}
 }
 
 // ── exit_plan_mode Tool ──


### PR DESCRIPTION
The plan mode prompts in buildDynamicContext and enter_plan_mode tool
description/result incorrectly described the tools available in plan mode:

1. buildDynamicContext (acp/server.go):
   - The clientCanReadFile=true branch only mentioned read_client_file as a
     read-only tool, omitting read, ls, grep, webfetch, websearch, recall,
     load_skill, and reload_skills.
   - The clientCanReadFile=false branch incorrectly claimed "You have no
     file-reading tools in this mode", even though read, ls, and grep are
     always available regardless of client capabilities.
   - Merged the two branches into a single unified text where only the
     read_client_file line is conditionally included. Tools are now listed
     by category (file inspection, web, memory & skills, planning) with
     brief descriptions for clarity.
   - Unified the workflow steps since file-reading capability is always
     available via read/ls/grep.

2. enter_plan_mode tool definition (plan/tool.go):
   - Added mention that read-only tools (read, ls, grep, webfetch,
     websearch, recall, load_skill, reload_skills) remain available after
     entering plan mode, preventing the agent from assuming all tools
     are removed.

3. enter_plan_mode execute result (plan/tool.go):
   - Added plan_update to the listed plan tools (it was missing).
   - Added the full list of read-only tools that remain available.

The tool lists in the prompts are kept in sync with the read-only
whitelist in governance/policy.go:222 (NewToolClassifier).