### PR TITLE
feat(feishu): run-card approval, /mode switching, 30KB guard, and clean code refinements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A fully pluggable, multi-agent AI agent framework in Go.
 - **Static context profiles** — `AGENTS.md` (working rules) and `SOUL.md` (persona & limits) with user-level and project-level resolution
 - **Slash commands** — built-in `/help`, `/mode`, `/model`, `/context`, `/cwd`, `/clear`, `/rename`, `/sessions`, extensible via `slash/` registry
 - **Full CLI** — `openagent-cli` with cobra commands, config-driven models, keyring secrets, WASM plugin runtime
-- **IM channels** — Feishu/Lark (WebSocket, card-based streaming output with markdown and tool call cards, one-click QR setup), personal WeChat (Tencent ilinkai channel, QR login with pairing code), and WeCom 企业微信 (official long connection, native streaming replies, QR robot auto-creation)
+- **IM channels** — Feishu/Lark (WebSocket, card-based streaming output with markdown and tool call cards, one-click QR setup, inline approval buttons, /clear and /mode commands), personal WeChat (Tencent ilinkai channel, QR login with pairing code, /clear command), and WeCom 企业微信 (official long connection, native streaming replies, QR robot auto-creation, /clear command)
 - **RunHooks with state** — start/end callbacks share opaque state; OTEL spans nest, slog logs duration
 - **Dynamic context** — session-level plan status and mode injected into every prompt turn
 
@@ -92,7 +92,7 @@ Connect your agent to Feishu (Lark) so users can chat with it in IM — group ch
 ./openagent-cli serve --channel feishu
 ```
 
-A QR code will appear in your terminal. Open Feishu on your phone, scan it, and confirm the app creation. The SDK automatically provisions a bot app with the correct permissions (`im:message`, `im:message:send_as_bot`, `im.message.receive_v1` event) and saves the credentials locally.
+A QR code will appear in your terminal. Open Feishu on your phone, scan it, and confirm the app creation. The SDK automatically provisions a bot app with the correct permissions (`im:message`, `im:message:send_as_bot`, `im.message.receive_v1` event, `card.action.trigger` for approval/mode button callbacks) and saves the credentials locally.
 
 ![First login - scan QR code](.github/images/feishu-first-login.jpg)
 
@@ -187,6 +187,27 @@ MCP tools are available to the Feishu bot at startup. Each tool call renders as 
 
 All fields are optional. Defaults: `~/.openagent/logs/openagent.log`, 10 MB rotation, 5 backups, info level.
 Each `max_size` unit is megabytes. Logs go to both stderr *and* the file. Set `level` to `"debug"` to see every API request.
+
+**Slash commands in IM:**
+
+All three IM channels support `/clear` — deletes the session's conversation history and replies with a confirmation. No agent round-trip; the command is intercepted before reaching the model.
+
+Feishu additionally supports `/mode` — switches between Manual and Auto execution modes:
+
+| Mode | Behaviour |
+|------|-----------|
+| **Manual** (default) | Each non-readonly tool call shows an approval card with 同意/拒绝 buttons before executing |
+| **Auto** | Tools execute immediately without human approval (higher risk) |
+
+`/mode` with no argument shows a mode-switch card with clickable buttons. `/mode auto` or `/mode manual` switches directly. The mode is per-chat (each group/private chat remembers its own setting).
+
+The initial mode for new chats defaults to Manual; set `"default_mode": "auto"` in settings.json to change the default.
+
+**Run card layout (Feishu):**
+
+Each agent run renders as a single card that updates in place (debounced patches). The body interleaves segments in arrival order: thinking (collapsed panel) → text → tool call (collapsed panel, titled with tool name + status ✓/✗) → text → … When a run completes, the card switches to an expanded state. Long runs that exceed the 28KB card limit auto-rotate: the old card folds to a collapsed "done" state and a fresh card starts with the last few blocks.
+
+Approval requests in Manual mode embed their buttons directly in the run card (no separate approval card). When the user clicks 同意/拒绝, the card updates in-place and the agent continues or stops.
 
 ### WeChat (personal) Integration
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -21,7 +21,7 @@
 - **静态上下文配置** — `AGENTS.md`（工作规则）和 `SOUL.md`（性格与底线），支持用户级和项目级覆盖
 - **Slash 命令** — 内置 `/help`、`/mode`、`/model`、`/context`、`/cwd`、`/clear`、`/rename`、`/sessions`，通过 `slash/` 注册表扩展
 - **完整 CLI** — `openagent-cli`，cobra 命令、配置驱动模型、keyring 密钥管理、WASM 插件运行时
-- **IM 频道** — 飞书/Lark（WebSocket，卡片式流式输出：Markdown 渲染、工具调用卡片，一键扫码创建应用）、个人微信（腾讯 ilinkai 官方通道，扫码登录 + 配对码）、企业微信（官方长连接，原生流式回复，扫码自动创建机器人）
+- **IM 频道** — 飞书/Lark（WebSocket，卡片式流式输出：Markdown 渲染、工具调用卡片，一键扫码创建应用，内嵌审批按钮、/clear 和 /mode 命令）、个人微信（腾讯 ilinkai 官方通道，扫码登录 + 配对码，/clear 命令）、企业微信（官方长连接，原生流式回复，扫码自动创建机器人，/clear 命令）
 - **RunHooks 状态传递** — Start/End 回调共享不透明状态，OTEL 正确嵌套 span，slog 精确计时
 - **动态上下文** — 会话级 plan 状态和 mode 指令每轮自动注入 prompt
 
@@ -92,7 +92,7 @@ export BOCHA_API_KEY=<你的-key>   # 在 https://open.bochaai.com 获取
 ./openagent-cli serve --channel feishu
 ```
 
-终端会出现二维码。打开飞书 App 扫码，确认创建应用即可。SDK 会自动创建机器人应用并配置好权限（`im:message`、`im:message:send_as_bot`、`im.message.receive_v1` 事件），凭据保存在本地。
+终端会出现二维码。打开飞书 App 扫码，确认创建应用即可。SDK 会自动创建机器人应用并配置好权限（`im:message`、`im:message:send_as_bot`、`im.message.receive_v1` 事件、`card.action.trigger` 审批/模式按钮回调），凭据保存在本地。
 
 ![首次使用 - 扫码创建应用](.github/images/feishu-first-login.jpg)
 
@@ -187,6 +187,27 @@ MCP 工具在启动时即可用，每次工具调用以卡片形式展示在飞�
 
 所有字段都是可选的。默认值：`~/.openagent/logs/openagent.log`，10 MB 轮转，保留 5 个备份，info 级别。
 单位是 MB。日志同时输出到 stderr 和文件。设为 `"debug"` 可查看每次 API 请求详情。
+
+**IM 中的 Slash 命令：**
+
+三个 IM 通道均支持 `/clear` —— 删除当前会话的对话历史并回复确认。不经过 agent，命令在到达模型前被拦截。
+
+飞书额外支持 `/mode` —— 切换 Manual 和 Auto 执行模式：
+
+| 模式 | 行为 |
+|------|------|
+| **Manual**（默认） | 每个非只读工具调用前弹出审批卡片，点击同意/拒绝后才执行 |
+| **Auto** | 工具自动执行，无需审批（风险较高） |
+
+`/mode` 不带参数时显示模式切换卡片（可点击按钮）。`/mode auto` 或 `/mode manual` 直接切换。模式按聊天隔离（每个群聊/私聊独立记忆）。
+
+新聊天的初始模式默认为 Manual；在 settings.json 中设置 `"default_mode": "auto"` 可更改默认值。
+
+**运行卡片布局（飞书）：**
+
+每次 agent 运行渲染为一张卡片，实时原地更新（防抖 patch）。卡片内容按到达顺序交错排列：思考（折叠面板）→ 文本 → 工具调用（折叠面板，标题显示工具名 + 状态 ✓/✗）→ 文本 → …… 运行完成后卡片切换为展开状态。超长运行超过 28KB 卡片限制时自动轮转：旧卡片折叠为"已完成"状态，新卡片从最后几个块开始。
+
+Manual 模式下的审批请求直接内嵌在运行卡片中（无独立审批卡片）。用户点击同意/拒绝后，卡片原地更新，agent 继续或停止。
 
 ### 个人微信集成
 

--- a/acp/server.go
+++ b/acp/server.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1097,7 +1096,7 @@ func (s *AgentServer) replayHistory(ctx context.Context, sid openacp.SessionId, 
 			for _, tc := range msg.ToolCalls {
 				sender.SendToolCall(openacp.ToolCallUpdate{
 					ToolCallID: tc.ID,
-					Title:      toolTitle(tc.Function.Name, tc.Function.Arguments),
+					Title:      opentool.ToolTitle(tc.Function.Name, tc.Function.Arguments),
 					Kind:       "execute",
 					Status:     "pending",
 					RawInput:   json.RawMessage(tc.Function.Arguments),
@@ -1600,7 +1599,7 @@ func (s *AgentServer) OnPrompt(ctx context.Context, req openacp.PromptRequest, s
 				for _, tc := range evt.Message.ToolCalls {
 					sender.SendToolCall(openacp.ToolCallUpdate{
 						ToolCallID: tc.ID,
-						Title:      toolTitle(tc.Function.Name, tc.Function.Arguments),
+						Title:      opentool.ToolTitle(tc.Function.Name, tc.Function.Arguments),
 						Kind:       "execute",
 						Status:     "pending",
 						RawInput:   json.RawMessage(tc.Function.Arguments),
@@ -2326,7 +2325,7 @@ func (a *acpApprover) Ask(ctx context.Context, call openagent.ToolCall, def open
 		SessionID: a.sessionID,
 		ToolCall: openacp.ToolCallUpdate{
 			ToolCallID: call.ID,
-			Title:      toolTitle(def.Name, call.Function.Arguments),
+			Title:      opentool.ToolTitle(def.Name, call.Function.Arguments),
 			Kind:       "execute",
 			Status:     "pending",
 			RawInput:   json.RawMessage(call.Function.Arguments),
@@ -2412,103 +2411,6 @@ func firstLine(s string, maxLen int) string {
 		return string(runes[:maxLen]) + "..."
 	}
 	return s
-}
-
-// toolTitle builds a human-readable title for an ACP tool_call update.
-// Extracts the most informative field from the tool arguments JSON.
-func toolTitle(name string, args string) string {
-	var params struct {
-		Path        string `json:"path"`
-		Line        int    `json:"line"`
-		Limit       int    `json:"limit"`
-		Command     string `json:"command"`
-		Description string `json:"description"`
-		Pattern     string `json:"pattern"`
-		Glob        string `json:"glob"`
-		Query       string `json:"query"`
-		Goal        string `json:"goal"`
-		URL         string `json:"url"`
-	}
-	if err := json.Unmarshal([]byte(args), &params); err != nil {
-		return name
-	}
-	switch name {
-	case "read":
-		if params.Path != "" {
-			base := filepath.Base(params.Path)
-			if params.Limit > 0 {
-				start := params.Line
-				if start == 0 {
-					start = 1
-				}
-				return fmt.Sprintf("%s %s (lines %d-%d)", name, base, start, start+params.Limit-1)
-			}
-			return name + " " + base
-		}
-	case "edit", "write", "ls":
-		if params.Path != "" {
-			return name + " " + params.Path
-		}
-	case "shell":
-		// Prefer the LLM-provided description (intent); fall back to the
-		// raw command (truncated) so the title is always actionable.
-		if params.Description != "" {
-			return name + " " + truncateToolArg(params.Description, 60)
-		}
-		if params.Command != "" {
-			return name + " " + truncateToolArg(params.Command, 60)
-		}
-	case "grep":
-		if params.Pattern != "" {
-			title := fmt.Sprintf("%s '%s'", name, params.Pattern)
-			if params.Path != "" {
-				title += " " + filepath.Base(params.Path)
-			}
-			if params.Glob != "" {
-				title += fmt.Sprintf(" '%s'", params.Glob)
-			}
-			return title
-		}
-	case "recall":
-		if params.Query != "" {
-			return name + " " + params.Query
-		}
-	case "plan_create":
-		if params.Goal != "" {
-			return name + " " + truncateToolArg(params.Goal, 60)
-		}
-	case "websearch":
-		if params.Query != "" {
-			return name + " " + truncateToolArg(params.Query, 60)
-		}
-	case "webfetch":
-		if params.URL != "" {
-			return name + " " + stripURLQuery(params.URL)
-		}
-	}
-	return name
-}
-
-// stripURLQuery removes the query string (and fragment) from rawURL so the
-// title shows only scheme://host/path. Falls back to the raw value on parse
-// error.
-func stripURLQuery(rawURL string) string {
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return rawURL
-	}
-	u.RawQuery = ""
-	u.Fragment = ""
-	return u.String()
-}
-
-// truncateToolArg truncates s to n characters, adding "..." at the end.
-func truncateToolArg(s string, n int) string {
-	s = strings.TrimSpace(s)
-	if len(s) <= n {
-		return s
-	}
-	return s[:n-3] + "..."
 }
 
 // finishReasonToACP maps model finish reasons to ACP stop reasons.

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -11,6 +11,7 @@ package channel
 
 import (
 	"context"
+	"strings"
 	"time"
 )
 
@@ -64,22 +65,76 @@ type ReplyMessage struct {
 	UpdateID string // update existing card instead of creating new message
 }
 
+// FoldMode controls how a card body is rendered on platforms that
+// support collapsible content (e.g. Feishu collapsible_panel).
+type FoldMode int
+
+const (
+	// FoldNone renders the body as plain markdown — always visible,
+	// no fold affordance. This is the zero value and the most common
+	// case (e.g. the run card's answer section).
+	FoldNone FoldMode = iota
+	// FoldCollapsed wraps the body in a collapsible panel that starts
+	// collapsed (hidden behind a clickable bar).
+	FoldCollapsed
+	// FoldExpanded wraps the body in a collapsible panel that starts
+	// expanded (visible, but the user can click to collapse).
+	FoldExpanded
+)
+
 // Card is a platform-neutral structured message. Each channel translates
 // it into the platform's native card format (e.g. Feishu interactive card,
 // WeChat Work template card).
 type Card struct {
-	Header    CardHeader
-	Content   string // markdown body
-	Footer    string // optional note at the bottom
-	Color     CardColor
-	Collapsed bool   // body starts collapsed (platforms that support fold)
-	Panels    []Card // nested collapsed sub-panels (when non-empty, Content is ignored)
+	Header     CardHeader
+	Content    string // markdown body
+	Footer     string // optional note at the bottom
+	Color      CardColor
+	Fold       FoldMode        // how the body wraps: none, collapsed panel, or expanded panel
+	Panels     []Card          // nested collapsed sub-panels (when non-empty, Content is ignored)
+	Approval   *CardApproval   // optional approval section rendered at the bottom
+	ModeSwitch *CardModeSwitch // optional mode-switch section rendered at the bottom
+}
+
+// Per-chat execution modes.
+const (
+	ModeManual = "manual"
+	ModeAuto   = "auto"
+)
+
+// IsValidMode reports whether mode is a recognized execution mode.
+func IsValidMode(mode string) bool {
+	return mode == ModeManual || mode == ModeAuto
+}
+
+// CardModeSwitch carries the info needed to render a mode-switch button
+// row inside a card. When set, BuildCard appends a separator and two
+// action buttons (Manual / Auto) with the current mode highlighted.
+// Button values carry {"type":"mode_switch","mode":"manual|auto"} so the
+// card action callback can route mode-switch clicks separately.
+type CardModeSwitch struct {
+	CurrentMode string // ModeManual | ModeAuto
+}
+
+// CardApproval carries the info needed to render an approval button row
+// inside a card. When set, BuildCard appends a separator, a context line
+// (tool name + args), and three action buttons (always allow / allow / deny)
+// to the card body. The ApprovalID is embedded in every button's value so
+// the card action callback can correlate clicks back to the pending approval.
+type CardApproval struct {
+	ToolName   string
+	Args       string
+	ApprovalID string
 }
 
 // CardHeader is the title area of a card.
 type CardHeader struct {
 	Title    string
 	Subtitle string
+	// TitleMarkdown renders the title with lark_md (Feishu markdown)
+	// instead of plain_text, allowing **bold** etc. Used by tool-call
+	// panel titles to bold the first word.
+	TitleMarkdown bool
 }
 
 // CardColor controls the header accent colour.
@@ -106,4 +161,31 @@ type IncomingMessage struct {
 	Mentions  []string  // IDs mentioned in the message
 	Timestamp time.Time // when the message was sent
 	Raw       any       // original platform event, nil if not needed
+}
+
+// CodeBlock wraps content in a markdown code fence long enough to safely
+// enclose any backtick run appearing inside content. Per CommonMark spec,
+// a fence of N backticks cannot be closed by a run of fewer than N
+// backticks, so inner ``` markers are rendered as literal text instead
+// of prematurely terminating the block. This prevents markdown constructs
+// inside tool output (e.g. tables in a SKILL.md) from leaking out and
+// tripping platform card limits (Feishu ErrCode 11310).
+func CodeBlock(content string) string {
+	maxRun, run := 0, 0
+	for _, c := range content {
+		if c == '`' {
+			run++
+			if run > maxRun {
+				maxRun = run
+			}
+		} else {
+			run = 0
+		}
+	}
+	n := 3
+	if maxRun >= n {
+		n = maxRun + 1
+	}
+	fence := strings.Repeat("`", n)
+	return fence + "\n" + content + "\n" + fence
 }

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -1,0 +1,51 @@
+package channel
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCodeBlockSimple(t *testing.T) {
+	got := CodeBlock("ls -la")
+	want := "```\nls -la\n```"
+	if got != want {
+		t.Errorf("CodeBlock(simple) = %q, want %q", got, want)
+	}
+}
+
+func TestCodeBlockWithBackticks(t *testing.T) {
+	content := "```bash\necho hi\n```"
+	got := CodeBlock(content)
+	fence := strings.Repeat("`", 4)
+	want := fence + "\n" + content + "\n" + fence
+	if got != want {
+		t.Errorf("CodeBlock(with ```) = %q, want %q", got, want)
+	}
+}
+
+func TestCodeBlockWithLongerRun(t *testing.T) {
+	content := "`````\nweird\n`````"
+	got := CodeBlock(content)
+	fence := strings.Repeat("`", 6)
+	want := fence + "\n" + content + "\n" + fence
+	if got != want {
+		t.Errorf("CodeBlock(5-tick run) = %q, want %q", got, want)
+	}
+}
+
+func TestCodeBlockEmpty(t *testing.T) {
+	got := CodeBlock("")
+	want := "```\n\n```"
+	if got != want {
+		t.Errorf("CodeBlock(empty) = %q, want %q", got, want)
+	}
+}
+
+func TestCodeBlockInlineBacktick(t *testing.T) {
+	content := "use `git` now"
+	got := CodeBlock(content)
+	want := "```\n" + content + "\n```"
+	if got != want {
+		t.Errorf("CodeBlock(inline tick) = %q, want %q", got, want)
+	}
+}

--- a/channel/feishu/approval_card.go
+++ b/channel/feishu/approval_card.go
@@ -1,0 +1,121 @@
+package feishu
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/yusheng-g/openagent-go/utils"
+)
+
+// approvalButtonRow builds the column_set element containing the two
+// approval buttons (同意 / 拒绝). The approvalID is embedded in
+// every button's value so the card action callback can correlate clicks.
+// Shared by buildApprovalCard (standalone card) and BuildCard (integrated
+// run card approval section).
+func approvalButtonRow(approvalID string) map[string]any {
+	btn := func(label, name, btnType string) map[string]any {
+		return map[string]any{
+			"tag":   "button",
+			"text":  map[string]any{"tag": "plain_text", "content": label},
+			"type":  btnType,
+			"width": "default",
+			"name":  name,
+			"value": map[string]any{"approval_id": approvalID, "action": name},
+		}
+	}
+	return map[string]any{
+		"tag":                "column_set",
+		"flex_mode":          "flow",
+		"horizontal_spacing": "8px",
+		"columns": []map[string]any{
+			{"tag": "column", "width": "auto", "elements": []map[string]any{btn("同意", "agree", "primary_filled")}},
+			{"tag": "column", "width": "auto", "elements": []map[string]any{btn("拒绝", "reject", "danger_filled")}},
+		},
+	}
+}
+
+// buildApprovalCard constructs the Feishu interactive card JSON for a tool
+// call approval request. The card shows the tool name and arguments, then
+// two action buttons (同意 / 拒绝).
+//
+// approvalID is embedded in every button's "value" field so the card action
+// callback can correlate the click back to the pending approval. The card
+// uses schema 2.0 with no banner image (keeping it self-contained — no
+// uploaded image dependency).
+func buildApprovalCard(approvalID, toolName, args string) (string, error) {
+	pretty := utils.PrettyJSON(args)
+	body := fmt.Sprintf("**工具名称** ：%s\n**执行参数** ：%s", toolName, pretty)
+
+	card := map[string]any{
+		"schema": "2.0",
+		"config": map[string]any{"update_multi": true},
+		"header": map[string]any{
+			"title":    map[string]any{"tag": "plain_text", "content": "需要权限"},
+			"subtitle": map[string]any{"tag": "plain_text", "content": ""},
+			"template": "blue",
+		},
+		"body": map[string]any{
+			"direction": "vertical",
+			"elements": []map[string]any{
+				{
+					"tag":     "markdown",
+					"content": body,
+				},
+				{"tag": "hr"},
+				approvalButtonRow(approvalID),
+			},
+		},
+	}
+
+	b, err := json.Marshal(card)
+	if err != nil {
+		return "", fmt.Errorf("feishu approval card marshal: %w", err)
+	}
+	return string(b), nil
+}
+
+// buildResolvedCard constructs the card JSON shown after the user has made a
+// decision. The card body is a collapsible_panel that starts collapsed —
+// the panel header shows the decision summary, and the hidden body contains
+// the tool name, args, and optional reason. The user can expand to see
+// details. The header colour reflects the outcome.
+func buildResolvedCard(toolName, args, decision, reason string) (string, error) {
+	pretty := utils.PrettyJSON(args)
+	var detail strings.Builder
+	fmt.Fprintf(&detail, "**工具名称** ：%s\n**执行参数** ：%s", toolName, pretty)
+	if reason != "" {
+		detail.WriteString("\n\n> ")
+		detail.WriteString(reason)
+	}
+
+	template := "green"
+	if strings.HasPrefix(decision, "❌") {
+		template = "red"
+	}
+
+	summary := decision + " — " + toolName
+
+	panelElements := []map[string]any{
+		{"tag": "markdown", "content": detail.String()},
+	}
+
+	card := map[string]any{
+		"schema": "2.0",
+		"header": map[string]any{
+			"title":    map[string]any{"tag": "plain_text", "content": "需要权限"},
+			"subtitle": map[string]any{"tag": "plain_text", "content": ""},
+			"template": template,
+		},
+		"body": map[string]any{
+			"direction": "vertical",
+			"elements":  []map[string]any{panel(summary, panelElements)},
+		},
+	}
+
+	b, err := json.Marshal(card)
+	if err != nil {
+		return "", fmt.Errorf("feishu resolved card marshal: %w", err)
+	}
+	return string(b), nil
+}

--- a/channel/feishu/approver.go
+++ b/channel/feishu/approver.go
@@ -1,0 +1,253 @@
+package feishu
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	lark "github.com/larksuite/oapi-sdk-go/v3"
+	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
+
+	openagent "github.com/yusheng-g/openagent-go"
+	"github.com/yusheng-g/openagent-go/governance"
+)
+
+// feishuApprover implements governance.HumanApprover for the Feishu channel.
+// When the policy engine routes a tool call to the human layer, Ask sends an
+// interactive approval card to the Feishu chat and blocks until the user
+// clicks a button (or the context is cancelled).
+//
+// Card action callbacks (button clicks) arrive via the WebSocket event loop
+// and are dispatched to handleCardAction, which resolves the pending
+// approval. The approver and the Channel share the same lark.Client
+// (created in Channel.Start).
+type feishuApprover struct {
+	client *lark.Client
+
+	mu      sync.Mutex
+	pending map[string]*pendingApproval // approvalID → pending entry
+
+	updaterMu sync.Mutex
+	updaters  map[string]func(toolName, args, approvalID string) // sessionID → run-card update callback
+}
+
+// pendingApproval pairs a result channel with the tool info needed to build
+// the resolved card after the user clicks.
+type pendingApproval struct {
+	result     chan approvalResult
+	toolName   string
+	args       string
+	integrated bool // true = buttons embedded in run card (no separate card to patch)
+}
+
+// approvalResult is the outcome extracted from a card action click.
+type approvalResult struct {
+	action string // "allow" | "deny"
+	reason string // populated for deny
+}
+
+// approvalSeq generates process-unique approval IDs.
+var approvalSeq uint64
+
+// newFeishuApprover creates an approver with no client (set later by
+// Channel.Start) and no memory (set later by Approver).
+func newFeishuApprover() *feishuApprover {
+	return &feishuApprover{
+		pending:  make(map[string]*pendingApproval),
+		updaters: make(map[string]func(toolName, args, approvalID string)),
+	}
+}
+
+// Ask implements governance.HumanApprover. It sends an approval card to the
+// Feishu chat and blocks until the user responds (or ctx is cancelled).
+func (a *feishuApprover) Ask(ctx context.Context, call openagent.ToolCall, def openagent.FunctionDefinition, session openagent.Session) (governance.Decision, error) {
+	if a.client == nil {
+		return governance.Decision{Action: governance.Deny, Reason: "approval channel not ready"}, nil
+	}
+
+	chatID := chatIDFromSession(session.ID)
+	if chatID == "" {
+		return governance.Decision{Action: governance.Deny, Reason: "cannot determine chat ID from session"}, nil
+	}
+
+	approvalID := strconv.FormatUint(atomic.AddUint64(&approvalSeq, 1), 36)
+	toolName := def.Name
+	args := call.Function.Arguments
+
+	// Check for a run-card updater (integrated path). When registered,
+	// embed the approval buttons in the existing run card instead of
+	// sending a separate approval card.
+	a.updaterMu.Lock()
+	updater := a.updaters[session.ID]
+	a.updaterMu.Unlock()
+
+	integrated := false
+	if updater != nil {
+		updater(toolName, args, approvalID)
+		integrated = true
+	} else {
+		cardJSON, err := buildApprovalCard(approvalID, toolName, args)
+		if err != nil {
+			return governance.Decision{Action: governance.Deny, Reason: "build approval card: " + err.Error()}, nil
+		}
+		if _, err := a.sendInteractive(ctx, chatID, cardJSON); err != nil {
+			return governance.Decision{Action: governance.Deny, Reason: "send approval card: " + err.Error()}, nil
+		}
+	}
+
+	resultCh := make(chan approvalResult, 1)
+	entry := &pendingApproval{result: resultCh, toolName: toolName, args: args, integrated: integrated}
+
+	a.mu.Lock()
+	a.pending[approvalID] = entry
+	a.mu.Unlock()
+
+	defer func() {
+		a.mu.Lock()
+		delete(a.pending, approvalID)
+		a.mu.Unlock()
+	}()
+
+	select {
+	case <-ctx.Done():
+		return governance.Decision{Action: governance.Deny, Reason: "approval cancelled: " + ctx.Err().Error()}, nil
+	case r := <-resultCh:
+		switch r.action {
+		case "allow":
+			return governance.Decision{Action: governance.Allow, Reason: "approved by user"}, nil
+		default:
+			return governance.Decision{Action: governance.Deny, Reason: r.reason}, nil
+		}
+	}
+}
+
+// handleCardAction processes a Feishu card action trigger event (button click
+// or form submit). It resolves the pending approval and returns a toast +
+// updated card for the Feishu client to send back over the WebSocket.
+func (a *feishuApprover) handleCardAction(_ context.Context, event *callback.CardActionTriggerEvent) (*callback.CardActionTriggerResponse, error) {
+	if event == nil || event.Event == nil || event.Event.Action == nil {
+		return toastResponse("error", "无效的审批事件"), nil
+	}
+
+	action := event.Event.Action
+	approvalID, _ := action.Value["approval_id"].(string)
+	if approvalID == "" {
+		return toastResponse("error", "无法识别审批ID"), nil
+	}
+
+	buttonAction, _ := action.Value["action"].(string)
+
+	a.mu.Lock()
+	entry, ok := a.pending[approvalID]
+	if ok {
+		delete(a.pending, approvalID)
+	}
+	a.mu.Unlock()
+
+	if !ok {
+		return toastResponse("warning", "审批已过期或已处理"), nil
+	}
+
+	var r approvalResult
+	switch buttonAction {
+	case "agree":
+		r = approvalResult{action: "allow"}
+	case "reject":
+		r = approvalResult{action: "deny", reason: "rejected by user"}
+	default:
+		return toastResponse("warning", "未知操作: "+buttonAction), nil
+	}
+
+	// Non-blocking send: Ask is waiting on this channel.
+	select {
+	case entry.result <- r:
+	default:
+	}
+
+	// Build the resolved card and patch the original card message — but
+	// only for the fallback path (standalone approval card). For the
+	// integrated path the buttons live in the run card; streamReply
+	// removes them when the next stream event arrives.
+	decision, toastType, toastText := resolvedDisplay(r)
+	resp := toastResponse(toastType, toastText)
+
+	if !entry.integrated {
+		go a.patchResolved(event, entry, decision, r.reason)
+	}
+
+	return resp, nil
+}
+
+// patchResolved fire-and-forgets a PATCH to update the approval card with
+// the final decision. Failures are non-critical (the toast already confirmed
+// the action to the user).
+func (a *feishuApprover) patchResolved(event *callback.CardActionTriggerEvent, entry *pendingApproval, decision, reason string) {
+	if a.client == nil || event.Event.Context == nil {
+		return
+	}
+	msgID := event.Event.Context.OpenMessageID
+	if msgID == "" {
+		return
+	}
+	cardJSON, err := buildResolvedCard(entry.toolName, entry.args, decision, reason)
+	if err != nil {
+		slog.Warn("feishu: build resolved card", "error", err)
+		return
+	}
+	if err := patchMessageCard(context.Background(), a.client, msgID, cardJSON); err != nil {
+		slog.Warn("feishu: patch resolved card", "error", err)
+	}
+}
+
+// sendInteractive sends a raw interactive card JSON to a chat by chat_id.
+func (a *feishuApprover) sendInteractive(ctx context.Context, chatID, cardJSON string) (string, error) {
+	return createMessage(ctx, a.client, "chat_id", chatID, "interactive", cardJSON)
+}
+
+// chatIDFromSession extracts the Feishu chat ID from a session ID. Channel
+// session IDs follow the convention "<channelName>_<chatID>" (e.g.
+// "feishu_oc_xxx").
+func chatIDFromSession(sessionID string) string {
+	prefix := "feishu_"
+	if strings.HasPrefix(sessionID, prefix) {
+		return strings.TrimPrefix(sessionID, prefix)
+	}
+	return sessionID
+}
+
+// resolvedDisplay maps an approvalResult to the display text for the
+// resolved card, plus the toast type and message.
+func resolvedDisplay(r approvalResult) (decision, toastType, toastText string) {
+	switch r.action {
+	case "allow":
+		return "✅ **已同意**", "success", "已同意"
+	default:
+		return "❌ **已拒绝**", "error", "已拒绝"
+	}
+}
+
+// toastResponse builds a CardActionTriggerResponse containing only a toast.
+func toastResponse(typ, content string) *callback.CardActionTriggerResponse {
+	return &callback.CardActionTriggerResponse{
+		Toast: &callback.Toast{Type: typ, Content: content},
+	}
+}
+
+// setRunCardUpdater registers a callback invoked by Ask to embed approval
+// buttons in the run card instead of sending a separate approval card.
+// Keyed by session ID to support concurrent chats.
+func (a *feishuApprover) setRunCardUpdater(sessionID string, cb func(toolName, args, approvalID string)) {
+	a.updaterMu.Lock()
+	a.updaters[sessionID] = cb
+	a.updaterMu.Unlock()
+}
+
+// clearRunCardUpdater removes the callback registered for the given session.
+func (a *feishuApprover) clearRunCardUpdater(sessionID string) {
+	a.updaterMu.Lock()
+	delete(a.updaters, sessionID)
+	a.updaterMu.Unlock()
+}

--- a/channel/feishu/approver_test.go
+++ b/channel/feishu/approver_test.go
@@ -1,0 +1,402 @@
+package feishu
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
+)
+
+func TestBuildApprovalCard(t *testing.T) {
+	cardJSON, err := buildApprovalCard("abc123", "shell", `{"command":"rm -rf /tmp"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var card map[string]any
+	if err := json.Unmarshal([]byte(cardJSON), &card); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// Header
+	assertPath(t, card, "header.title.content", "需要权限")
+	assertPath(t, card, "header.template", "blue")
+	assertPath(t, card, "schema", "2.0")
+
+	// No banner image — first body element is markdown, not img.
+	body, _ := card["body"].(map[string]any)
+	elems, _ := body["elements"].([]any)
+	first, _ := elems[0].(map[string]any)
+	if first["tag"] != "markdown" {
+		t.Errorf("first element tag = %v, want markdown (no banner image)", first["tag"])
+	}
+
+	// Markdown contains tool name and args.
+	md, _ := first["content"].(string)
+	if !strings.Contains(md, "shell") {
+		t.Error("markdown should contain tool name")
+	}
+	if !strings.Contains(md, "rm -rf /tmp") {
+		t.Error("markdown should contain args")
+	}
+
+	// Approval ID embedded in all button values.
+	if !strings.Contains(cardJSON, `"approval_id":"abc123"`) {
+		t.Error("approval ID should be embedded in button values")
+	}
+
+	// Count buttons with approval_id — should be 2 (同意/拒绝).
+	count := strings.Count(cardJSON, `"approval_id":"abc123"`)
+	if count != 2 {
+		t.Errorf("expected 2 buttons with approval_id, got %d", count)
+	}
+}
+
+func TestBuildApprovalCardButtonStructure(t *testing.T) {
+	cardJSON, err := buildApprovalCard("x", "read", `{"path":"/etc"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var card map[string]any
+	json.Unmarshal([]byte(cardJSON), &card)
+
+	body, _ := card["body"].(map[string]any)
+	elems, _ := body["elements"].([]any)
+
+	// elements: [markdown, hr, column_set]
+	if len(elems) != 3 {
+		t.Fatalf("expected 3 body elements, got %d", len(elems))
+	}
+	if elems[1].(map[string]any)["tag"] != "hr" {
+		t.Error("second element should be hr")
+	}
+
+	colSet, _ := elems[2].(map[string]any)
+	if colSet["tag"] != "column_set" {
+		t.Error("third element should be column_set")
+	}
+
+	cols, _ := colSet["columns"].([]any)
+	if len(cols) != 2 {
+		t.Fatalf("expected 2 columns (buttons), got %d", len(cols))
+	}
+
+	// No form, no input, no submit button.
+	if strings.Contains(cardJSON, `"tag":"form"`) {
+		t.Error("card should not contain a form")
+	}
+	if strings.Contains(cardJSON, `"tag":"input"`) {
+		t.Error("card should not contain an input")
+	}
+	if strings.Contains(cardJSON, `"form_action_type"`) {
+		t.Error("card should not contain a submit button")
+	}
+}
+
+func TestBuildResolvedCard(t *testing.T) {
+	cardJSON, err := buildResolvedCard("shell", `{"command":"ls"}`, "✅ **已同意**", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var card map[string]any
+	json.Unmarshal([]byte(cardJSON), &card)
+
+	assertPath(t, card, "header.template", "green")
+	body, _ := card["body"].(map[string]any)
+	elems, _ := body["elements"].([]any)
+
+	// First element should be a collapsible_panel (collapsed).
+	panel, _ := elems[0].(map[string]any)
+	if panel["tag"] != "collapsible_panel" {
+		t.Errorf("expected collapsible_panel, got %v", panel["tag"])
+	}
+	if expanded, _ := panel["expanded"].(bool); expanded {
+		t.Error("panel should start collapsed")
+	}
+
+	// Panel header title contains decision + tool name.
+	hdr, _ := panel["header"].(map[string]any)
+	title, _ := hdr["title"].(map[string]any)
+	content, _ := title["content"].(string)
+	if !strings.Contains(content, "已同意") {
+		t.Error("panel header should contain decision text")
+	}
+	if !strings.Contains(content, "shell") {
+		t.Error("panel header should contain tool name")
+	}
+
+	// Panel body (hidden) contains the details.
+	panelElems, _ := panel["elements"].([]any)
+	md, _ := panelElems[0].(map[string]any)
+	mdContent, _ := md["content"].(string)
+	if !strings.Contains(mdContent, "shell") {
+		t.Error("panel body should contain tool name details")
+	}
+
+	// No form in resolved card.
+	if strings.Contains(cardJSON, `"tag":"form"`) {
+		t.Error("resolved card should not contain a form")
+	}
+}
+
+func TestBuildResolvedCardDeny(t *testing.T) {
+	cardJSON, err := buildResolvedCard("shell", `{}`, "❌ **已拒绝**", "too dangerous")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var card map[string]any
+	json.Unmarshal([]byte(cardJSON), &card)
+
+	assertPath(t, card, "header.template", "red")
+
+	// Panel body should contain the rejection reason.
+	body, _ := card["body"].(map[string]any)
+	elems, _ := body["elements"].([]any)
+	panel, _ := elems[0].(map[string]any)
+	panelElems, _ := panel["elements"].([]any)
+	md, _ := panelElems[0].(map[string]any)
+	mdContent, _ := md["content"].(string)
+	if !strings.Contains(mdContent, "too dangerous") {
+		t.Error("panel body should contain rejection reason")
+	}
+}
+
+func TestChatIDFromSession(t *testing.T) {
+	tests := []struct {
+		sessionID string
+		want      string
+	}{
+		{"feishu_oc_abcd1234", "oc_abcd1234"},
+		{"feishu_", ""},
+		{"other_prefix", "other_prefix"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := chatIDFromSession(tt.sessionID)
+		if got != tt.want {
+			t.Errorf("chatIDFromSession(%q) = %q, want %q", tt.sessionID, got, tt.want)
+		}
+	}
+}
+
+func TestHandleCardAction(t *testing.T) {
+	tests := []struct {
+		name       string
+		buttonName string
+		wantAction string
+		wantReason string
+	}{
+		{"agree", "agree", "allow", ""},
+		{"reject", "reject", "deny", "rejected by user"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ap := newFeishuApprover()
+			resultCh := make(chan approvalResult, 1)
+			approvalID := "test-" + tt.name
+			ap.mu.Lock()
+			ap.pending[approvalID] = &pendingApproval{
+				result:   resultCh,
+				toolName: "shell",
+				args:     `{}`,
+			}
+			ap.mu.Unlock()
+
+			event := &callback.CardActionTriggerEvent{
+				Event: &callback.CardActionTriggerRequest{
+					Action: &callback.CallBackAction{
+						Name:  tt.buttonName,
+						Value: map[string]any{"approval_id": approvalID, "action": tt.buttonName},
+					},
+				},
+			}
+
+			resp, err := ap.handleCardAction(nil, event)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resp == nil || resp.Toast == nil {
+				t.Fatal("expected toast response")
+			}
+
+			select {
+			case r := <-resultCh:
+				if r.action != tt.wantAction {
+					t.Errorf("action = %q, want %q", r.action, tt.wantAction)
+				}
+				if tt.wantReason != "" && r.reason != tt.wantReason {
+					t.Errorf("reason = %q, want %q", r.reason, tt.wantReason)
+				}
+			default:
+				t.Fatal("pending approval was not resolved")
+			}
+		})
+	}
+}
+
+func TestHandleCardActionExpired(t *testing.T) {
+	ap := newFeishuApprover()
+
+	event := &callback.CardActionTriggerEvent{
+		Event: &callback.CardActionTriggerRequest{
+			Action: &callback.CallBackAction{
+				Name:  "agree",
+				Value: map[string]any{"approval_id": "nonexistent", "action": "agree"},
+			},
+		},
+	}
+
+	resp, err := ap.handleCardAction(nil, event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Toast.Type != "warning" {
+		t.Errorf("expired approval should return warning, got %s", resp.Toast.Type)
+	}
+}
+
+func TestHandleCardActionIntegrated(t *testing.T) {
+	// When integrated=true, handleCardAction should resolve the result
+	// channel and return a toast, but NOT call patchResolved (no separate
+	// card to patch). We verify the result is delivered correctly.
+	ap := newFeishuApprover()
+	resultCh := make(chan approvalResult, 1)
+	ap.mu.Lock()
+	ap.pending["int-1"] = &pendingApproval{
+		result:     resultCh,
+		toolName:   "shell",
+		args:       `{}`,
+		integrated: true,
+	}
+	ap.mu.Unlock()
+
+	event := &callback.CardActionTriggerEvent{
+		Event: &callback.CardActionTriggerRequest{
+			Action: &callback.CallBackAction{
+				Name:  "agree",
+				Value: map[string]any{"approval_id": "int-1", "action": "agree"},
+			},
+		},
+	}
+
+	resp, err := ap.handleCardAction(nil, event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || resp.Toast == nil {
+		t.Fatal("expected toast response")
+	}
+	if resp.Toast.Type != "success" {
+		t.Errorf("expected success toast, got %s", resp.Toast.Type)
+	}
+
+	select {
+	case r := <-resultCh:
+		if r.action != "allow" {
+			t.Errorf("action = %q, want allow", r.action)
+		}
+	default:
+		t.Fatal("pending approval was not resolved")
+	}
+}
+
+func TestSetClearRunCardUpdater(t *testing.T) {
+	ap := newFeishuApprover()
+
+	called := false
+	cb := func(toolName, args, approvalID string) {
+		called = true
+	}
+
+	ap.setRunCardUpdater("session-1", cb)
+
+	// Verify lookup.
+	ap.updaterMu.Lock()
+	_, ok := ap.updaters["session-1"]
+	ap.updaterMu.Unlock()
+	if !ok {
+		t.Fatal("updater should be registered")
+	}
+
+	// Verify the callback is invocable.
+	ap.updaterMu.Lock()
+	updater := ap.updaters["session-1"]
+	ap.updaterMu.Unlock()
+	if updater == nil {
+		t.Fatal("updater should not be nil")
+	}
+	updater("shell", "{}", "test-id")
+	if !called {
+		t.Error("updater callback should have been called")
+	}
+
+	// Clear.
+	ap.clearRunCardUpdater("session-1")
+	ap.updaterMu.Lock()
+	_, ok = ap.updaters["session-1"]
+	ap.updaterMu.Unlock()
+	if ok {
+		t.Error("updater should be cleared")
+	}
+}
+
+func TestHandleCardActionNilEvent(t *testing.T) {
+	ap := newFeishuApprover()
+	resp, err := ap.handleCardAction(nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+}
+
+func TestResolvedDisplay(t *testing.T) {
+	tests := []struct {
+		r            approvalResult
+		wantDecision string
+		wantToast    string
+	}{
+		{approvalResult{action: "allow"}, "✅ **已同意**", "已同意"},
+		{approvalResult{action: "deny"}, "❌ **已拒绝**", "已拒绝"},
+	}
+	for _, tt := range tests {
+		decision, _, toast := resolvedDisplay(tt.r)
+		if decision != tt.wantDecision {
+			t.Errorf("decision = %q, want %q", decision, tt.wantDecision)
+		}
+		if toast != tt.wantToast {
+			t.Errorf("toast = %q, want %q", toast, tt.wantToast)
+		}
+	}
+}
+
+// ── helpers ──
+
+func assertPath(t *testing.T, m map[string]any, path, want string) {
+	t.Helper()
+	parts := strings.Split(path, ".")
+	cur := any(m)
+	for i, p := range parts {
+		mp, ok := cur.(map[string]any)
+		if !ok {
+			t.Fatalf("at %q: expected map, got %T", strings.Join(parts[:i], "."), cur)
+		}
+		v, ok := mp[p]
+		if !ok {
+			t.Fatalf("path %q not found", path)
+		}
+		if i == len(parts)-1 {
+			if s, ok := v.(string); !ok || s != want {
+				t.Errorf("%s = %q, want %q", path, v, want)
+			}
+			return
+		}
+		cur = v
+	}
+}

--- a/channel/feishu/card.go
+++ b/channel/feishu/card.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/yusheng-g/openagent-go/channel"
+	"github.com/yusheng-g/openagent-go/utils"
 )
 
 // BuildCard converts a channel.Card into a Feishu interactive card JSON
@@ -17,9 +18,11 @@ import (
 //	header  → title + subtitle + colour template
 //	body.elements → markdown(content) [→ hr → note(footer)]
 //
-// When Card.Collapsed is set, the body markdown is wrapped in a
+// When Card.Fold is FoldCollapsed, the body markdown is wrapped in a
 // collapsible_panel (expanded:false) so verbose content (tool output,
 // reasoning) is hidden behind a clickable bar by default.
+// FoldExpanded wraps it in a panel that starts expanded; FoldNone
+// renders plain markdown with no fold affordance.
 //
 // See: https://open.feishu.cn/document/uAjLw4CM/ukzMukzMukzM/feishu-cards/card-components/overview
 func BuildCard(c *channel.Card) (string, error) {
@@ -34,12 +37,13 @@ func BuildCard(c *channel.Card) (string, error) {
 	// A single element keeps multi-line constructs (tables, code blocks)
 	// intact so they render correctly.
 	body := strings.TrimSpace(c.Content)
-	if body == "" {
-		body = "(empty)"
-	}
-	bodyElem := map[string]any{
-		"tag":     "markdown",
-		"content": body,
+
+	var bodyElem map[string]any
+	if body != "" {
+		bodyElem = map[string]any{
+			"tag":     "markdown",
+			"content": body,
+		}
 	}
 
 	var elems []map[string]any
@@ -47,22 +51,35 @@ func BuildCard(c *channel.Card) (string, error) {
 		// Nested panels: each sub-card becomes an inner collapsible_panel.
 		inner := make([]map[string]any, 0, len(c.Panels))
 		for i := range c.Panels {
-			inner = append(inner, subPanel(&c.Panels[i]))
+			if sp := subPanel(&c.Panels[i]); sp != nil {
+				inner = append(inner, sp)
+			}
 		}
-		if c.Collapsed {
+		if len(inner) == 0 && bodyElem == nil {
+			elems = append(elems, map[string]any{"tag": "hr"})
+		} else if c.Fold == channel.FoldCollapsed && len(inner) > 0 {
 			elems = append(elems, collapsiblePanelList(c.Header.Title, inner))
 		} else {
 			elems = append(elems, inner...)
 		}
-		// When the card also carries a markdown body (e.g. the run card's
-		// answer section), append it after the panels.
-		if body != "" && body != "(empty)" {
+		if bodyElem != nil {
 			elems = append(elems, bodyElem)
 		}
-	} else if c.Collapsed {
-		elems = append(elems, collapsiblePanel(bodyElem))
 	} else {
-		elems = append(elems, bodyElem)
+		if bodyElem == nil {
+			// No panels and no body — Feishu requires at least one
+			// element. Add a blank spacer to avoid API rejection.
+			elems = append(elems, map[string]any{"tag": "hr"})
+		} else {
+			switch c.Fold {
+			case channel.FoldCollapsed:
+				elems = append(elems, collapsiblePanel(bodyElem))
+			case channel.FoldExpanded:
+				elems = append(elems, collapsiblePanelExpanded(bodyElem))
+			default:
+				elems = append(elems, bodyElem)
+			}
+		}
 	}
 
 	// Separator + footer note.
@@ -79,10 +96,34 @@ func BuildCard(c *channel.Card) (string, error) {
 		})
 	}
 
+	// Approval section: separator + context (tool name + args) + buttons.
+	// Rendered at the very bottom so it's visible without expanding any
+	// collapsed panels.
+	if c.Approval != nil {
+		elems = append(elems, map[string]any{"tag": "hr"})
+		preview := truncateForCard(utils.PrettyJSON(c.Approval.Args), 200)
+		elems = append(elems, map[string]any{
+			"tag":     "markdown",
+			"content": fmt.Sprintf("🔐 **需要权限**：`%s`\n%s", c.Approval.ToolName, channel.CodeBlock(preview)),
+		})
+		elems = append(elems, approvalButtonRow(c.Approval.ApprovalID))
+	}
+
+	// Mode-switch section: separator + button row (Manual / Auto).
+	if c.ModeSwitch != nil {
+		elems = append(elems, map[string]any{"tag": "hr"})
+		elems = append(elems, modeButtonRow(c.ModeSwitch.CurrentMode))
+	}
+
 	card := map[string]any{
 		"schema": "2.0",
 		"header": hdr,
 		"body":   map[string]any{"elements": elems},
+	}
+
+	// Allow multiple users to click the approval/mode buttons in group chats.
+	if c.Approval != nil || c.ModeSwitch != nil {
+		card["config"] = map[string]any{"update_multi": true}
 	}
 
 	b, err := json.Marshal(card)
@@ -129,6 +170,14 @@ func collapsiblePanel(body map[string]any) map[string]any {
 	return panel(panelPreview(body), []map[string]any{body})
 }
 
+// collapsiblePanelExpanded wraps a single markdown body element in a
+// collapsible panel that starts expanded. The user can click to collapse.
+func collapsiblePanelExpanded(body map[string]any) map[string]any {
+	p := collapsiblePanel(body)
+	p["expanded"] = true
+	return p
+}
+
 // collapsiblePanelList wraps a list of inner panels in one outer collapsed
 // panel — used to group multiple tool calls under a single "toolcalls (N)" bar.
 func collapsiblePanelList(title string, inner []map[string]any) map[string]any {
@@ -137,8 +186,18 @@ func collapsiblePanelList(title string, inner []map[string]any) map[string]any {
 
 // subPanel renders a nested Card as an inner collapsed panel. The sub-card's
 // header title becomes the panel bar label; an empty title falls back to a
-// one-line preview of the content. Nested panels recurse.
+// one-line preview of the content. Nested panels recurse. A FoldNone panel
+// renders as a plain markdown element (no collapsible wrapper).
 func subPanel(c *channel.Card) map[string]any {
+	// FoldNone: plain markdown, no collapsible wrapper — used for inline
+	// text segments interleaved with tool-call panels.
+	if c.Fold == channel.FoldNone {
+		body := strings.TrimSpace(c.Content)
+		if body == "" {
+			return nil
+		}
+		return map[string]any{"tag": "markdown", "content": body}
+	}
 	var elements []map[string]any
 	if len(c.Panels) > 0 {
 		elements = make([]map[string]any, 0, len(c.Panels))
@@ -148,7 +207,7 @@ func subPanel(c *channel.Card) map[string]any {
 	} else {
 		body := strings.TrimSpace(c.Content)
 		if body == "" {
-			body = "(empty)"
+			return nil
 		}
 		elements = []map[string]any{{"tag": "markdown", "content": body}}
 	}
@@ -156,7 +215,12 @@ func subPanel(c *channel.Card) map[string]any {
 	if title == "" {
 		title = panelPreview(elements[0])
 	}
-	return panel(title, elements)
+	p := panel(title, elements)
+	if c.Header.TitleMarkdown {
+		hdr, _ := p["header"].(map[string]any)
+		hdr["title"] = map[string]any{"tag": "lark_md", "content": title}
+	}
+	return p
 }
 
 // panelPreview extracts a one-line preview from a markdown body element.
@@ -216,8 +280,8 @@ func BuildPlanCard(goal string, entriesMarkdown string) (string, error) {
 
 // BuildToolCallCard renders a tool call result as a compact card.
 func BuildToolCallCard(toolName, params, result string) (string, error) {
-	content := fmt.Sprintf("**Tool:** `%s`\n\n**Args:**\n```\n%s\n```\n\n**Result:**\n%s",
-		toolName, truncateForCard(params, 300), truncateForCard(result, 500))
+	content := fmt.Sprintf("**Tool:** `%s`\n\n**Args:**\n%s\n\n**Result:**\n%s",
+		toolName, channel.CodeBlock(truncateForCard(params, 300)), truncateForCard(result, 500))
 	return BuildCard(&channel.Card{
 		Header:  channel.CardHeader{Title: "Tool: " + toolName},
 		Content: content,

--- a/channel/feishu/card_test.go
+++ b/channel/feishu/card_test.go
@@ -54,8 +54,12 @@ func TestBuildCardEmptyContent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(result, "(empty)") {
-		t.Errorf("empty content should produce (empty), got: %s", result)
+	// Empty content should produce a placeholder element (hr), not "(empty)".
+	if strings.Contains(result, "(empty)") {
+		t.Errorf("empty content should not produce (empty), got: %s", result)
+	}
+	if !strings.Contains(result, `"tag":"hr"`) {
+		t.Errorf("empty content should produce an hr placeholder, got: %s", result)
 	}
 }
 
@@ -122,6 +126,88 @@ func TestBuildCardNil(t *testing.T) {
 	_, err := BuildCard(nil)
 	if err == nil {
 		t.Fatal("expected error for nil card")
+	}
+}
+
+func TestBuildCardWithApproval(t *testing.T) {
+	c := &channel.Card{
+		Header:  channel.CardHeader{Title: "🔧 调用工具中"},
+		Content: "running...",
+		Color:   channel.CardColorYellow,
+		Approval: &channel.CardApproval{
+			ToolName:   "shell",
+			Args:       `{"command":"rm -rf /tmp"}`,
+			ApprovalID: "abc123",
+		},
+	}
+	result, err := BuildCard(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(result), &m); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// config.update_multi should be set when approval is present.
+	cfg, _ := m["config"].(map[string]any)
+	if cfg == nil {
+		t.Fatal("expected config when approval is set")
+	}
+	if cfg["update_multi"] != true {
+		t.Error("expected update_multi=true")
+	}
+
+	body, _ := m["body"].(map[string]any)
+	elems, _ := body["elements"].([]any)
+
+	// Last three elements: hr, markdown (approval context), column_set (buttons).
+	n := len(elems)
+	if n < 3 {
+		t.Fatalf("expected at least 3 elements, got %d", n)
+	}
+	hr, _ := elems[n-3].(map[string]any)
+	if hr["tag"] != "hr" {
+		t.Errorf("expected hr before approval, got %v", hr["tag"])
+	}
+	md, _ := elems[n-2].(map[string]any)
+	if md["tag"] != "markdown" {
+		t.Errorf("expected markdown for approval context, got %v", md["tag"])
+	}
+	mdContent, _ := md["content"].(string)
+	if !strings.Contains(mdContent, "shell") {
+		t.Error("approval markdown should contain tool name")
+	}
+	if !strings.Contains(mdContent, "rm -rf /tmp") {
+		t.Error("approval markdown should contain args")
+	}
+	colSet, _ := elems[n-1].(map[string]any)
+	if colSet["tag"] != "column_set" {
+		t.Errorf("expected column_set for buttons, got %v", colSet["tag"])
+	}
+
+	// Approval ID embedded in all 2 button values.
+	count := strings.Count(result, `"approval_id":"abc123"`)
+	if count != 2 {
+		t.Errorf("expected 2 buttons with approval_id, got %d", count)
+	}
+}
+
+func TestBuildCardWithoutApprovalHasNoConfig(t *testing.T) {
+	c := &channel.Card{
+		Header:  channel.CardHeader{Title: "X"},
+		Content: "body",
+		Color:   channel.CardColorBlue,
+	}
+	result, err := BuildCard(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	json.Unmarshal([]byte(result), &m)
+	if _, ok := m["config"]; ok {
+		t.Error("card without approval should not have config")
 	}
 }
 

--- a/channel/feishu/feishu.go
+++ b/channel/feishu/feishu.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -18,21 +19,39 @@ import (
 	lark "github.com/larksuite/oapi-sdk-go/v3"
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher"
+	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
 	larkapplication "github.com/larksuite/oapi-sdk-go/v3/service/application/v6"
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 	larkws "github.com/larksuite/oapi-sdk-go/v3/ws"
 
 	"github.com/yusheng-g/openagent-go/channel"
+	"github.com/yusheng-g/openagent-go/governance"
 )
+
+// leadingMentionRe matches one or more consecutive Feishu @-mention
+// placeholders at the start of a message (e.g. "@_user_1 @_user_2").
+// In group chats, Feishu embeds these opaque tokens in the text field
+// instead of human-readable "@name". They must be stripped so that
+// slash commands like "/mode" are recognized and the agent doesn't
+// receive rendering artifacts as user input.
+var leadingMentionRe = regexp.MustCompile(`^(@_user_\d+\s*)+`)
 
 // Channel implements channel.Channel for Feishu via WebSocket long connection.
 type Channel struct {
 	appID     string
 	appSecret string
 
-	client *lark.Client
-	ws     *larkws.Client
-	once   sync.Once
+	client   *lark.Client
+	ws       *larkws.Client
+	once     sync.Once
+	approver *feishuApprover
+
+	// Per-chat mode state ("manual" | "auto"). defMode is the fallback
+	// for chats that have never switched; it comes from config
+	// DefaultMode (defaults to "manual").
+	modeMu  sync.RWMutex
+	modes   map[string]string
+	defMode string
 
 	// onReady is invoked by the SDK once the WebSocket is connected and
 	// ready to receive messages (nil = ignore). Used by the connection
@@ -53,10 +72,81 @@ type Channel struct {
 	connectedOnce atomic.Bool
 }
 
-// New returns a Feishu Channel. The Channel must be started via Start() to
-// begin receiving messages.
-func New(appID, appSecret string) *Channel {
-	return &Channel{appID: appID, appSecret: appSecret}
+// New returns a Feishu Channel. defaultMode is the initial mode for chats
+// that haven't explicitly switched ("manual" or "auto"; empty = "manual").
+// The Channel must be started via Start() to begin receiving messages.
+func New(appID, appSecret, defaultMode string) *Channel {
+	if !channel.IsValidMode(defaultMode) {
+		defaultMode = channel.ModeManual
+	}
+	return &Channel{
+		appID:     appID,
+		appSecret: appSecret,
+		approver:  newFeishuApprover(),
+		modes:     make(map[string]string),
+		defMode:   defaultMode,
+	}
+}
+
+// GetMode returns the current mode for a chat ("manual" | "auto").
+// Chats that have never switched return the default mode.
+func (c *Channel) GetMode(chatID string) string {
+	c.modeMu.RLock()
+	defer c.modeMu.RUnlock()
+	if m, ok := c.modes[chatID]; ok {
+		return m
+	}
+	return c.defMode
+}
+
+// SetMode updates the mode for a chat.
+func (c *Channel) SetMode(chatID, mode string) {
+	if !channel.IsValidMode(mode) {
+		return
+	}
+	c.modeMu.Lock()
+	defer c.modeMu.Unlock()
+	c.modes[chatID] = mode
+}
+
+// BuildModeCard returns a platform-neutral Card for the mode-switching
+// UI. The current mode for the chat is highlighted. Used by the channel
+// handler when the user sends /mode.
+func (c *Channel) BuildModeCard(chatID string) *channel.Card {
+	return &channel.Card{
+		Header:     channel.CardHeader{Title: "模式切换"},
+		Color:      channel.CardColorBlue,
+		Content:    modeCardContent(c.GetMode(chatID)),
+		ModeSwitch: &channel.CardModeSwitch{CurrentMode: c.GetMode(chatID)},
+	}
+}
+
+// modeCardContent returns the markdown body for the mode card.
+func modeCardContent(currentMode string) string {
+	return fmt.Sprintf(
+		"选择 agent 的工作模式：\n\n"+
+			modeDescription+"\n\n"+
+			"当前模式：**%s**",
+		modeLabel(currentMode),
+	)
+}
+
+// Approver returns the Feishu-card-based human approver for this channel.
+// May be called before Start; the lark client is wired in Start.
+func (c *Channel) Approver(_ governance.ApprovalMemory) governance.HumanApprover {
+	return c.approver
+}
+
+// SetRunCardUpdater registers a callback that Ask invokes to embed approval
+// buttons in the run card instead of sending a separate approval card.
+// streamReply calls this before each agent run and clears it after.
+func (c *Channel) SetRunCardUpdater(sessionID string, cb func(toolName, args, approvalID string)) {
+	c.approver.setRunCardUpdater(sessionID, cb)
+}
+
+// ClearRunCardUpdater removes the run-card update callback for a session.
+func (c *Channel) ClearRunCardUpdater(sessionID string) {
+	c.approver.clearRunCardUpdater(sessionID)
 }
 
 // SetOnReady registers the connection-ready callback (nil clears it).
@@ -78,6 +168,7 @@ func (c *Channel) Name() string { return "feishu" }
 // Feishu and blocks until ctx is cancelled.
 func (c *Channel) Start(ctx context.Context, handler channel.MessageHandler) error {
 	c.client = lark.NewClient(c.appID, c.appSecret)
+	c.approver.client = c.client
 
 	dh := dispatcher.NewEventDispatcher("", "").
 		OnP2MessageReceiveV1(func(ctx context.Context, event *larkim.P2MessageReceiveV1) error {
@@ -87,6 +178,9 @@ func (c *Channel) Start(ctx context.Context, handler channel.MessageHandler) err
 			}
 			handler(ctx, *msg, c.buildReply(ctx, event))
 			return nil
+		}).
+		OnP2CardActionTrigger(func(ctx context.Context, event *callback.CardActionTriggerEvent) (*callback.CardActionTriggerResponse, error) {
+			return c.handleCardAction(ctx, event)
 		}).
 		// Silently accept non-message events to avoid error spam.
 		OnP2ChatAccessEventBotP2pChatEnteredV1(func(ctx context.Context, event *larkim.P2ChatAccessEventBotP2pChatEnteredV1) error {
@@ -209,7 +303,7 @@ func toIncoming(event *larkim.P2MessageReceiveV1) *channel.IncomingMessage {
 	}
 	msg := event.Event.Message
 
-	text := extractText(msg)
+	text := stripLeadingMentions(extractText(msg))
 	if strings.TrimSpace(text) == "" {
 		return nil
 	}
@@ -299,6 +393,16 @@ func extractText(msg *larkim.EventMessage) string {
 	return strings.TrimSpace(raw)
 }
 
+// stripLeadingMentions removes Feishu @-mention placeholders (@_user_N)
+// from the beginning of text. Only leading mentions are stripped so that
+// inline mentions (e.g. "tell @_user_1 to review") are preserved for the
+// agent to see. Returns empty string when text contains only mentions.
+func stripLeadingMentions(text string) string {
+	t := strings.TrimSpace(text)
+	t = leadingMentionRe.ReplaceAllString(t, "")
+	return strings.TrimSpace(t)
+}
+
 // ── Reply ──
 
 // buildReply returns a channel.ReplyFunc that sends a message back
@@ -379,7 +483,14 @@ func (c *Channel) sendCard(ctx context.Context, receiveIDType, receiveID string,
 }
 
 func (c *Channel) sendMessage(ctx context.Context, receiveIDType, receiveID, msgType, content string) (string, error) {
-	resp, err := c.client.Im.Message.Create(ctx,
+	return createMessage(ctx, c.client, receiveIDType, receiveID, msgType, content)
+}
+
+// createMessage sends a message via the Feishu IM API and returns the
+// platform-assigned message ID. Shared by Channel.sendMessage and
+// feishuApprover.sendInteractive.
+func createMessage(ctx context.Context, client *lark.Client, receiveIDType, receiveID, msgType, content string) (string, error) {
+	resp, err := client.Im.Message.Create(ctx,
 		larkim.NewCreateMessageReqBuilder().
 			ReceiveIdType(receiveIDType).
 			Body(larkim.NewCreateMessageReqBodyBuilder().
@@ -403,19 +514,96 @@ func (c *Channel) sendMessage(ctx context.Context, receiveIDType, receiveID, msg
 // patchCard updates an existing interactive card message by message ID.
 // https://open.feishu.cn/document/server-docs/im-v1/message/patch
 func (c *Channel) patchCard(ctx context.Context, messageID, cardJSON string) error {
-	content := cardJSON // PATCH body just needs the new card content
-	resp, err := c.client.Im.Message.Patch(ctx,
+	return patchMessageCard(ctx, c.client, messageID, cardJSON)
+}
+
+// patchMessageCard patches an existing interactive card message.
+// Shared by Channel.patchCard and feishuApprover.patchResolved.
+func patchMessageCard(ctx context.Context, client *lark.Client, messageID, cardJSON string) error {
+	resp, err := client.Im.Message.Patch(ctx,
 		larkim.NewPatchMessageReqBuilder().
 			MessageId(messageID).
 			Body(larkim.NewPatchMessageReqBodyBuilder().
-				Content(content).
+				Content(cardJSON).
 				Build()).
 			Build())
 	if err != nil {
 		return fmt.Errorf("feishu: patch card: %w", err)
 	}
 	if !resp.Success() {
+		slog.Warn("feishu: patch card failed", "code", resp.Code, "msg", resp.Msg, "cardSize", len(cardJSON))
 		return fmt.Errorf("feishu: patch card failed: code=%d msg=%s", resp.Code, resp.Msg)
 	}
 	return nil
+}
+
+// CardSize returns the serialized JSON size of a card for size-limit
+// checks. Implements the server.CardSizer interface.
+func (c *Channel) CardSize(card *channel.Card) int {
+	b, err := BuildCard(card)
+	if err != nil {
+		return 0
+	}
+	return len(b)
+}
+
+// ── Card action routing ──
+
+// handleCardAction routes a Feishu card action trigger event to either
+// mode-switch handling (when value["type"]=="mode_switch") or the
+// existing approval flow (delegated to feishuApprover).
+func (c *Channel) handleCardAction(ctx context.Context, event *callback.CardActionTriggerEvent) (*callback.CardActionTriggerResponse, error) {
+	if event != nil && event.Event != nil && event.Event.Action != nil {
+		if typ, _ := event.Event.Action.Value["type"].(string); typ == "mode_switch" {
+			return c.handleModeSwitch(ctx, event)
+		}
+	}
+	return c.approver.handleCardAction(ctx, event)
+}
+
+// handleModeSwitch processes a mode-switch button click. It extracts the
+// target mode and chat ID from the event, updates the per-chat mode
+// state, patches the card to show the result, and returns a toast.
+func (c *Channel) handleModeSwitch(_ context.Context, event *callback.CardActionTriggerEvent) (*callback.CardActionTriggerResponse, error) {
+	action := event.Event.Action
+	mode, _ := action.Value["mode"].(string)
+	if !channel.IsValidMode(mode) {
+		return toastResponse("error", "未知模式: "+mode), nil
+	}
+
+	chatID := ""
+	if event.Event.Context != nil {
+		chatID = event.Event.Context.OpenChatID
+	}
+	if chatID == "" {
+		return toastResponse("error", "无法识别聊天ID"), nil
+	}
+
+	c.SetMode(chatID, mode)
+
+	// Patch the card to show the resolved state (fire-and-forget).
+	go c.patchModeCardResolved(event, mode)
+
+	return toastResponse("success", "已切换到 "+modeLabel(mode)+" 模式"), nil
+}
+
+// patchModeCardResolved updates the mode-switch card in-place to reflect
+// the new current mode. Failures are non-critical (the toast already
+// confirmed the switch).
+func (c *Channel) patchModeCardResolved(event *callback.CardActionTriggerEvent, mode string) {
+	if c.client == nil || event.Event.Context == nil {
+		return
+	}
+	msgID := event.Event.Context.OpenMessageID
+	if msgID == "" {
+		return
+	}
+	cardJSON, err := buildModeCardResolved(mode)
+	if err != nil {
+		slog.Warn("feishu: build mode resolved card", "error", err)
+		return
+	}
+	if err := c.patchCard(context.Background(), msgID, cardJSON); err != nil {
+		slog.Warn("feishu: patch mode card", "error", err)
+	}
 }

--- a/channel/feishu/feishu_test.go
+++ b/channel/feishu/feishu_test.go
@@ -1,0 +1,29 @@
+package feishu
+
+import "testing"
+
+func TestStripLeadingMentions(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"single mention + slash command", "@_user_1 /mode", "/mode"},
+		{"single mention + slash command with args", "@_user_1 /mode auto", "/mode auto"},
+		{"single mention + plain text", "@_user_1 hello world", "hello world"},
+		{"multiple mentions", "@_user_1 @_user_2 hi", "hi"},
+		{"inline mention not stripped", "hello @_user_1 world", "hello @_user_1 world"},
+		{"mention only", "@_user_1", ""},
+		{"mention only with trailing space", "@_user_1 ", ""},
+		{"no mention", "/mode", "/mode"},
+		{"empty string", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := stripLeadingMentions(c.in)
+			if got != c.want {
+				t.Errorf("stripLeadingMentions(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/channel/feishu/mode_card.go
+++ b/channel/feishu/mode_card.go
@@ -1,0 +1,111 @@
+package feishu
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// modeDescription is the shared Manual/Auto explanation shown on mode cards.
+const modeDescription = "• **Manual**：每个非只读工具调用需点击审批卡片\n" +
+	"• **Auto**：自动执行，无需审批（高风险）"
+
+// buildModeCardResolved constructs the card JSON shown after the user has
+// switched modes. The header colour reflects the new mode (green for auto,
+// blue for manual). The body shows a confirmation message and the updated
+// button row with the new current mode highlighted.
+func buildModeCardResolved(currentMode string) (string, error) {
+	template := "blue"
+	if currentMode == "auto" {
+		template = "green"
+	}
+
+	body := fmt.Sprintf(
+		"✅ 已切换到 **%s** 模式\n\n"+
+			modeDescription+"\n\n"+
+			"当前模式：**%s**",
+		modeLabel(currentMode),
+		modeLabel(currentMode),
+	)
+
+	card := map[string]any{
+		"schema": "2.0",
+		"config": map[string]any{"update_multi": true},
+		"header": map[string]any{
+			"title":    map[string]any{"tag": "plain_text", "content": "模式切换"},
+			"subtitle": map[string]any{"tag": "plain_text", "content": ""},
+			"template": template,
+		},
+		"body": map[string]any{
+			"direction": "vertical",
+			"elements": []map[string]any{
+				{
+					"tag":     "markdown",
+					"content": body,
+				},
+				{"tag": "hr"},
+				modeButtonRow(currentMode),
+			},
+		},
+	}
+
+	b, err := json.Marshal(card)
+	if err != nil {
+		return "", fmt.Errorf("feishu mode card resolved marshal: %w", err)
+	}
+	return string(b), nil
+}
+
+// modeButtonRow builds the column_set element containing the two mode
+// buttons (Manual / Auto). The current mode uses primary_filled (bold
+// colour); the other uses default (grey). Button values carry
+// {"type":"mode_switch","mode":"..."} so handleCardAction can route
+// mode-switch clicks separately from approval clicks.
+func modeButtonRow(currentMode string) map[string]any {
+	btn := func(label, mode, btnType string) map[string]any {
+		return map[string]any{
+			"tag":   "button",
+			"text":  map[string]any{"tag": "plain_text", "content": label},
+			"type":  btnType,
+			"width": "default",
+			"name":  "mode_" + mode,
+			"value": map[string]any{"type": "mode_switch", "mode": mode},
+		}
+	}
+
+	manualType := "primary_filled"
+	autoType := "default"
+	if currentMode == "auto" {
+		manualType = "default"
+		autoType = "primary_filled"
+	}
+
+	manualLabel := "Manual"
+	autoLabel := "Auto"
+	if currentMode == "manual" {
+		manualLabel = "Manual (当前)"
+	} else if currentMode == "auto" {
+		autoLabel = "Auto (当前)"
+	}
+
+	return map[string]any{
+		"tag":                "column_set",
+		"flex_mode":          "flow",
+		"horizontal_spacing": "8px",
+		"columns": []map[string]any{
+			{"tag": "column", "width": "auto", "elements": []map[string]any{btn(manualLabel, "manual", manualType)}},
+			{"tag": "column", "width": "auto", "elements": []map[string]any{btn(autoLabel, "auto", autoType)}},
+		},
+	}
+}
+
+// modeLabel returns a human-readable label for a mode identifier.
+func modeLabel(mode string) string {
+	switch mode {
+	case "auto":
+		return "Auto"
+	case "manual":
+		return "Manual"
+	default:
+		return "Manual"
+	}
+}

--- a/cmd/cli/server/acp.go
+++ b/cmd/cli/server/acp.go
@@ -182,7 +182,7 @@ func RunACP(ctx context.Context, cfg *config.Config, caps config.Capabilities) e
 		channelDeps.Tools = buildTools(sb, cwd, []string{"shell", "read", "write", "ls", "grep", "websearch", "webfetch"})
 	}
 
-	if _, _, _, err := RunChannels(ctx, cfg.Profiles, channelCfg, channelDeps, cfg.Channels); err != nil {
+	if _, _, _, err := RunChannels(ctx, cfg.Profiles, channelCfg, channelDeps, cfg.Channels, cfg.DefaultMode); err != nil {
 		slog.Warn("channel error", "error", err)
 	}
 

--- a/cmd/cli/server/channel.go
+++ b/cmd/cli/server/channel.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/yusheng-g/openagent-go/agent"
 	"github.com/yusheng-g/openagent-go/channel"
 	"github.com/yusheng-g/openagent-go/kernel"
+	opentool "github.com/yusheng-g/openagent-go/tool"
 
 	"github.com/yusheng-g/openagent-go/cmd/cli/config"
 )
@@ -27,8 +29,10 @@ import (
 // entry points are --channel <name> (Explicit, fail-fast: the user asked
 // for the bot, so running silently without it would read as "connected"
 // while delivering nothing) and the frontend's POST /connect.
-func RunChannels(ctx context.Context, profiles string, cfg *agent.Agent, deps kernel.Deps, channelsCfg config.ChannelsConfig) (*FeishuManager, *WechatManager, *WecomManager, error) {
-	feishuMgr := NewFeishuManager(ctx, profiles, channelsCfg.Feishu, cfg, deps)
+// defaultMode is the initial session mode for channel chats ("manual"
+// or "auto"; empty = "manual").
+func RunChannels(ctx context.Context, profiles string, cfg *agent.Agent, deps kernel.Deps, channelsCfg config.ChannelsConfig, defaultMode string) (*FeishuManager, *WechatManager, *WecomManager, error) {
+	feishuMgr := NewFeishuManager(ctx, profiles, channelsCfg.Feishu, cfg, deps, defaultMode)
 	if channelsCfg.Feishu != nil && channelsCfg.Feishu.Explicit {
 		if err := feishuMgr.Connect(); err != nil {
 			return nil, nil, nil, err
@@ -86,7 +90,11 @@ func (pq *patchQueue) mark(msgID string, card *channel.Card) {
 }
 
 func (pq *patchQueue) create(msg channel.ReplyMessage) string {
-	id, _ := pq.reply(context.Background(), msg)
+	id, err := pq.reply(context.Background(), msg)
+	if err != nil {
+		slog.Warn("pq.create failed", "error", err)
+	}
+	slog.Info("pq.create", "msgID", id)
 	return id
 }
 
@@ -106,9 +114,12 @@ func (pq *patchQueue) flush() {
 	pq.timer = nil
 	pq.mu.Unlock()
 
+	slog.Info("pq.flush", "batchSize", len(batch))
 	for msgID, card := range batch {
 		msg := channel.ReplyMessage{UpdateID: msgID, Card: card}
-		_, _ = pq.reply(context.Background(), msg)
+		if _, err := pq.reply(context.Background(), msg); err != nil {
+			slog.Warn("patch card failed", "msgID", msgID, "error", err)
+		}
 	}
 }
 
@@ -125,8 +136,84 @@ func (pq *patchQueue) stop() {
 
 	for msgID, card := range batch {
 		msg := channel.ReplyMessage{UpdateID: msgID, Card: card}
-		_, _ = pq.reply(context.Background(), msg)
+		if _, err := pq.reply(context.Background(), msg); err != nil {
+			slog.Warn("patch card failed", "msgID", msgID, "error", err)
+		}
 	}
+}
+
+// runCardUpdater is implemented by channels that support embedding approval
+// buttons in the run card instead of sending a separate approval card.
+// Currently only *feishu.Channel.
+type runCardUpdater interface {
+	SetRunCardUpdater(sessionID string, cb func(toolName, args, approvalID string))
+	ClearRunCardUpdater(sessionID string)
+}
+
+// CardSizer returns the serialized size of a card for platforms that have a
+// content size limit (e.g. Feishu ~30KB interactive cards). When non-nil,
+// streamReply uses it to detect oversize cards and truncate tool history.
+// Currently only *feishu.Channel.
+type CardSizer interface {
+	CardSize(card *channel.Card) int
+}
+
+// maxCardBytes is the threshold at which streamReply abandons the current
+// card and starts a fresh one with only the latest tool call. Feishu's
+// interactive card limit is ~30KB; 28KB leaves a 2KB safety margin.
+const maxCardBytes = 28000
+
+// maxThoughtDisplay caps the thinking content shown in a run card panel.
+// The full buffer is kept for session persistence; only the card view is
+// trimmed to the most recent bytes (recent reasoning is most relevant).
+const maxThoughtDisplay = maxCardBytes / 3
+
+// ModeController is implemented by channels that support per-chat mode
+// switching (manual / auto). The handler intercepts /mode text commands
+// and card-action button clicks to switch modes without going through
+// the ACP server. Currently only *feishu.Channel.
+type ModeController interface {
+	GetMode(chatID string) string
+	SetMode(chatID, mode string)
+	BuildModeCard(chatID string) *channel.Card
+}
+
+// isModeCommand reports whether the text is a /mode invocation (with or
+// without an explicit mode argument).
+func isModeCommand(text string) bool {
+	t := strings.TrimSpace(text)
+	return t == "/mode" || strings.HasPrefix(t, "/mode ")
+}
+
+// isClearCommand reports whether the text is a /clear invocation.
+func isClearCommand(text string) bool {
+	t := strings.TrimSpace(text)
+	return t == "/clear" || strings.HasPrefix(t, "/clear ")
+}
+
+// handleClearCommand deletes the session identified by sessionID and sends
+// a confirmation reply. Shared by feishu, wechat, and wecom handlers.
+// The caller has already verified isClearCommand(msg.Text) is true.
+func handleClearCommand(deps kernel.Deps, reply channel.ReplyFunc, msgCtx context.Context, sessionID string) {
+	if deps.SessionStore != nil {
+		if err := deps.SessionStore.DeleteSession(msgCtx, sessionID); err != nil {
+			_, _ = reply(msgCtx, channel.ReplyMessage{Text: "❌ 清空失败: " + err.Error()})
+		} else {
+			_, _ = reply(msgCtx, channel.ReplyMessage{Text: "✅ 已清空对话历史"})
+		}
+	} else {
+		_, _ = reply(msgCtx, channel.ReplyMessage{Text: "✅ 已清空对话历史"})
+	}
+}
+
+// parseModeArgs extracts the mode argument from "/mode <args>".
+// Returns "" when no argument is present.
+func parseModeArgs(text string) string {
+	fields := strings.Fields(strings.TrimSpace(text))
+	if len(fields) >= 2 {
+		return strings.ToLower(fields[1])
+	}
+	return ""
 }
 
 // streamReply drains the agent stream and sends every message as a card.
@@ -134,10 +221,19 @@ func (pq *patchQueue) stop() {
 // Card patches are debounced — updates to the same card within 500ms
 // are collapsed so the Feishu API sees at most 2 PATCH/s per card.
 // This prevents the event loop from blocking on HTTP latency.
-func streamReply(reply channel.ReplyFunc, stream <-chan openagent.StreamEvent) {
+//
+// When updater is non-nil, approval buttons are embedded in the run card
+// via a callback + signal channel: Ask calls the callback (setting
+// pendingApproval), which sends on approvalSig, which wakes this loop
+// to flush the card with buttons. This avoids the approver reading
+// streamReply's shared state from a different goroutine.
+//
+// When sizer is non-nil, the serialized card size is checked before each
+// patch; if it exceeds maxCardBytes the current card is abandoned and a
+// fresh one is created with only the latest tool call.
+func streamReply(reply channel.ReplyFunc, stream <-chan openagent.StreamEvent, sessionID string, updater runCardUpdater, sizer CardSizer) {
 	type tpend struct {
 		name string
-		args string
 	}
 
 	var (
@@ -146,15 +242,13 @@ func streamReply(reply channel.ReplyFunc, stream <-chan openagent.StreamEvent) {
 		_ = pq.stop // used via defer-like pattern below
 	)
 
-	// One card per agent run. Title tracks the stage; body stacks
-	// thinking (collapsed) → toolcalls (collapsed) → answer (open).
+	// One card per agent run. Title tracks the stage; body interleaves
+	// thinking (collapsed) → [text → tool call (collapsed)]* → text.
 	var (
 		runCardID   string
 		thoughtBuf  strings.Builder
-		textBuf     strings.Builder
-		pendingTool = map[string]*tpend{} // toolCallID → {name, args}
-		toolCalls   []toolCallEntry
-		toolCallIdx = map[string]int{} // toolCallID → index in toolCalls
+		pendingTool = map[string]*tpend{} // toolCallID → {name}
+		blocks      []block
 
 		// Stage only advances (thinking < toolcalling < answering < done),
 		// so a second round of reasoning mid-turn doesn't flicker the title
@@ -162,13 +256,78 @@ func streamReply(reply channel.ReplyFunc, stream <-chan openagent.StreamEvent) {
 		stage    = stageThinking
 		lastErr  string
 		lastTime = time.Now()
+
+		// Approval integration: pendingApproval is set by the Ask callback
+		// (runtime goroutine) and read by flushRunCard (this goroutine).
+		// The mutex makes the cross-goroutine access safe; approvalSig
+		// wakes the select loop to flush when buttons are added.
+		approvalMu      sync.Mutex
+		pendingApproval *channel.CardApproval
+		approvalSig     = make(chan struct{}, 1)
 	)
 
 	// flushRunCard rebuilds the single run card from current state and
 	// creates-or-patches it. The 500ms patch debounce bounds API rate.
 	flushRunCard := func() {
-		card := runCard(stage, thoughtBuf.String(), toolCalls, textBuf.String(), lastErr)
+		if thoughtBuf.Len() == 0 && len(blocks) == 0 && lastErr == "" {
+			return
+		}
+		card := runCard(stage, thoughtBuf.String(), blocks, lastErr)
+		approvalMu.Lock()
+		card.Approval = pendingApproval
+		approvalMu.Unlock()
+
+		var cardSize int
+		if sizer != nil {
+			cardSize = sizer.CardSize(card)
+		}
+		slog.Info("flushRunCard",
+			"stage", stage.title(),
+			"thoughtLen", thoughtBuf.Len(),
+			"blocks", len(blocks),
+			"cardSize", cardSize,
+			"runCardID", runCardID)
+
+		// When the card exceeds the platform's size limit, fold the
+		// old card to a collapsed "done" state, then start a fresh
+		// one keeping only the last few blocks.
+		if runCardID != "" && cardTooLarge(sizer, card) {
+			slog.Info("cardTooLarge triggered",
+				"cardSize", cardSize,
+				"thoughtLen", thoughtBuf.Len(),
+				"blocks", len(blocks),
+				"oldRunCardID", runCardID)
+			pq.mark(runCardID, &channel.Card{
+				Header: channel.CardHeader{Title: stageDone.title()},
+				Color:  stageDone.color(),
+				Panels: card.Panels,
+				Fold:   channel.FoldCollapsed,
+			})
+			runCardID = ""
+			if len(blocks) > 3 {
+				blocks = blocks[len(blocks)-3:]
+			}
+			card = runCard(stage, thoughtBuf.String(), blocks, lastErr)
+			approvalMu.Lock()
+			card.Approval = pendingApproval
+			approvalMu.Unlock()
+			if sizer != nil {
+				cardSize = sizer.CardSize(card)
+			}
+			slog.Info("cardTooLarge rebuild",
+				"newCardSize", cardSize,
+				"thoughtLen", thoughtBuf.Len(),
+				"blocks", len(blocks))
+		}
+
+		// When approval buttons are shown, the title reflects the wait
+		// for a human decision instead of the tool-calling stage.
+		if card.Approval != nil {
+			card.Header.Title = "⏳ 等待审批"
+		}
+
 		if runCardID == "" {
+			slog.Info("card create", "cardSize", cardSize)
 			runCardID = pq.create(channel.ReplyMessage{Card: card})
 		} else {
 			pq.mark(runCardID, card)
@@ -178,112 +337,175 @@ func streamReply(reply channel.ReplyFunc, stream <-chan openagent.StreamEvent) {
 
 	// maybeFlush throttles patches during streaming output.
 	maybeFlush := func() {
-		if time.Since(lastTime) >= 80*time.Millisecond || textBuf.Len() >= 50 {
+		if time.Since(lastTime) >= 80*time.Millisecond {
 			flushRunCard()
 		}
 	}
 
-	for evt := range stream {
-		switch evt.Type {
-		case openagent.StreamThought:
-			stage = stageThinking
-			thoughtBuf.WriteString(evt.Text)
-			flushRunCard()
+	// clearApproval removes the pending approval so the next flush omits
+	// the button row. Called on stream events that indicate the approval
+	// was resolved (the stream advanced past Ask).
+	clearApproval := func() {
+		approvalMu.Lock()
+		pendingApproval = nil
+		approvalMu.Unlock()
+	}
 
-		case openagent.StreamTextDelta:
-			stage = stageAnswering
-			textBuf.WriteString(evt.Text)
-			maybeFlush()
+	if updater != nil {
+		updater.SetRunCardUpdater(sessionID, func(toolName, args, approvalID string) {
+			approvalMu.Lock()
+			pendingApproval = &channel.CardApproval{
+				ToolName:   toolName,
+				Args:       args,
+				ApprovalID: approvalID,
+			}
+			approvalMu.Unlock()
+			select {
+			case approvalSig <- struct{}{}:
+			default:
+			}
+		})
+		defer updater.ClearRunCardUpdater(sessionID)
+	}
 
-		case openagent.StreamToolCall:
-			stage = stageToolCalling
-			for _, tc := range evt.Message.ToolCalls {
-				switch tc.Function.Name {
-				case "plan_create":
-					goal, steps := parsePlanCreate(tc.Function.Arguments)
-					if goal != "" {
-						pq.create(channel.ReplyMessage{Card: mkCard("📋 "+goal, steps, channel.CardColorBlue)})
+loop:
+	for {
+		select {
+		case evt, ok := <-stream:
+			if !ok {
+				break loop
+			}
+			slog.Debug("stream event",
+				"type", evt.Type,
+				"thoughtLen", thoughtBuf.Len(),
+				"blocks", len(blocks))
+			// Clear approval buttons on any event except StreamToolCall.
+			// StreamToolCall arrives BEFORE Ask (the callback), so clearing
+			// on it would race with the callback setting the buttons.
+			if evt.Type != openagent.StreamToolCall {
+				clearApproval()
+			}
+			switch evt.Type {
+			case openagent.StreamThought:
+				stage = stageThinking
+				thoughtBuf.WriteString(evt.Text)
+				maybeFlush()
+
+			case openagent.StreamTextDelta:
+				stage = stageAnswering
+				if len(blocks) == 0 || blocks[len(blocks)-1].tool != nil {
+					blocks = append(blocks, block{text: evt.Text})
+				} else {
+					blocks[len(blocks)-1].text += evt.Text
+				}
+				maybeFlush()
+
+			case openagent.StreamToolCall:
+				stage = stageToolCalling
+				for _, tc := range evt.Message.ToolCalls {
+					switch tc.Function.Name {
+					case "plan_create":
+						goal, steps := parsePlanCreate(tc.Function.Arguments)
+						if goal != "" {
+							pq.create(channel.ReplyMessage{Card: mkCard("📋 "+goal, steps, channel.CardColorBlue)})
+						}
+						continue
+					case "plan_update", "enter_plan_mode":
+						pendingTool[tc.ID] = &tpend{name: tc.Function.Name}
+						continue
 					}
-					continue
-				case "plan_update", "enter_plan_mode":
-					pendingTool[tc.ID] = &tpend{name: tc.Function.Name, args: tc.Function.Arguments}
+					pendingTool[tc.ID] = &tpend{name: tc.Function.Name}
+					entry := toolCallEntry{
+						name:       tc.Function.Name,
+						args:       tc.Function.Arguments,
+						status:     "in_progress",
+						title:      opentool.ToolTitle(tc.Function.Name, tc.Function.Arguments),
+						toolCallID: tc.ID,
+					}
+					blocks = append(blocks, block{tool: &entry})
+				}
+				flushRunCard()
+
+			case openagent.StreamToolProgress:
+				if _, ok := pendingTool[evt.ToolCallID]; !ok {
 					continue
 				}
-				pendingTool[tc.ID] = &tpend{name: tc.Function.Name, args: tc.Function.Arguments}
-				toolCallIdx[tc.ID] = len(toolCalls)
-				toolCalls = append(toolCalls, toolCallEntry{
-					name:   tc.Function.Name,
-					args:   tc.Function.Arguments,
-					status: "in_progress",
-				})
-			}
-			flushRunCard()
+				for i := len(blocks) - 1; i >= 0; i-- {
+					if blocks[i].tool != nil && blocks[i].tool.toolCallID == evt.ToolCallID {
+						blocks[i].tool.output += evt.Text
+						break
+					}
+				}
+				flushRunCard()
 
-		case openagent.StreamToolProgress:
-			if _, ok := pendingTool[evt.ToolCallID]; !ok {
-				continue
-			}
-			idx, ok := toolCallIdx[evt.ToolCallID]
-			if !ok {
-				continue
-			}
-			toolCalls[idx].output += evt.Text
-			flushRunCard()
+			case openagent.StreamToolResult:
+				t, ok := pendingTool[evt.Message.ToolCallID]
+				if !ok {
+					continue
+				}
+				delete(pendingTool, evt.Message.ToolCallID)
+				if t.name == "plan_update" || t.name == "enter_plan_mode" {
+					continue
+				}
+				output := evt.Message.Content
+				status := "completed"
+				if strings.HasPrefix(output, "error: ") {
+					status = "failed"
+				}
+				for i := len(blocks) - 1; i >= 0; i-- {
+					if blocks[i].tool != nil && blocks[i].tool.toolCallID == evt.Message.ToolCallID {
+						blocks[i].tool.status = status
+						blocks[i].tool.output = output
+						break
+					}
+				}
+				flushRunCard()
 
-		case openagent.StreamToolResult:
-			t, ok := pendingTool[evt.Message.ToolCallID]
-			if !ok {
-				continue
-			}
-			delete(pendingTool, evt.Message.ToolCallID)
-			if t.name == "plan_update" || t.name == "enter_plan_mode" {
-				continue
-			}
-			output := evt.Message.Content
-			status := "completed"
-			if strings.HasPrefix(output, "error: ") {
-				status = "failed"
-			}
-			if idx, ok := toolCallIdx[evt.Message.ToolCallID]; ok {
-				toolCalls[idx].status = status
-				toolCalls[idx].output = output
-			}
-			flushRunCard()
+			case openagent.StreamRetrying:
+				if evt.Error != nil {
+					lastErr = fmt.Sprintf("retrying: %v", evt.Error)
+				} else {
+					lastErr = "retrying..."
+				}
+				flushRunCard()
 
-		case openagent.StreamRetrying:
-			if evt.Error != nil {
-				lastErr = fmt.Sprintf("retrying: %v", evt.Error)
-			} else {
-				lastErr = "retrying..."
+			case openagent.StreamDone:
+				stage = stageDone
+				flushRunCard()
+				pq.flush()
+
+			case openagent.StreamError:
+				stage = stageDone
+				if evt.Error != nil {
+					lastErr = fmt.Sprintf("error: %v", evt.Error)
+				}
+				flushRunCard()
+				pq.stop()
+				return
+
+			case openagent.StreamAborted:
+				stage = stageDone
+				lastErr = "aborted"
+				flushRunCard()
+				pq.stop()
+				return
 			}
-			flushRunCard()
 
-		case openagent.StreamDone:
-			stage = stageDone
-			flushRunCard()
-			pq.flush()
-
-		case openagent.StreamError:
-			stage = stageDone
-			if evt.Error != nil {
-				lastErr = fmt.Sprintf("error: %v", evt.Error)
+		case <-approvalSig:
+			// Flush the run card with the approval section. If the card
+			// hasn't been created yet, skip — the next stream event will
+			// create it with the approval section already set (avoids
+			// flashing an empty card with just buttons).
+			if runCardID != "" {
+				flushRunCard()
 			}
-			flushRunCard()
-			pq.stop()
-			return
-
-		case openagent.StreamAborted:
-			stage = stageDone
-			lastErr = "aborted"
-			flushRunCard()
-			pq.stop()
-			return
 		}
 	}
 
 	// Stream closed without StreamDone/Error/Aborted — finalize the card so
 	// the title doesn't freeze on "回答中". If a terminal event already
 	// set stageDone this is a harmless re-mark.
+	clearApproval()
 	if runCardID != "" && stage != stageDone {
 		stage = stageDone
 		flushRunCard()
@@ -292,6 +514,15 @@ func streamReply(reply channel.ReplyFunc, stream <-chan openagent.StreamEvent) {
 }
 
 // ── Run card ──
+
+// cardTooLarge reports whether the card's serialized size exceeds maxCardBytes.
+// Returns false when sizer is nil (no platform size limit).
+func cardTooLarge(sizer CardSizer, card *channel.Card) bool {
+	if sizer == nil {
+		return false
+	}
+	return sizer.CardSize(card) > maxCardBytes
+}
 
 // mkCard is a plain card builder used for standalone cards (plan_create).
 func mkCard(title, body string, color channel.CardColor) *channel.Card {
@@ -329,37 +560,58 @@ func (s stage) color() channel.CardColor {
 	return channel.CardColorYellow
 }
 
-// runCard builds the single card for an agent run. The body stacks three
-// sections in fixed order: thinking (collapsed) → toolcalls (collapsed,
-// nested) → answer (open). Empty sections are omitted. errMsg, when set,
-// is appended at the end.
-func runCard(s stage, thought string, calls []toolCallEntry, answer, errMsg string) *channel.Card {
+// runCard builds the single card for an agent run. The body interleaves
+// in event-arrival order: thinking (collapsed) → [text → tool call
+// (collapsed)]* → text. Empty segments are omitted. errMsg, when set,
+// is appended as a final text segment.
+//
+// thought is capped to the last maxThoughtDisplay bytes so a reasoning
+// model's long chain-of-thought can't blow past the card size limit — the
+// buffer itself is untouched (session persistence keeps the full trace).
+func runCard(s stage, thought string, blks []block, errMsg string) *channel.Card {
 	var panels []channel.Card
 
 	if thought != "" {
+		if len(thought) > maxThoughtDisplay {
+			thought = "...(已截断)\n" + thought[len(thought)-maxThoughtDisplay:]
+		}
 		panels = append(panels, channel.Card{
-			// Title left empty — subPanel falls back to a content preview.
-			Content:   thought,
-			Collapsed: true,
+			Content: thought,
+			Fold:    channel.FoldCollapsed,
 		})
 	}
-	if len(calls) > 0 {
-		panels = append(panels, toolCallsSection(calls))
-	}
 
-	body := answer
-	if errMsg != "" {
-		if body != "" {
-			body += "\n\n"
+	var lastText string
+	for _, b := range blks {
+		if b.tool != nil {
+			if lastText != "" {
+				panels = append(panels, channel.Card{Content: lastText, Fold: channel.FoldNone})
+				lastText = ""
+			}
+			panels = append(panels, toolCallSubCard(*b.tool))
+		} else {
+			lastText += b.text
 		}
-		body += errMsg
+	}
+	if errMsg != "" {
+		lastText += "\n\n" + errMsg
+	}
+	if lastText != "" {
+		if len(lastText) > maxThoughtDisplay {
+			lastText = lastText[len(lastText)-maxThoughtDisplay:] + "\n...(已截断)"
+		}
+		panels = append(panels, channel.Card{Content: lastText, Fold: channel.FoldNone})
 	}
 
+	fold := channel.FoldNone
+	if s == stageDone {
+		fold = channel.FoldExpanded
+	}
 	return &channel.Card{
-		Header:  channel.CardHeader{Title: s.title()},
-		Color:   s.color(),
-		Content: body,
-		Panels:  panels,
+		Header: channel.CardHeader{Title: s.title()},
+		Color:  s.color(),
+		Fold:   fold,
+		Panels: panels,
 	}
 }
 
@@ -367,46 +619,50 @@ func runCard(s stage, thought string, calls []toolCallEntry, answer, errMsg stri
 
 // toolCallEntry is the per-call state collected for the run card.
 type toolCallEntry struct {
-	name   string
-	args   string
-	status string // "in_progress" | "completed" | "failed"
-	output string
+	name       string
+	args       string
+	status     string // "in_progress" | "completed" | "failed"
+	output     string
+	title      string // human-readable title from opentool.ToolTitle; empty = fall back to name
+	toolCallID string // for lookup during StreamToolProgress/Result
+}
+
+// block is one segment of the run card body, preserving the interleaved
+// order of agent text and tool calls (mimicking SSE-style rendering).
+type block struct {
+	text string         // agent output segment
+	tool *toolCallEntry // tool call segment
 }
 
 // toolCallSubCard builds the inner collapsed Card for one tool call.
-// Title is the tool name + status marker (no emoji); body is input + output.
+// Title is the tool title (with bold first word) + status marker; body is
+// input + output.
 func toolCallSubCard(e toolCallEntry) channel.Card {
-	title := e.name
+	title := e.title
+	if title == "" {
+		title = e.name
+	}
+	title = boldFirstWord(title)
 	switch e.status {
 	case "completed":
-		title = e.name + " ✓"
+		title += " ✓"
 	case "failed":
-		title = e.name + " ✗"
+		title += " ✗"
 	}
 
 	body := formatInput(e.name, e.args)
 	if e.output != "" {
-		body += "\n```\n" + e.output + "\n```"
+		out := e.output
+		if r := []rune(out); len(r) > maxCardBytes/4 {
+			out = string(r[:maxCardBytes/4-3]) + "..."
+		}
+		body += "\n" + channel.CodeBlock(out)
 	}
 
 	return channel.Card{
-		Header:    channel.CardHeader{Title: title},
-		Content:   body,
-		Collapsed: true,
-	}
-}
-
-// toolCallsSection builds the collapsed sub-card for the toolcalls section.
-// Title "toolcalls (N)"; expanding reveals one nested panel per call.
-func toolCallsSection(entries []toolCallEntry) channel.Card {
-	subs := make([]channel.Card, 0, len(entries))
-	for _, e := range entries {
-		subs = append(subs, toolCallSubCard(e))
-	}
-	return channel.Card{
-		Header:    channel.CardHeader{Title: fmt.Sprintf("toolcalls (%d)", len(entries))},
-		Collapsed: true,
-		Panels:    subs,
+		Header:  channel.CardHeader{Title: title, TitleMarkdown: true},
+		Content: body,
+		Fold:    channel.FoldCollapsed,
 	}
 }
 
@@ -416,7 +672,7 @@ func formatInput(name, args string) string {
 	case "shell", "terminal_create":
 		cmd := jsonStr(m, "command")
 		if cmd != "" {
-			return "```\n" + trunc(cmd, 500) + "\n```"
+			return channel.CodeBlock(trunc(cmd, 500))
 		}
 	case "read", "read_client_file":
 		path := jsonStr(m, "path")
@@ -468,7 +724,7 @@ func formatInput(name, args string) string {
 			return "`" + path + "`"
 		}
 	}
-	return "```\n" + trunc(args, 200) + "\n```"
+	return channel.CodeBlock(trunc(args, 200))
 }
 
 func pathStr(p string) string {
@@ -550,8 +806,22 @@ func parsePlanCreate(args string) (goal string, steps string) {
 }
 
 func trunc(s string, n int) string {
-	if len(s) <= n {
+	if r := []rune(s); len(r) > n {
+		return string(r[:n]) + "..."
+	}
+	return s
+}
+
+// boldFirstWord wraps the first whitespace-delimited word in ** for
+// lark_md bold, leaving the rest of the string unchanged.
+func boldFirstWord(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
 		return s
 	}
-	return s[:n] + "..."
+	i := strings.IndexByte(s, ' ')
+	if i < 0 {
+		return "**" + s + "**"
+	}
+	return "**" + s[:i] + "**" + s[i:]
 }

--- a/cmd/cli/server/channel_manager.go
+++ b/cmd/cli/server/channel_manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/yusheng-g/openagent-go/channel"
 	"github.com/yusheng-g/openagent-go/channel/feishu"
 	"github.com/yusheng-g/openagent-go/cmd/cli/config"
+	"github.com/yusheng-g/openagent-go/governance"
 	"github.com/yusheng-g/openagent-go/kernel"
 
 	clirest "github.com/yusheng-g/openagent-go/cmd/cli/rest"
@@ -35,11 +36,12 @@ import (
 var _ clirest.FeishuChannel = (*FeishuManager)(nil)
 
 type FeishuManager struct {
-	baseCtx   context.Context
-	profiles  string
-	cfg       *agent.Agent
-	deps      kernel.Deps
-	feishuCfg *config.FeishuConfig // settings.json channels.feishu (may be nil)
+	baseCtx     context.Context
+	profiles    string
+	cfg         *agent.Agent
+	deps        kernel.Deps
+	feishuCfg   *config.FeishuConfig // settings.json channels.feishu (may be nil)
+	defaultMode string               // "manual" | "auto" (empty = "manual")
 
 	mu     sync.Mutex
 	lock   *ChannelLock
@@ -61,14 +63,15 @@ type FeishuManager struct {
 // returning. feishuCfg is the settings.json channels.feishu block (nil
 // when the user did not configure credentials — the manager then runs
 // the QR registration flow).
-func NewFeishuManager(baseCtx context.Context, profiles string, feishuCfg *config.FeishuConfig, cfg *agent.Agent, deps kernel.Deps) *FeishuManager {
+func NewFeishuManager(baseCtx context.Context, profiles string, feishuCfg *config.FeishuConfig, cfg *agent.Agent, deps kernel.Deps, defaultMode string) *FeishuManager {
 	return &FeishuManager{
-		baseCtx:   baseCtx,
-		profiles:  profiles,
-		feishuCfg: feishuCfg,
-		cfg:       cfg,
-		deps:      deps,
-		status:    clirest.FeishuStatus{Phase: clirest.FeishuIdle},
+		baseCtx:     baseCtx,
+		profiles:    profiles,
+		feishuCfg:   feishuCfg,
+		cfg:         cfg,
+		deps:        deps,
+		defaultMode: defaultMode,
+		status:      clirest.FeishuStatus{Phase: clirest.FeishuIdle},
 	}
 }
 
@@ -271,7 +274,12 @@ func (m *FeishuManager) startConnection(lock *ChannelLock, creds FeishuCredentia
 		// The connection blocks until the process context is cancelled
 		// or the connection is permanently lost; the SDK reconnects on
 		// transient failures internally.
-		ch := feishu.New(creds.AppID, creds.AppSecret)
+		ch := feishu.New(creds.AppID, creds.AppSecret, m.defaultMode)
+		mem := governance.NewSessionApprovalMemory()
+		deps := m.deps
+		deps.HumanApprover = ch.Approver(mem)
+		deps.ApprovalMemory = mem
+		slog.Info("channel approver enabled", "channel", "feishu")
 		everReady := false
 		ch.SetOnReady(func() {
 			// The SDK flips to ready after the WebSocket connects (and
@@ -298,7 +306,7 @@ func (m *FeishuManager) startConnection(lock *ChannelLock, creds FeishuCredentia
 				m.setStatus(clirest.FeishuStatus{Phase: clirest.FeishuDisconnected, AppID: creds.AppID, LastError: err.Error()}, connDone)
 			}
 		})
-		err := ch.Start(connCtx, feishuMessageHandler(m.cfg, m.deps))
+		err := ch.Start(connCtx, feishuMessageHandler(m.cfg, deps, ch))
 		lock.Release()
 		// Publish BEFORE the cleanup — the guard compares m.done against
 		// connDone, so clearing the field first would drop the flow's own
@@ -497,10 +505,40 @@ func (m *FeishuManager) SetCredentials(appID, appSecret string) error {
 }
 
 // feishuMessageHandler routes incoming Feishu messages to the agent,
-// one ephemeral run per message.
-func feishuMessageHandler(cfg *agent.Agent, deps kernel.Deps) channel.MessageHandler {
+// one ephemeral run per message. ch is the concrete channel, used for
+// runCardUpdater / ModeController interface checks.
+func feishuMessageHandler(cfg *agent.Agent, deps kernel.Deps, ch channel.Channel) channel.MessageHandler {
+	var updater runCardUpdater
+	if u, ok := ch.(runCardUpdater); ok {
+		updater = u
+	}
+
+	var sizer CardSizer
+	if s, ok := ch.(CardSizer); ok {
+		sizer = s
+	}
+
 	return func(msgCtx context.Context, msg channel.IncomingMessage, reply channel.ReplyFunc) {
 		sessionID := "feishu_" + msg.ChatID
+
+		// Intercept /clear before sending to the agent.
+		if isClearCommand(msg.Text) {
+			handleClearCommand(deps, reply, msgCtx, sessionID)
+			return
+		}
+
+		// Intercept /mode command before sending to the agent.
+		if mc, ok := ch.(ModeController); ok && isModeCommand(msg.Text) {
+			args := parseModeArgs(msg.Text)
+			if channel.IsValidMode(args) {
+				mc.SetMode(msg.ChatID, args)
+				_, _ = reply(msgCtx, channel.ReplyMessage{Text: "✅ 已切换到 " + args + " 模式"})
+			} else {
+				_, _ = reply(msgCtx, channel.ReplyMessage{Card: mc.BuildModeCard(msg.ChatID)})
+			}
+			return
+		}
+
 		go func() {
 			// Carry the resolved Model instance so downstream consumers
 			// (RunHooks via SessionFromContext, e.g. the artifact hook's
@@ -511,8 +549,15 @@ func feishuMessageHandler(cfg *agent.Agent, deps kernel.Deps) channel.MessageHan
 				Model:     cfg.Model,
 				CreatedAt: time.Now(),
 			}
-			stream := kernel.New(cfg, deps).RunStream(msgCtx, session, openagent.UserMessage(msg.Text))
-			streamReply(reply, stream)
+			rt := kernel.New(cfg, deps)
+			// In auto mode, disable human approval so tools execute
+			// without prompting. In manual mode (default), the
+			// feishu approver wired in startConnection stays active.
+			if mc, ok := ch.(ModeController); ok && mc.GetMode(msg.ChatID) == channel.ModeAuto {
+				rt.SetHumanApprover(nil)
+			}
+			stream := rt.RunStream(msgCtx, session, openagent.UserMessage(msg.Text))
+			streamReply(reply, stream, sessionID, updater, sizer)
 		}()
 	}
 }

--- a/cmd/cli/server/channel_test.go
+++ b/cmd/cli/server/channel_test.go
@@ -3,12 +3,17 @@ package server
 import (
 	"strings"
 	"testing"
+
+	"github.com/yusheng-g/openagent-go/channel"
 )
 
 func TestToolCardCompleted(t *testing.T) {
-	card := toolCallSubCard(toolCallEntry{name: "shell", args: `{"command":"echo hello"}`, status: "completed", output: "hello\n"})
-	if card.Header.Title != "shell ✓" {
+	card := toolCallSubCard(toolCallEntry{name: "shell", args: `{"command":"echo hello"}`, status: "completed", output: "hello\n", title: "shell echo hello"})
+	if card.Header.Title != "**shell** echo hello ✓" {
 		t.Errorf("title = %q", card.Header.Title)
+	}
+	if !card.Header.TitleMarkdown {
+		t.Errorf("TitleMarkdown should be true")
 	}
 	if !strings.Contains(card.Content, "echo hello") {
 		t.Errorf("content should contain command: %s", card.Content)
@@ -19,14 +24,14 @@ func TestToolCardCompleted(t *testing.T) {
 }
 
 func TestToolCardFailed(t *testing.T) {
-	card := toolCallSubCard(toolCallEntry{name: "write", args: `{"path":"/tmp/x"}`, status: "failed", output: "error: permission denied"})
+	card := toolCallSubCard(toolCallEntry{name: "write", args: `{"path":"/tmp/x"}`, status: "failed", output: "error: permission denied", title: "write /tmp/x"})
 	if !strings.Contains(card.Header.Title, "✗") {
 		t.Errorf("failed card should have ✗ in title: %s", card.Header.Title)
 	}
 }
 
 func TestToolCardInProgress(t *testing.T) {
-	card := toolCallSubCard(toolCallEntry{name: "shell", args: `{"command":"sleep 10"}`, status: "in_progress", output: "running..."})
+	card := toolCallSubCard(toolCallEntry{name: "shell", args: `{"command":"sleep 10"}`, status: "in_progress", output: "running...", title: "shell sleep 10"})
 	if !strings.Contains(card.Header.Title, "shell") {
 		t.Errorf("in-progress title should contain name: %s", card.Header.Title)
 	}
@@ -57,6 +62,27 @@ func TestFormatInputUnknown(t *testing.T) {
 	result := formatInput("unknown_tool", `{"key":"val"}`)
 	if !strings.Contains(result, "```") {
 		t.Errorf("unknown tool should show raw args in code block: %s", result)
+	}
+}
+
+func TestFormatInputShellWithBackticks(t *testing.T) {
+	cmd := "echo ```bash```"
+	result := formatInput("shell", `{"command":"`+cmd+`"}`)
+	fence4 := strings.Repeat("`", 4)
+	if !strings.HasPrefix(result, fence4) {
+		t.Errorf("shell command with ``` should use 4-tick fence, got: %s", result)
+	}
+	if !strings.Contains(result, cmd) {
+		t.Errorf("result should contain command: %s", result)
+	}
+}
+
+func TestFormatInputUnknownWithBackticks(t *testing.T) {
+	args := "{\"key\":\"```x```\"}"
+	result := formatInput("unknown_tool", args)
+	fence4 := strings.Repeat("`", 4)
+	if !strings.HasPrefix(result, fence4) {
+		t.Errorf("unknown tool args with ``` should use 4-tick fence, got: %s", result)
 	}
 }
 
@@ -101,3 +127,61 @@ func TestParsePlanCreatePriorityEmoji(t *testing.T) {
 		t.Errorf("low priority should have green circle emoji: %s", steps)
 	}
 }
+
+func TestCardTooLarge(t *testing.T) {
+	card := &channel.Card{Header: channel.CardHeader{Title: "test"}, Content: "x"}
+
+	t.Run("nil_sizer_returns_false", func(t *testing.T) {
+		if cardTooLarge(nil, card) {
+			t.Error("nil sizer should never report too large")
+		}
+	})
+
+	t.Run("under_limit", func(t *testing.T) {
+		sizer := &mockSizer{size: maxCardBytes - 1}
+		if cardTooLarge(sizer, card) {
+			t.Error("size below limit should report false")
+		}
+	})
+
+	t.Run("at_limit", func(t *testing.T) {
+		sizer := &mockSizer{size: maxCardBytes}
+		if cardTooLarge(sizer, card) {
+			t.Error("size at limit should report false")
+		}
+	})
+
+	t.Run("over_limit", func(t *testing.T) {
+		sizer := &mockSizer{size: maxCardBytes + 1}
+		if !cardTooLarge(sizer, card) {
+			t.Error("size over limit should report true")
+		}
+	})
+}
+
+func TestRunCardInterleaved(t *testing.T) {
+	// Two text blocks with a tool call in between should produce 3 panels:
+	// [text (FoldNone)] [tool (FoldCollapsed)] [text (FoldNone)]
+	blks := []block{
+		{text: "Let me check."},
+		{tool: &toolCallEntry{name: "shell", args: `{"command":"ls"}`, status: "completed", title: "shell ls"}},
+		{text: "Done."},
+	}
+	card := runCard(stageDone, "", blks, "")
+	if len(card.Panels) != 3 {
+		t.Fatalf("expected 3 panels, got %d", len(card.Panels))
+	}
+	if card.Panels[0].Fold != channel.FoldNone {
+		t.Errorf("panel 0 should be FoldNone, got %v", card.Panels[0].Fold)
+	}
+	if card.Panels[1].Fold != channel.FoldCollapsed {
+		t.Errorf("panel 1 should be FoldCollapsed, got %v", card.Panels[1].Fold)
+	}
+	if card.Panels[2].Fold != channel.FoldNone {
+		t.Errorf("panel 2 should be FoldNone, got %v", card.Panels[2].Fold)
+	}
+}
+
+type mockSizer struct{ size int }
+
+func (m *mockSizer) CardSize(_ *channel.Card) int { return m.size }

--- a/cmd/cli/server/feishu_setup.go
+++ b/cmd/cli/server/feishu_setup.go
@@ -147,6 +147,7 @@ func registerFeishuApp(ctx context.Context, profiles string, onQR func(url strin
 				Items: registration.AppAddonsEventItems{
 					Tenant: []string{
 						"im.message.receive_v1",
+						"card.action.trigger",
 					},
 				},
 			},

--- a/cmd/cli/server/feishu_setup_test.go
+++ b/cmd/cli/server/feishu_setup_test.go
@@ -196,7 +196,7 @@ func TestClearCredentialsPreservesOtherFields(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Now clear via the manager path used by the DELETE endpoint.
-	m := NewFeishuManager(context.Background(), ".openagent/profile", nil, nil, kernel.Deps{})
+	m := NewFeishuManager(context.Background(), ".openagent/profile", nil, nil, kernel.Deps{}, "")
 	if err := m.ClearCredentials(); err != nil {
 		t.Fatal(err)
 	}
@@ -235,7 +235,7 @@ func TestClearCredentialsPreservesOtherFields(t *testing.T) {
 // total.
 func TestFeishuQRCacheRoundTrip(t *testing.T) {
 	profiles := filepath.Join(t.TempDir(), "profile")
-	m := NewFeishuManager(context.Background(), profiles, nil, nil, kernel.Deps{})
+	m := NewFeishuManager(context.Background(), profiles, nil, nil, kernel.Deps{}, "")
 
 	if err := saveFeishuQR(profiles, "https://qr.example/x", 300); err != nil {
 		t.Fatal(err)
@@ -271,7 +271,7 @@ func TestFeishuQRCacheRoundTrip(t *testing.T) {
 // to surface the expiry on its next cycle.
 func TestFeishuQRExpired(t *testing.T) {
 	profiles := filepath.Join(t.TempDir(), "profile")
-	m := NewFeishuManager(context.Background(), profiles, nil, nil, kernel.Deps{})
+	m := NewFeishuManager(context.Background(), profiles, nil, nil, kernel.Deps{}, "")
 
 	if err := saveFeishuQR(profiles, "https://qr.example/x", 300); err != nil {
 		t.Fatal(err)
@@ -294,7 +294,7 @@ func TestFeishuQRExpired(t *testing.T) {
 // not cancel it, and the SDK polls without a client timeout) must return
 // within disconnectTimeout instead of hanging the endpoint.
 func TestDisconnectTimesOutOnStuckFlow(t *testing.T) {
-	m := NewFeishuManager(context.Background(), filepath.Join(t.TempDir(), "profile"), nil, nil, kernel.Deps{})
+	m := NewFeishuManager(context.Background(), filepath.Join(t.TempDir(), "profile"), nil, nil, kernel.Deps{}, "")
 	cancelled := make(chan struct{})
 	m.mu.Lock()
 	m.cancel = func() { close(cancelled) }
@@ -322,7 +322,7 @@ func TestDisconnectTimesOutOnStuckFlow(t *testing.T) {
 // registration goroutine finishing late would clobber the state of a
 // newer connection.
 func TestSetStatusGuardDropsStalePublish(t *testing.T) {
-	m := NewFeishuManager(context.Background(), filepath.Join(t.TempDir(), "profile"), nil, nil, kernel.Deps{})
+	m := NewFeishuManager(context.Background(), filepath.Join(t.TempDir(), "profile"), nil, nil, kernel.Deps{}, "")
 	current := make(chan struct{})
 	m.mu.Lock()
 	m.done = current
@@ -345,7 +345,7 @@ func TestSetStatusGuardDropsStalePublish(t *testing.T) {
 // cleanup (the buggy ordering) makes the guard see m.done != guard and
 // drop the publish, leaving the status stuck on the previous phase.
 func TestFlowTerminalPublishSurvivesOwnCleanup(t *testing.T) {
-	m := NewFeishuManager(context.Background(), filepath.Join(t.TempDir(), "profile"), nil, nil, kernel.Deps{})
+	m := NewFeishuManager(context.Background(), filepath.Join(t.TempDir(), "profile"), nil, nil, kernel.Deps{}, "")
 	done := make(chan struct{})
 	m.mu.Lock()
 	m.done = done

--- a/cmd/cli/server/http.go
+++ b/cmd/cli/server/http.go
@@ -118,7 +118,7 @@ func RunREST(ctx context.Context, cfg *config.Config, caps config.Capabilities) 
 	// flagged channel). Both managers are ALWAYS created (even when no
 	// channel is configured) so the CLI-level REST API can query status
 	// and trigger connect/registration on demand.
-	feishuMgr, wechatMgr, wecomMgr, err := RunChannels(ctx, cfg.Profiles, agentCfg, deps, cfg.Channels)
+	feishuMgr, wechatMgr, wecomMgr, err := RunChannels(ctx, cfg.Profiles, agentCfg, deps, cfg.Channels, cfg.DefaultMode)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/server/wechat_manager.go
+++ b/cmd/cli/server/wechat_manager.go
@@ -461,6 +461,13 @@ const wechatDefaultBaseURL = "https://ilinkai.weixin.qq.com"
 func wechatMessageHandler(cfg *agent.Agent, deps kernel.Deps, ch *wechat.Channel) channel.MessageHandler {
 	return func(msgCtx context.Context, msg channel.IncomingMessage, reply channel.ReplyFunc) {
 		sessionID := "wechat_" + msg.ChatID
+
+		// Intercept /clear before sending to the agent.
+		if isClearCommand(msg.Text) {
+			handleClearCommand(deps, reply, msgCtx, sessionID)
+			return
+		}
+
 		go func() {
 			// "对方正在输入" while the agent works (best-effort).
 			_ = ch.SendTyping(msgCtx, msg.UserID)

--- a/cmd/cli/server/wecom_manager.go
+++ b/cmd/cli/server/wecom_manager.go
@@ -352,6 +352,13 @@ func (m *WecomManager) SetCredentials(botID, secret string) error {
 func wecomMessageHandler(cfg *agent.Agent, deps kernel.Deps) channel.MessageHandler {
 	return func(msgCtx context.Context, msg channel.IncomingMessage, reply channel.ReplyFunc) {
 		sessionID := "wecom_" + msg.ChatID
+
+		// Intercept /clear before sending to the agent.
+		if isClearCommand(msg.Text) {
+			handleClearCommand(deps, reply, msgCtx, sessionID)
+			return
+		}
+
 		go func() {
 			session := openagent.Session{
 				ID:        sessionID,

--- a/tool/title.go
+++ b/tool/title.go
@@ -1,0 +1,104 @@
+package tool
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+)
+
+// ToolTitle builds a human-readable title for a tool call.
+// Extracts the most informative field from the tool arguments JSON.
+func ToolTitle(name string, args string) string {
+	var params struct {
+		Path        string `json:"path"`
+		Line        int    `json:"line"`
+		Limit       int    `json:"limit"`
+		Command     string `json:"command"`
+		Description string `json:"description"`
+		Pattern     string `json:"pattern"`
+		Glob        string `json:"glob"`
+		Query       string `json:"query"`
+		Goal        string `json:"goal"`
+		URL         string `json:"url"`
+	}
+	if err := json.Unmarshal([]byte(args), &params); err != nil {
+		return name
+	}
+	switch name {
+	case "read":
+		if params.Path != "" {
+			base := filepath.Base(params.Path)
+			if params.Limit > 0 {
+				start := params.Line
+				if start == 0 {
+					start = 1
+				}
+				return fmt.Sprintf("%s %s (lines %d-%d)", name, base, start, start+params.Limit-1)
+			}
+			return name + " " + base
+		}
+	case "edit", "write", "ls":
+		if params.Path != "" {
+			return name + " " + params.Path
+		}
+	case "shell":
+		if params.Description != "" {
+			return name + " " + TruncateToolArg(params.Description, 60)
+		}
+		if params.Command != "" {
+			return name + " " + TruncateToolArg(params.Command, 60)
+		}
+	case "grep":
+		if params.Pattern != "" {
+			title := fmt.Sprintf("%s '%s'", name, params.Pattern)
+			if params.Path != "" {
+				title += " " + filepath.Base(params.Path)
+			}
+			if params.Glob != "" {
+				title += fmt.Sprintf(" '%s'", params.Glob)
+			}
+			return title
+		}
+	case "recall":
+		if params.Query != "" {
+			return name + " " + params.Query
+		}
+	case "plan_create":
+		if params.Goal != "" {
+			return name + " " + TruncateToolArg(params.Goal, 60)
+		}
+	case "websearch":
+		if params.Query != "" {
+			return name + " " + TruncateToolArg(params.Query, 60)
+		}
+	case "webfetch":
+		if params.URL != "" {
+			return name + " " + StripURLQuery(params.URL)
+		}
+	}
+	return name
+}
+
+// StripURLQuery removes the query string (and fragment) from rawURL so the
+// title shows only scheme://host/path. Falls back to the raw value on parse
+// error.
+func StripURLQuery(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}
+
+// TruncateToolArg truncates s to n characters, adding "..." at the end.
+func TruncateToolArg(s string, n int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-3] + "..."
+}

--- a/utils/json.go
+++ b/utils/json.go
@@ -1,0 +1,17 @@
+package utils
+
+import "encoding/json"
+
+// PrettyJSON re-indents a JSON string for display. If the input is not
+// valid JSON it is returned as-is.
+func PrettyJSON(s string) string {
+	var v any
+	if err := json.Unmarshal([]byte(s), &v); err != nil {
+		return s
+	}
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return s
+	}
+	return string(b)
+}


### PR DESCRIPTION
feat(feishu): run-card redesign with /clear, /mode, approval, and group-chat fixes
Run-card redesign:
- Interleaved SSE-style layout: thinking (collapsed) → tool call
  (collapsed, titled) → text → …
- Tool-call panel titles via opentool.ToolTitle (bold first word)
- Card-too-large rotation: auto-fold old card at 28KB, start fresh
- Run card FoldExpanded on completion; skip flush when no content

IM slash commands:
- /clear for feishu, wechat, wecom (DeleteSession, shared handler)
- /mode for feishu: Manual (approval) / Auto (no approval), per-chat
  state, card-button switching

Approval integration:
- Approval buttons embedded in run card (no separate card)
- Card action callback via card.action.trigger event
- Feishu approver with session-scoped run-card updater

Bug fixes:
- Variable-length code fence (channel.CodeBlock) to prevent Feishu
  ErrCode 11310 (card table number over limit) when tool output
  contains triple-backtick markers
- Strip leading @_user_N mention placeholders so slash commands work
  in group chats (@bot /mode → /mode)

Code quality:
- gofmt compliance (acp/server.go, cmd/cli/server/channel.go)
- Remove dead tpend.args field
- Extract handleClearCommand to deduplicate /clear across 3 managers
- Extract modeDescription constant for mode card text
- Rune-based truncation to prevent invalid UTF-8 on Chinese text
- Fix approval_card.go doc comment misalignment

docs:
- Update README (en + zh) for run-card, /clear, /mode, approval