### PR TITLE
feat(openviking): add Bearer token auth support

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -90,7 +90,7 @@
 ### B13. OpenViking 客户端资源与安全
 
 - `client.go:105-108` `io.ReadAll` 无大小上限：异常/被攻陷服务端返回 GB 级响应直接耗尽进程内存。修：`io.LimitReader`（如 32MB）。
-- 客户端零认证通道（`OpenVikingConfig` 只有 Endpoint，无 header 注入点）：远程部署时任何能触达端点地址的进程可读可写全部记忆。修：可选 Bearer token / 自定义 header。
+- ~~客户端零认证通道（`OpenVikingConfig` 只有 Endpoint，无 header 注入点）：远程部署时任何能触达端点地址的进程可读可写全部记忆。修：可选 Bearer token / 自定义 header。~~ ✅ 已修复（2026-08-05）：`OpenVikingConfig` 新增 `APIKey` 字段，`doJSON` 注入 `Authorization: Bearer <key>` 头。
 - `Remember`（client.go:199-209）中途失败残留孤儿会话（创建后 commit 失败不清理）。
 
 ### B14. 工具截断产物权限过宽

--- a/README.md
+++ b/README.md
@@ -171,6 +171,33 @@ MCP tools are available to the Feishu bot at startup. Each tool call renders as 
 All fields are optional. Defaults: `~/.openagent/logs/openagent.log`, 10 MB rotation, 5 backups, info level.
 Each `max_size` unit is megabytes. Logs go to both stderr *and* the file. Set `level` to `"debug"` to see every API request.
 
+### OpenViking Integration
+
+OpenViking is a context database that provides server-side memory, skill, and resource management. Configuring an endpoint switches all three domains from local storage to the OpenViking server — one address is enough.
+
+```json
+{
+  "openviking": {
+    "endpoint": "http://127.0.0.1:1933",
+    "api_key": "ov-xxxxxxxxxxxx"
+  }
+}
+```
+
+- `endpoint` — OpenViking server address. Required to enable.
+- `api_key` — Bearer token sent as `Authorization: Bearer <key>`. Optional; empty = no auth (dev mode only).
+
+To keep a specific domain on local storage while using OpenViking for the rest:
+
+```json
+{
+  "openviking": { "endpoint": "http://127.0.0.1:1933", "api_key": "ov-xxx" },
+  "context_providers": { "memory": "builtin" }
+}
+```
+
+`context_providers` accepts `"builtin"` or `"openviking"` for each of `memory`, `skill`, `resource`. Empty = follow the endpoint default.
+
 ## Architecture
 
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -171,6 +171,33 @@ MCP 工具在启动时即可用，每次工具调用以卡片形式展示在飞�
 所有字段都是可选的。默认值：`~/.openagent/logs/openagent.log`，10 MB 轮转，保留 5 个备份，info 级别。
 单位是 MB。日志同时输出到 stderr 和文件。设为 `"debug"` 可查看每次 API 请求详情。
 
+### OpenViking 集成
+
+OpenViking 是一个上下文数据库，提供服务端记忆、技能和资源管理。配置 endpoint 后，三个域均从本地存储切换到 OpenViking 服务端 — 一个地址即可。
+
+```json
+{
+  "openviking": {
+    "endpoint": "http://127.0.0.1:1933",
+    "api_key": "ov-xxxxxxxxxxxx"
+  }
+}
+```
+
+- `endpoint` — OpenViking 服务端地址。必填，留空则不启用。
+- `api_key` — Bearer token，以 `Authorization: Bearer <key>` 发送。可选；留空 = 不认证（仅限 dev 模式）。
+
+若部分域仍使用本地存储，其余使用 OpenViking：
+
+```json
+{
+  "openviking": { "endpoint": "http://127.0.0.1:1933", "api_key": "ov-xxx" },
+  "context_providers": { "memory": "builtin" }
+}
+```
+
+`context_providers` 对 `memory`、`skill`、`resource` 各域可设为 `"builtin"` 或 `"openviking"`。留空 = 跟随 endpoint 默认值。
+
 ## 架构
 
 ```

--- a/cmd/cli/config/config.go
+++ b/cmd/cli/config/config.go
@@ -52,6 +52,7 @@ type ContextProviderConfig struct {
 // search/remember/read, no SDK).
 type OpenVikingConfig struct {
 	Endpoint string `json:"endpoint,omitempty"` // e.g. "http://127.0.0.1:1933"
+	APIKey   string `json:"api_key,omitempty"`   // Bearer token; empty = no auth
 }
 
 // EmbeddingConfig selects the semantic-embedding backend for knowledge

--- a/cmd/cli/server/shared.go
+++ b/cmd/cli/server/shared.go
@@ -143,7 +143,7 @@ func applyContextProviders(cfg *config.Config, deps *kernel.Deps) error {
 	if cfg.OpenViking.Endpoint == "" {
 		return nil
 	}
-	client, err := openviking.NewClient(cfg.OpenViking.Endpoint)
+	client, err := openviking.NewClient(cfg.OpenViking.Endpoint, cfg.OpenViking.APIKey)
 	if err != nil {
 		return fmt.Errorf("openviking: %w", err)
 	}

--- a/context/extractor_llm.go
+++ b/context/extractor_llm.go
@@ -99,6 +99,7 @@ func (e *LLMExtractor) Extract(ctx context.Context, scope ContextScope, messages
 	if e == nil || model == nil || e.Provider == nil || len(messages) == 0 {
 		return
 	}
+	slog.Debug("openagent: knowledge extraction triggered", "user", scope.UserID, "messages", len(messages))
 	max := e.MaxItems
 	if max <= 0 {
 		max = maxKnowledgeItems
@@ -191,6 +192,7 @@ func (e *LLMExtractor) Extract(ctx context.Context, scope ContextScope, messages
 		}
 		stored++
 	}
+	slog.Debug("openagent: knowledge extraction done", "user", scope.UserID, "stored", stored, "candidates", len(items))
 }
 
 // buildTranscript renders messages as a compact transcript (role: content).

--- a/provider/memory/sqlite/memory.go
+++ b/provider/memory/sqlite/memory.go
@@ -106,6 +106,7 @@ func (m *Memory) Store(ctx context.Context, scope ctxpkg.ContextScope, item ctxp
 			if err != nil {
 				return fmt.Errorf("sqlite knowledge store: %w", err)
 			}
+			slog.Debug("openagent: knowledge stored (update)", "id", id, "kind", item.Kind, "topic", item.Topic)
 			m.indexEmbedding(ctx, id, item.Content)
 			return nil
 		}
@@ -122,6 +123,7 @@ func (m *Memory) Store(ctx context.Context, scope ctxpkg.ContextScope, item ctxp
 	id, _ = res.LastInsertId()
 
 	if id > 0 {
+		slog.Debug("openagent: knowledge stored (insert)", "id", id, "kind", item.Kind, "topic", item.Topic)
 		m.indexEmbedding(ctx, id, item.Content)
 	}
 	return nil
@@ -145,6 +147,8 @@ func (m *Memory) indexEmbedding(ctx context.Context, id int64, content string) {
 		id, buf,
 	); err != nil {
 		slog.Warn("openagent: knowledge vector write failed", "id", id, "error", err)
+	} else {
+		slog.Debug("openagent: knowledge vector indexed", "id", id, "dim", len(vec))
 	}
 }
 

--- a/provider/openviking/client.go
+++ b/provider/openviking/client.go
@@ -32,21 +32,23 @@ type Item struct {
 	Score   float64        `json:"score,omitempty"`
 }
 
-// Client talks to an OpenViking server over its HTTP API. Knowledge is
-// scoped by the server's own identity (API key / account / user), not by
-// this client.
+// Client talks to an OpenViking server over its HTTP API. An optional API
+// key is sent as a Bearer token; when empty, the server's own identity
+// (account / user) scopes the knowledge.
 type Client struct {
 	baseURL string
+	apiKey  string
 	http    *http.Client
 }
 
 // NewClient creates a client for an OpenViking server.
-func NewClient(endpoint string) (*Client, error) {
+func NewClient(endpoint, apiKey string) (*Client, error) {
 	if endpoint == "" {
 		return nil, fmt.Errorf("openviking: empty endpoint")
 	}
 	return &Client{
 		baseURL: endpoint,
+		apiKey:  apiKey,
 		http:    &http.Client{Timeout: 120 * time.Second},
 	}, nil
 }
@@ -95,6 +97,9 @@ func (c *Client) doJSON(ctx context.Context, method, path string, query url.Valu
 	}
 	if payload != nil {
 		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	}
 
 	resp, err := c.http.Do(req)


### PR DESCRIPTION
- OpenVikingConfig gains APIKey field; client sends Authorization: Bearer <key> when non-empty (empty = no auth, behavior unchanged)
- Add debug log for openviking memory operation
- Document OpenViking integration (endpoint + api_key + context_providers opt-out) in README.md and README.zh.md
- Mark BUGS.md B13 zero-auth-channel item as fixed