### PR TITLE
fix(openviking): use GET /api/v1/skills listing endpoint instead of Search with empty query

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -1,6 +1,6 @@
 # BUGS.md — Known Issues & Technical Debt
 
-> Last updated 2026-08-04.
+> Last updated 2026-08-04 (B3 Discover 空 query 已修复).
 > Format: `[P0]` = critical, `[P1]` = high, `[P2]` = medium, `[P3]` = low.
 
 ---
@@ -24,7 +24,9 @@
 - `provider/openviking/client.go:169-177` `Search` 只构造 `{Kind, ID, Content, Score}`，`Item.Meta` **恒为 nil**；`skill.go:39-44` 读 `it.Meta["path"]/["name"]` 恒为空 → `Match` 返回的每个 SkillInfo `Name="skill"`（全部同名）、`Path=""`；若配置 fs.Loader，`Load` 会去进程 CWD 读 `SKILL.md` 命中错文件。`Discover` 用 `Name=it.ID`（viking:// URI）与 Match 命名互不兼容。
 - `client.go:110-123` `doJSON` 从不校验 envelope `Status`：HTTP 200 + `{"status":"error"}` 时静默视为成功；`Read` 返回 `""` + nil error。
 
-修复：Search 填充 Meta（或 Match 直接用 `it.ID`）；doJSON 校验 `env.Status`，Read 的 result 缺失视为错误。
+- `skill.go:52` `Discover` 调用 `client.Search(ctx, "", 100, "skill")` 传空 query，但服务端 `/api/v1/search/search` 要求 query 非空 → HTTP 400 `INVALID_ARGUMENT`，技能目录永远无法注入上下文。客户端假设"空 query = 全量目录"，服务端不支持该语义——契约不匹配。✅ 已修复（2026-08-04）
+
+修复（Discover 空 query）：`Discover` 改用 `GET /api/v1/skills` 列举接口（`client.ListSkills`），不再走 search；`SkillEntry` 直接映射 `Name/Description/URI` → `SkillInfo`。其余两项（Search Meta、doJSON 校验）仍待修。
 
 ### B4. 模型上下文窗口表误判
 

--- a/provider/openviking/client.go
+++ b/provider/openviking/client.go
@@ -4,11 +4,12 @@
 // OpenViking is a Provider — the runtime never depends on it directly.
 // The client talks to the OpenViking HTTP API directly (no SDK): the
 // server's REST surface is the stable contract, and the provider needs
-// only four endpoints.
+// only a handful of endpoints.
 //
-//	Search  — POST /api/v1/search/search  (semantic retrieval)
-//	Remember — POST /api/v1/sessions → /messages/batch → /commit
-//	Read    — GET  /api/v1/content/read  (viking:// URI → content)
+//	Search     — POST /api/v1/search/search  (semantic retrieval)
+//	ListSkills — GET  /api/v1/skills         (list skill catalog)
+//	Remember   — POST /api/v1/sessions → /messages/batch → /commit
+//	Read       — GET  /api/v1/content/read  (viking:// URI → content)
 package openviking
 
 import (
@@ -176,6 +177,40 @@ func (c *Client) Search(ctx context.Context, query string, limit int, contextTyp
 		})
 	}
 	return items, nil
+}
+
+// ── ListSkills ──
+
+// SkillEntry is one skill in the GET /api/v1/skills catalog listing.
+type SkillEntry struct {
+	Name        string   `json:"name"`
+	URI         string   `json:"uri"`
+	RootURI     string   `json:"root_uri,omitempty"`
+	SkillMDURI  string   `json:"skill_md_uri,omitempty"`
+	Description string   `json:"description"`
+	Tags        []string `json:"tags,omitempty"`
+	Level       int      `json:"level,omitempty"`
+}
+
+// listSkillsResult mirrors the GET /api/v1/skills response result.
+type listSkillsResult struct {
+	Skills []SkillEntry `json:"skills,omitempty"`
+	Total  int          `json:"total,omitempty"`
+}
+
+// ListSkills lists the full skill catalog from OpenViking. nodeLimit caps
+// the number of nodes returned per skill (0 = server default). Unlike
+// Search, this endpoint requires no query and returns every skill.
+func (c *Client) ListSkills(ctx context.Context, nodeLimit int) ([]SkillEntry, error) {
+	query := url.Values{}
+	if nodeLimit > 0 {
+		query.Set("node_limit", fmt.Sprintf("%d", nodeLimit))
+	}
+	var res listSkillsResult
+	if err := c.doJSON(ctx, http.MethodGet, "/api/v1/skills", query, nil, &res); err != nil {
+		return nil, fmt.Errorf("openviking list skills: %w", err)
+	}
+	return res.Skills, nil
 }
 
 // ── Remember ──

--- a/provider/openviking/skill.go
+++ b/provider/openviking/skill.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Skill implements provider/skill.Provider backed by OpenViking's skill
-// index. Discover returns the full catalog (Search with empty query);
+// index. Discover returns the full catalog (GET /api/v1/skills);
 // Load returns the content the index carries for the skill (the full
 // SKILL.md body when the server indexed it, an abstract otherwise — the
 // framework contract is "whatever content the provider has", mirroring
@@ -48,17 +48,18 @@ func (s *Skill) Match(ctx context.Context, intent string, limit int) ([]openagen
 }
 
 // Discover implements provider/skill.Provider: the full skill catalog
-// from OpenViking's skill index.
+// from OpenViking's GET /api/v1/skills listing endpoint.
 func (s *Skill) Discover(ctx context.Context) ([]openagent.SkillInfo, error) {
-	items, err := s.client.Search(ctx, "", 100, "skill")
+	entries, err := s.client.ListSkills(ctx, 1000)
 	if err != nil {
 		return nil, err
 	}
-	out := make([]openagent.SkillInfo, 0, len(items))
-	for _, it := range items {
+	out := make([]openagent.SkillInfo, 0, len(entries))
+	for _, e := range entries {
 		out = append(out, openagent.SkillInfo{
-			Name:        it.ID,
-			Description: it.Content,
+			Name:        e.Name,
+			Description: e.Description,
+			Path:        e.URI,
 		})
 	}
 	return out, nil


### PR DESCRIPTION
Discover called client.Search(ctx, "", 100, "skill") with an empty query, but the server's /api/v1/search/search requires a non-empty query and returns HTTP 400 INVALID_ARGUMENT, so the skill catalog was never injected into context.

Fix:
- client.go: add ListSkills method calling GET /api/v1/skills?node_limit=N
- skill.go: Discover now uses ListSkills; SkillEntry maps directly Name/Description/URI -> SkillInfo
- BUGS.md: record empty-query sub-issue under B3, mark as fixed

Closes B3 (Discover empty-query part)