### PR TITLE
fix(summarizer): retry transient model errors + nil-response defense (B9)

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -1,6 +1,6 @@
 # BUGS.md — Known Issues & Technical Debt
 
-> Last updated 2026-08-04 (B3 Discover 空 query 已修复).
+> Last updated 2026-08-07 (B9 summarizer 重试 + nil 防御已修复).
 > Format: `[P0]` = critical, `[P1]` = high, `[P2]` = medium, `[P3]` = low.
 
 ---
@@ -62,12 +62,12 @@
 
 修复：同 firstLine 改为 rune 截断。
 
-### B9. summarizer 无重试 + 无 nil 防御
+### B9. ~~summarizer 无重试 + 无 nil 防御~~ ✅ 已修复（2026-08-07）
 
-- 主模型调用有重试，但 Compact→Summarize 单发：429/503 瞬时限流 → 溢出区间既不在摘要也不在工作集 → **当轮上下文空洞**（`kernel/run.go` 仅 `slog.Error` 后继续，prepareMemory 仍推进工作集起点）。
-- `summarizer/llm.go:70-74` 未判 `resp == nil`（extractor_llm.go:137 有检查，两处不对称）；接口未禁止第三方 Model 返回 (nil,nil)，违规即 panic。
+- ~~主模型调用有重试，但 Compact→Summarize 单发：429/503 瞬时限流 → 溢出区间既不在摘要也不在工作集 → **当轮上下文空洞**（`kernel/run.go` 仅 `slog.Error` 后继续，prepareMemory 仍推进工作集起点）。~~
+- ~~`summarizer/llm.go:70-74` 未判 `resp == nil`（extractor_llm.go:137 有检查，两处不对称）；接口未禁止第三方 Model 返回 (nil,nil)，违规即 panic。~~
 
-修复：Summarize 调用处对 RetryableError 重试一次；补 `resp == nil` 防御。
+修复：`summarizer/llm.go` 的 `Summarize` 对 `RetryableError` 重试一次（默认 1s 指数退避，尊重 `RetryAfter`，cancel 安全），镜像 `kernel/modelcall.go` 的重试契约；补 `resp == nil` 防御（返回明确错误，不重试、不 panic）。新增 `summarizer/llm_test.go` 覆盖重试成功/耗尽/nil 响应/非重试错误/cancel 路径。
 
 ### B10. SSE 连接永久悬挂（team 端点）
 

--- a/summarizer/llm.go
+++ b/summarizer/llm.go
@@ -9,9 +9,11 @@ package summarizer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	openagent "github.com/yusheng-g/openagent-go"
 )
@@ -22,6 +24,9 @@ type Compressor struct {
 	mu        sync.RWMutex
 	model     openagent.Model
 	maxTokens int // 0 = no hint; non-zero = prompt the model to keep the summary under this
+	// backoff returns the wait before retry attempt N (1-based). nil uses
+	// the default exponential backoff. Overridable in tests to avoid sleeps.
+	backoff func(attempt int, re *openagent.RetryableError) time.Duration
 }
 
 // New creates a Compressor backed by m.
@@ -69,14 +74,48 @@ func (c *Compressor) Summarize(ctx context.Context, messages []openagent.Message
 	// No MaxTokens on purpose: a hard output cap truncates the JSON
 	// envelope mid-stream and parseSummary rejects it. Length control is
 	// the prompt hint below plus the prompt-side truncation in kernel.
-	resp, err := model.ChatCompletion(ctx, openagent.ChatCompletionRequest{
-		Messages: []openagent.Message{
-			{Role: openagent.RoleSystem, Content: summarizeSystemPrompt},
-			{Role: openagent.RoleUser, Content: prompt},
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("summarizer: model call: %w", err)
+
+	// Retry transient failures (429/5xx incl. 504 Gateway Timeout) once
+	// with backoff — mirrors kernel/modelcall.go's retry contract. Without
+	// this a single transient gateway error fails compaction, the working
+	// set is left untrimmed, and the growing context eventually trips the
+	// hard window check (fail-loud turn failure).
+	const maxRetries = 1
+	var lastErr error
+	var resp *openagent.ChatCompletionResponse
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-time.After(c.backoffFor(attempt, lastErr)):
+			case <-ctx.Done():
+				return nil, fmt.Errorf("summarizer: model call: %w", ctx.Err())
+			}
+		}
+		var err error
+		resp, err = model.ChatCompletion(ctx, openagent.ChatCompletionRequest{
+			Messages: []openagent.Message{
+				{Role: openagent.RoleSystem, Content: summarizeSystemPrompt},
+				{Role: openagent.RoleUser, Content: prompt},
+			},
+		})
+		if err == nil {
+			if resp == nil {
+				// Defend against a third-party Model returning (nil, nil)
+				// — a contract violation that would panic below. Not
+				// retryable: retrying won't fix a broken implementation.
+				return nil, fmt.Errorf("summarizer: model returned nil response")
+			}
+			break
+		}
+		var re *openagent.RetryableError
+		if !errors.As(err, &re) {
+			return nil, fmt.Errorf("summarizer: model call: %w", err)
+		}
+		lastErr = err
+	}
+	if resp == nil {
+		// Retries exhausted on a transient error.
+		return nil, fmt.Errorf("summarizer: model call: %w", lastErr)
 	}
 
 	content := ""
@@ -88,6 +127,21 @@ func (c *Compressor) Summarize(ctx context.Context, messages []openagent.Message
 		return nil, fmt.Errorf("summarizer: model returned empty summary")
 	}
 	return &openagent.CompressedContext{Summary: content}, nil
+}
+
+// backoffFor returns the wait before retry attempt N (1-based), honoring
+// a RetryAfter hint when the provider supplies one.
+func (c *Compressor) backoffFor(attempt int, lastErr error) time.Duration {
+	var re *openagent.RetryableError
+	errors.As(lastErr, &re)
+	if c.backoff != nil {
+		return c.backoff(attempt, re)
+	}
+	b := time.Duration(1<<uint(attempt-1)) * time.Second
+	if re != nil && re.RetryAfter > 0 {
+		b = re.RetryAfter
+	}
+	return b
 }
 
 // ── Prompt ──

--- a/summarizer/llm_test.go
+++ b/summarizer/llm_test.go
@@ -1,0 +1,212 @@
+package summarizer
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	openagent "github.com/yusheng-g/openagent-go"
+)
+
+// scriptModel plays a scripted sequence of ChatCompletion outcomes. When
+// the script is exhausted it repeats the last entry, so a single-entry
+// script models "always returns X".
+type scriptModel struct {
+	mu    sync.Mutex
+	calls int
+	steps []scriptStep
+}
+
+type scriptStep struct {
+	resp *openagent.ChatCompletionResponse
+	err  error
+}
+
+func (m *scriptModel) ChatCompletion(_ context.Context, _ openagent.ChatCompletionRequest) (*openagent.ChatCompletionResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	i := m.calls
+	if i >= len(m.steps) {
+		i = len(m.steps) - 1
+	}
+	m.calls++
+	return m.steps[i].resp, m.steps[i].err
+}
+
+func (m *scriptModel) ChatCompletionStream(_ context.Context, _ openagent.ChatCompletionRequest) (openagent.StreamReader, error) {
+	return nil, nil
+}
+
+func (m *scriptModel) ContextWindow() int { return 128_000 }
+
+func (m *scriptModel) callCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
+}
+
+func okResponse(content string) *openagent.ChatCompletionResponse {
+	return &openagent.ChatCompletionResponse{
+		Choices: []openagent.Choice{{
+			Message:      openagent.Message{Role: openagent.RoleAssistant, Content: content},
+			FinishReason: "stop",
+		}},
+	}
+}
+
+// newTestCompressor builds a Compressor whose backoff is a no-op so retry
+// paths run without sleeping.
+func newTestCompressor(m openagent.Model) *Compressor {
+	c := New(m)
+	c.backoff = func(int, *openagent.RetryableError) time.Duration { return 0 }
+	return c
+}
+
+func TestSummarize_RetriesOnceOnRetryableError(t *testing.T) {
+	m := &scriptModel{steps: []scriptStep{
+		{err: &openagent.RetryableError{Err: errors.New("504 Gateway Timeout")}},
+		{resp: okResponse("1. Primary Request: ...\n8. Next Step: ...")},
+	}}
+	c := newTestCompressor(m)
+
+	cc, err := c.Summarize(context.Background(), []openagent.Message{
+		{Role: openagent.RoleUser, Content: "hello"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("expected success after retry, got error: %v", err)
+	}
+	if cc == nil || !strings.Contains(cc.Summary, "Primary Request") {
+		t.Fatalf("expected summary content, got %+v", cc)
+	}
+	if got := m.callCount(); got != 2 {
+		t.Fatalf("expected 2 attempts (1 retry), got %d", got)
+	}
+}
+
+func TestSummarize_RetriesExhausted(t *testing.T) {
+	transient := &openagent.RetryableError{Err: errors.New("504 Gateway Timeout")}
+	m := &scriptModel{steps: []scriptStep{
+		{err: transient},
+		{err: transient},
+	}}
+	c := newTestCompressor(m)
+
+	cc, err := c.Summarize(context.Background(), []openagent.Message{
+		{Role: openagent.RoleUser, Content: "hello"},
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error after retries exhausted, got nil")
+	}
+	if cc != nil {
+		t.Fatalf("expected nil CompressedContext on failure, got %+v", cc)
+	}
+	if !strings.Contains(err.Error(), "summarizer: model call:") {
+		t.Fatalf("expected error wrapped as 'summarizer: model call', got: %v", err)
+	}
+	if !errors.Is(err, transient) {
+		t.Fatalf("expected underlying RetryableError preserved, got: %v", err)
+	}
+	if got := m.callCount(); got != 2 {
+		t.Fatalf("expected exactly 2 attempts (1 retry), got %d", got)
+	}
+}
+
+func TestSummarize_NilResponseNoPanic(t *testing.T) {
+	m := &scriptModel{steps: []scriptStep{{resp: nil, err: nil}}}
+	c := newTestCompressor(m)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Summarize panicked on nil response: %v", r)
+		}
+	}()
+	cc, err := c.Summarize(context.Background(), []openagent.Message{
+		{Role: openagent.RoleUser, Content: "hello"},
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error for nil response, got nil")
+	}
+	if cc != nil {
+		t.Fatalf("expected nil CompressedContext, got %+v", cc)
+	}
+	if !strings.Contains(err.Error(), "nil response") {
+		t.Fatalf("expected 'nil response' error, got: %v", err)
+	}
+	if got := m.callCount(); got != 1 {
+		t.Fatalf("nil response must not be retried, expected 1 call, got %d", got)
+	}
+}
+
+func TestSummarize_NonRetryableNoRetry(t *testing.T) {
+	perm := errors.New("400 Bad Request: invalid model")
+	m := &scriptModel{steps: []scriptStep{{err: perm}}}
+	c := newTestCompressor(m)
+
+	cc, err := c.Summarize(context.Background(), []openagent.Message{
+		{Role: openagent.RoleUser, Content: "hello"},
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if cc != nil {
+		t.Fatalf("expected nil CompressedContext, got %+v", cc)
+	}
+	if !errors.Is(err, perm) {
+		t.Fatalf("expected underlying error preserved, got: %v", err)
+	}
+	if got := m.callCount(); got != 1 {
+		t.Fatalf("non-retryable error must not retry, expected 1 call, got %d", got)
+	}
+}
+
+func TestSummarize_EmptySummaryAfterRetry(t *testing.T) {
+	m := &scriptModel{steps: []scriptStep{
+		{err: &openagent.RetryableError{Err: errors.New("503")}},
+		{resp: okResponse("   ")},
+	}}
+	c := newTestCompressor(m)
+
+	cc, err := c.Summarize(context.Background(), []openagent.Message{
+		{Role: openagent.RoleUser, Content: "hello"},
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error for empty summary, got nil")
+	}
+	if cc != nil {
+		t.Fatalf("expected nil CompressedContext, got %+v", cc)
+	}
+	if !strings.Contains(err.Error(), "empty summary") {
+		t.Fatalf("expected 'empty summary' error, got: %v", err)
+	}
+	if got := m.callCount(); got != 2 {
+		t.Fatalf("expected 2 attempts (retry then empty), got %d", got)
+	}
+}
+
+func TestSummarize_CancelledDuringBackoff(t *testing.T) {
+	m := &scriptModel{steps: []scriptStep{
+		{err: &openagent.RetryableError{Err: errors.New("504")}},
+		{resp: okResponse("ok")},
+	}}
+	c := New(m)
+	// Real backoff (1s) so the cancel below actually fires during the wait.
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		cancel()
+	}()
+	cc, err := c.Summarize(ctx, []openagent.Message{
+		{Role: openagent.RoleUser, Content: "hello"},
+	}, nil)
+	if err == nil {
+		t.Fatal("expected cancellation error, got nil")
+	}
+	if cc != nil {
+		t.Fatalf("expected nil CompressedContext, got %+v", cc)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled in chain, got: %v", err)
+	}
+}


### PR DESCRIPTION
Summarize retried once on RetryableError (429/5xx incl. 504 Gateway Timeout) with backoff honoring RetryAfter, mirroring kernel/modelcall's retry contract. Without this a single transient gateway error failed compaction, left the working set untrimmed, and the growing context eventually tripped the hard window check (fail-loud turn failure).

Also guards resp == nil (third-party Model returning (nil,nil) would panic on resp.Choices — asymmetric with extractor_llm.go:138). Adds summarizer/llm_test.go covering retry-success/exhausted/nil/non-retryable/ cancel paths with a scripted mock model.

Closes BUGS.md B9.