### PR TITLE
fix(openviking): repair skill Match/Load/doJSON  & handle empty LLM response

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -19,14 +19,14 @@
 
 修复：approvals 落独立表/行，或所有 session meta 写操作经单一写者/事务串行化。
 
-### B3. OpenViking 技能能力实际不可用
+### B3. ~~OpenViking 技能能力实际不可用~~ ✅ 已修复（2026-08-04）
 
-- `provider/openviking/client.go:169-177` `Search` 只构造 `{Kind, ID, Content, Score}`，`Item.Meta` **恒为 nil**；`skill.go:39-44` 读 `it.Meta["path"]/["name"]` 恒为空 → `Match` 返回的每个 SkillInfo `Name="skill"`（全部同名）、`Path=""`；若配置 fs.Loader，`Load` 会去进程 CWD 读 `SKILL.md` 命中错文件。`Discover` 用 `Name=it.ID`（viking:// URI）与 Match 命名互不兼容。
-- `client.go:110-123` `doJSON` 从不校验 envelope `Status`：HTTP 200 + `{"status":"error"}` 时静默视为成功；`Read` 返回 `""` + nil error。
+- ~~`provider/openviking/client.go:169-177` `Search` 只构造 `{Kind, ID, Content, Score}`，`Item.Meta` **恒为 nil**；`skill.go:39-44` 读 `it.Meta["path"]/["name"]` 恒为空 → `Match` 返回的每个 SkillInfo `Name="skill"`（全部同名）、`Path=""`~~。修复：`Match` 不再依赖 `Meta`，直接从 `it.ID`（URI）提取 skill 名和根 URI。
+- ~~`client.go:110-123` `doJSON` 从不校验 envelope `Status`~~。修复：`doJSON` 在 `env.Error` 检查后新增 `env.Status != "" && env.Status != "ok"` 校验。
+- ~~`skill.go:69-74` `Load` 在 `s.loader==nil` 时返回 `skill.Description`（一句话摘要），非完整 SKILL.md body~~。修复：`Load` 改用 `client.Read(skill.Path+"/SKILL.md")` 拉取完整内容，Read 失败时回退到 description。
+- ~~`skill.go:52` `Discover` 调用 `client.Search(ctx, "", 100, "skill")` 传空 query~~。修复（2026-08-04 早些时候）：`Discover` 改用 `GET /api/v1/skills` 列举接口。
 
-- `skill.go:52` `Discover` 调用 `client.Search(ctx, "", 100, "skill")` 传空 query，但服务端 `/api/v1/search/search` 要求 query 非空 → HTTP 400 `INVALID_ARGUMENT`，技能目录永远无法注入上下文。客户端假设"空 query = 全量目录"，服务端不支持该语义——契约不匹配。✅ 已修复（2026-08-04）
-
-修复（Discover 空 query）：`Discover` 改用 `GET /api/v1/skills` 列举接口（`client.ListSkills`），不再走 search；`SkillEntry` 直接映射 `Name/Description/URI` → `SkillInfo`。其余两项（Search Meta、doJSON 校验）仍待修。
+修复仅涉及 `provider/openviking/skill.go` + `provider/openviking/client.go`，与本地 FS provider（`provider/skill/fs.go`）零交集，两种接入场景（有/无 OpenViking）均可用。
 
 ### B4. 模型上下文窗口表误判
 

--- a/cmd/cli/server/shared.go
+++ b/cmd/cli/server/shared.go
@@ -375,7 +375,7 @@ type slogObserver struct {
 }
 
 func (o slogObserver) ObserveStage(_ context.Context, event openagent.StageEvent) {
-	o.logger.Info("stage", "name", event.Name, "phase", event.Phase, "duration", event.Duration)
+	o.logger.Debug("stage", "name", event.Name, "phase", event.Phase, "duration", event.Duration)
 }
 
 // buildSlogObserver creates a minimal stderr stage observer.

--- a/context/extractor_llm.go
+++ b/context/extractor_llm.go
@@ -139,9 +139,22 @@ func (e *LLMExtractor) Extract(ctx context.Context, scope ContextScope, messages
 		return
 	}
 
-	items, err := parseExtractionItems(resp.Choices[0].Message.Content)
+	choice := resp.Choices[0]
+	raw := choice.Message.Content
+
+	// An empty response is normal — the model found nothing worth
+	// extracting this turn. Log finish_reason only when it indicates a
+	// truncation or filter that may have suppressed content.
+	if strings.TrimSpace(raw) == "" {
+		if fr := choice.FinishReason; fr == "length" || fr == "content_filter" {
+			slog.Warn("openagent: knowledge extract empty response",
+				"finish_reason", fr)
+		}
+		return
+	}
+
+	items, err := parseExtractionItems(raw)
 	if err != nil {
-		raw := resp.Choices[0].Message.Content
 		if len(raw) > 300 {
 			raw = raw[:300]
 		}
@@ -233,9 +246,12 @@ func recallQuery(messages []openagent.Message) string {
 }
 
 // parseExtractionItems parses the model's JSON array response (markdown
-// fences tolerated).
+// fences tolerated). An empty string returns nil (nothing to extract).
 func parseExtractionItems(raw string) ([]ExtractionItem, error) {
 	content := strings.TrimSpace(raw)
+	if content == "" {
+		return nil, nil
+	}
 	content = strings.TrimPrefix(content, "```json")
 	content = strings.TrimPrefix(content, "```")
 	content = strings.TrimSuffix(content, "```")

--- a/provider/openviking/client.go
+++ b/provider/openviking/client.go
@@ -115,6 +115,9 @@ func (c *Client) doJSON(ctx context.Context, method, path string, query url.Valu
 	if env.Error != nil {
 		return &apiError{StatusCode: resp.StatusCode, Code: env.Error.Code, Message: env.Error.Message}
 	}
+	if env.Status != "" && env.Status != "ok" {
+		return &apiError{StatusCode: resp.StatusCode, Code: env.Status, Message: truncate(string(data), 200)}
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return &apiError{StatusCode: resp.StatusCode, Message: truncate(string(data), 200)}
 	}

--- a/provider/openviking/skill.go
+++ b/provider/openviking/skill.go
@@ -2,6 +2,7 @@ package openviking
 
 import (
 	"context"
+	"strings"
 
 	openagent "github.com/yusheng-g/openagent-go"
 	"github.com/yusheng-g/openagent-go/skill/fs"
@@ -9,10 +10,8 @@ import (
 
 // Skill implements provider/skill.Provider backed by OpenViking's skill
 // index. Discover returns the full catalog (GET /api/v1/skills);
-// Load returns the content the index carries for the skill (the full
-// SKILL.md body when the server indexed it, an abstract otherwise — the
-// framework contract is "whatever content the provider has", mirroring
-// the filesystem provider's body load).
+// Match runs semantic search (POST /api/v1/search/search);
+// Load fetches the full SKILL.md body via GET /api/v1/content/read.
 type Skill struct {
 	client *Client
 	loader *fs.Loader // optional local fallback for full instructions
@@ -33,14 +32,9 @@ func (s *Skill) Match(ctx context.Context, intent string, limit int) ([]openagen
 	out := make([]openagent.SkillInfo, 0, len(items))
 	for _, it := range items {
 		info := openagent.SkillInfo{
-			Name:        it.Kind,
+			Name:        skillNameFromURI(it.ID),
 			Description: it.Content,
-		}
-		if id, ok := it.Meta["path"].(string); ok {
-			info.Path = id
-		}
-		if name, ok := it.Meta["name"].(string); ok {
-			info.Name = name
+			Path:        skillRootFromURI(it.ID),
 		}
 		out = append(out, info)
 	}
@@ -70,6 +64,44 @@ func (s *Skill) Load(ctx context.Context, skill openagent.SkillInfo) (string, er
 	if s.loader != nil {
 		return s.loader.Load(ctx, skill)
 	}
-	// Fallback: content already embedded in the match (kind carried it).
-	return skill.Description, nil
+	if skill.Path == "" {
+		return skill.Description, nil
+	}
+	content, err := s.client.Read(ctx, strings.TrimSuffix(skill.Path, "/")+"/SKILL.md")
+	if err != nil {
+		return skill.Description, nil
+	}
+	return content, nil
+}
+
+// skillNameFromURI extracts the skill name from a viking:// URI.
+//
+//	"viking://user/default/skills/huawei-cloud-cli-guidance/.abstract.md" → "huawei-cloud-cli-guidance"
+//	"viking://user/default/skills/huawei-cloud-cli-guidance"             → "huawei-cloud-cli-guidance"
+func skillNameFromURI(uri string) string {
+	idx := strings.Index(uri, "/skills/")
+	if idx == -1 {
+		return ""
+	}
+	rest := uri[idx+len("/skills/"):]
+	if slash := strings.Index(rest, "/"); slash != -1 {
+		rest = rest[:slash]
+	}
+	return rest
+}
+
+// skillRootFromURI strips any trailing file path to get the skill root URI.
+//
+//	"viking://user/default/skills/huawei-cloud-cli-guidance/.abstract.md" → "viking://user/default/skills/huawei-cloud-cli-guidance"
+//	"viking://user/default/skills/huawei-cloud-cli-guidance"             → "viking://user/default/skills/huawei-cloud-cli-guidance"
+func skillRootFromURI(uri string) string {
+	idx := strings.Index(uri, "/skills/")
+	if idx == -1 {
+		return uri
+	}
+	rest := uri[idx+len("/skills/"):]
+	if slash := strings.Index(rest, "/"); slash != -1 {
+		return uri[:idx+len("/skills/")+slash]
+	}
+	return uri
 }


### PR DESCRIPTION
[fix(openviking): repair skill Match/Load/doJSON — B3 fully fixed](https://github.com/yusheng-g/openagent-go/commit/a138b99437137dc0794e7634096dae4b5af4d2e2)
[fix(context): handle empty LLM response in knowledge extractor and degrade memory log level](https://github.com/yusheng-g/openagent-go/commit/460b81419a05e97dd4ffbc4b5d06aff28c003a72)

skills all saved in OpenViking
<img width="1116" height="1079" alt="image" src="https://github.com/user-attachments/assets/06306549-c247-47b9-8fa4-79ae91d77593" />

