### PR TITLE
feat(channel/feishu): ACP-style approval buttons — Allow Once/Allow Always/Deny

### DIFF
--- a/channel/feishu/approval_card.go
+++ b/channel/feishu/approval_card.go
@@ -8,11 +8,11 @@ import (
 	"github.com/yusheng-g/openagent-go/utils"
 )
 
-// approvalButtonRow builds the column_set element containing the two
-// approval buttons (同意 / 拒绝). The approvalID is embedded in
-// every button's value so the card action callback can correlate clicks.
-// Shared by buildApprovalCard (standalone card) and BuildCard (integrated
-// run card approval section).
+// approvalButtonRow builds the column_set element containing the three
+// ACP-style approval buttons (Allow Once / Allow Always / Deny).
+// The approvalID is embedded in every button's value so the card action
+// callback can correlate clicks. "allow_always" remembers the decision
+// for the session (same tool+args won't ask again).
 func approvalButtonRow(approvalID string) map[string]any {
 	btn := func(label, name, btnType string) map[string]any {
 		return map[string]any{
@@ -29,15 +29,16 @@ func approvalButtonRow(approvalID string) map[string]any {
 		"flex_mode":          "flow",
 		"horizontal_spacing": "8px",
 		"columns": []map[string]any{
-			{"tag": "column", "width": "auto", "elements": []map[string]any{btn("同意", "agree", "primary_filled")}},
-			{"tag": "column", "width": "auto", "elements": []map[string]any{btn("拒绝", "reject", "danger_filled")}},
+			{"tag": "column", "width": "auto", "elements": []map[string]any{btn("Allow Once", "allow_once", "primary_filled")}},
+			{"tag": "column", "width": "auto", "elements": []map[string]any{btn("Allow Always", "allow_always", "primary_filled")}},
+			{"tag": "column", "width": "auto", "elements": []map[string]any{btn("Deny", "deny", "danger_filled")}},
 		},
 	}
 }
 
 // buildApprovalCard constructs the Feishu interactive card JSON for a tool
 // call approval request. The card shows the tool name and arguments, then
-// two action buttons (同意 / 拒绝).
+// three ACP-style action buttons (Allow Once / Allow Always / Deny).
 //
 // approvalID is embedded in every button's "value" field so the card action
 // callback can correlate the click back to the pending approval. The card

--- a/channel/feishu/approver.go
+++ b/channel/feishu/approver.go
@@ -2,6 +2,7 @@ package feishu
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -26,6 +27,7 @@ import (
 // (created in Channel.Start).
 type feishuApprover struct {
 	client *lark.Client
+	memory governance.ApprovalMemory // set by Channel.Approver; used by "allow_always"
 
 	mu      sync.Mutex
 	pending map[string]*pendingApproval // approvalID → pending entry
@@ -153,9 +155,13 @@ func (a *feishuApprover) handleCardAction(_ context.Context, event *callback.Car
 
 	var r approvalResult
 	switch buttonAction {
-	case "agree":
+	case "allow_once":
 		r = approvalResult{action: "allow"}
-	case "reject":
+	case "allow_always":
+		r = approvalResult{action: "allow"}
+		// Remember for the session — same tool+args won't ask again.
+		a.rememberAllowAlways(event, entry)
+	case "deny":
 		r = approvalResult{action: "deny", reason: "rejected by user"}
 	default:
 		return toastResponse("warning", "未知操作: "+buttonAction), nil
@@ -179,6 +185,32 @@ func (a *feishuApprover) handleCardAction(_ context.Context, event *callback.Car
 	}
 
 	return resp, nil
+}
+
+// rememberAllowAlways persists the approval decision for the session so
+// the same tool+args won't ask again (ACP "Allow Always" semantics).
+func (a *feishuApprover) rememberAllowAlways(event *callback.CardActionTriggerEvent, entry *pendingApproval) {
+	if a.memory == nil {
+		return
+	}
+	chatID := ""
+	if event.Event.Context != nil {
+		chatID = event.Event.Context.OpenChatID
+	}
+	if chatID == "" {
+		return
+	}
+	sessionID := "feishu_" + chatID
+	d := governance.Decision{Action: governance.Allow}
+	keys := governance.MemoryKeys(entry.toolName, json.RawMessage(entry.args))
+	if len(keys) == 0 {
+		keys = []string{governance.ApprovalKey(entry.toolName, json.RawMessage(entry.args))}
+	}
+	for _, key := range keys {
+		if err := a.memory.Remember(context.Background(), sessionID, key, d); err != nil {
+			slog.Warn("feishu: approve always persistence failed", "session", sessionID, "error", err)
+		}
+	}
 }
 
 // patchResolved fire-and-forgets a PATCH to update the approval card with

--- a/channel/feishu/approver_test.go
+++ b/channel/feishu/approver_test.go
@@ -46,10 +46,10 @@ func TestBuildApprovalCard(t *testing.T) {
 		t.Error("approval ID should be embedded in button values")
 	}
 
-	// Count buttons with approval_id — should be 2 (同意/拒绝).
+	// Count buttons with approval_id — should be 3 (Allow Once/Allow Always/Deny).
 	count := strings.Count(cardJSON, `"approval_id":"abc123"`)
-	if count != 2 {
-		t.Errorf("expected 2 buttons with approval_id, got %d", count)
+	if count != 3 {
+		t.Errorf("expected 3 buttons with approval_id, got %d", count)
 	}
 }
 
@@ -75,23 +75,20 @@ func TestBuildApprovalCardButtonStructure(t *testing.T) {
 
 	colSet, _ := elems[2].(map[string]any)
 	if colSet["tag"] != "column_set" {
-		t.Error("third element should be column_set")
+		t.Errorf("third element should be column_set, got %v", colSet["tag"])
 	}
 
 	cols, _ := colSet["columns"].([]any)
-	if len(cols) != 2 {
-		t.Fatalf("expected 2 columns (buttons), got %d", len(cols))
+	if len(cols) != 3 {
+		t.Fatalf("expected 3 columns (buttons), got %d", len(cols))
 	}
 
-	// No form, no input, no submit button.
+	// No form or hint — Feishu schema V2 doesn't support them.
 	if strings.Contains(cardJSON, `"tag":"form"`) {
 		t.Error("card should not contain a form")
 	}
-	if strings.Contains(cardJSON, `"tag":"input"`) {
-		t.Error("card should not contain an input")
-	}
-	if strings.Contains(cardJSON, `"form_action_type"`) {
-		t.Error("card should not contain a submit button")
+	if strings.Contains(cardJSON, "/mode") {
+		t.Error("card should not contain /mode hint")
 	}
 }
 
@@ -190,8 +187,9 @@ func TestHandleCardAction(t *testing.T) {
 		wantAction string
 		wantReason string
 	}{
-		{"agree", "agree", "allow", ""},
-		{"reject", "reject", "deny", "rejected by user"},
+		{"allow_once", "allow_once", "allow", ""},
+		{"allow_always", "allow_always", "allow", ""},
+		{"deny", "deny", "deny", "rejected by user"},
 	}
 
 	for _, tt := range tests {
@@ -245,8 +243,8 @@ func TestHandleCardActionExpired(t *testing.T) {
 	event := &callback.CardActionTriggerEvent{
 		Event: &callback.CardActionTriggerRequest{
 			Action: &callback.CallBackAction{
-				Name:  "agree",
-				Value: map[string]any{"approval_id": "nonexistent", "action": "agree"},
+				Name:  "allow_once",
+				Value: map[string]any{"approval_id": "nonexistent", "action": "allow_once"},
 			},
 		},
 	}
@@ -278,8 +276,8 @@ func TestHandleCardActionIntegrated(t *testing.T) {
 	event := &callback.CardActionTriggerEvent{
 		Event: &callback.CardActionTriggerRequest{
 			Action: &callback.CallBackAction{
-				Name:  "agree",
-				Value: map[string]any{"approval_id": "int-1", "action": "agree"},
+				Name:  "allow_once",
+				Value: map[string]any{"approval_id": "int-1", "action": "allow_once"},
 			},
 		},
 	}
@@ -373,6 +371,32 @@ func TestResolvedDisplay(t *testing.T) {
 		if toast != tt.wantToast {
 			t.Errorf("toast = %q, want %q", toast, tt.wantToast)
 		}
+	}
+}
+
+func TestBuildApprovalCardACPButtons(t *testing.T) {
+	cardJSON, err := buildApprovalCard("abc", "shell", `{"command":"ls"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(cardJSON, "Allow Once") {
+		t.Error("card should contain Allow Once button")
+	}
+	if !strings.Contains(cardJSON, "Allow Always") {
+		t.Error("card should contain Allow Always button")
+	}
+	if !strings.Contains(cardJSON, "Deny") {
+		t.Error("card should contain Deny button")
+	}
+	if !strings.Contains(cardJSON, `"action":"allow_once"`) {
+		t.Error("card should contain allow_once action")
+	}
+	if !strings.Contains(cardJSON, `"action":"allow_always"`) {
+		t.Error("card should contain allow_always action")
+	}
+	if !strings.Contains(cardJSON, `"action":"deny"`) {
+		t.Error("card should contain deny action")
 	}
 }
 

--- a/channel/feishu/card_test.go
+++ b/channel/feishu/card_test.go
@@ -162,7 +162,7 @@ func TestBuildCardWithApproval(t *testing.T) {
 	body, _ := m["body"].(map[string]any)
 	elems, _ := body["elements"].([]any)
 
-	// Last three elements: hr, markdown (approval context), column_set (buttons).
+	// Last three elements: hr, markdown (approval context), column_set (3 buttons).
 	n := len(elems)
 	if n < 3 {
 		t.Fatalf("expected at least 3 elements, got %d", n)
@@ -187,10 +187,10 @@ func TestBuildCardWithApproval(t *testing.T) {
 		t.Errorf("expected column_set for buttons, got %v", colSet["tag"])
 	}
 
-	// Approval ID embedded in all 2 button values.
+	// Approval ID embedded in all 3 button values.
 	count := strings.Count(result, `"approval_id":"abc123"`)
-	if count != 2 {
-		t.Errorf("expected 2 buttons with approval_id, got %d", count)
+	if count != 3 {
+		t.Errorf("expected 3 buttons with approval_id, got %d", count)
 	}
 }
 

--- a/channel/feishu/feishu.go
+++ b/channel/feishu/feishu.go
@@ -133,7 +133,8 @@ func modeCardContent(currentMode string) string {
 
 // Approver returns the Feishu-card-based human approver for this channel.
 // May be called before Start; the lark client is wired in Start.
-func (c *Channel) Approver(_ governance.ApprovalMemory) governance.HumanApprover {
+func (c *Channel) Approver(mem governance.ApprovalMemory) governance.HumanApprover {
+	c.approver.memory = mem
 	return c.approver
 }
 
@@ -549,16 +550,22 @@ func (c *Channel) CardSize(card *channel.Card) int {
 
 // ── Card action routing ──
 
-// handleCardAction routes a Feishu card action trigger event to either
-// mode-switch handling (when value["type"]=="mode_switch") or the
-// existing approval flow (delegated to feishuApprover).
+// handleCardAction routes a Feishu card action trigger event by the
+// "type" field in the action value. "mode_switch" is handled inline;
+// all other actions (approval buttons) are delegated to
+// handleApprovalAction.
 func (c *Channel) handleCardAction(ctx context.Context, event *callback.CardActionTriggerEvent) (*callback.CardActionTriggerResponse, error) {
-	if event != nil && event.Event != nil && event.Event.Action != nil {
-		if typ, _ := event.Event.Action.Value["type"].(string); typ == "mode_switch" {
-			return c.handleModeSwitch(ctx, event)
-		}
+	if event == nil || event.Event == nil || event.Event.Action == nil {
+		return c.approver.handleCardAction(ctx, event)
 	}
-	return c.approver.handleCardAction(ctx, event)
+
+	actionType, _ := event.Event.Action.Value["type"].(string)
+	switch actionType {
+	case "mode_switch":
+		return c.handleModeSwitch(ctx, event)
+	default:
+		return c.approver.handleCardAction(ctx, event)
+	}
 }
 
 // handleModeSwitch processes a mode-switch button click. It extracts the

--- a/cmd/cli/server/channel.go
+++ b/cmd/cli/server/channel.go
@@ -428,10 +428,17 @@ loop:
 				"type", evt.Type,
 				"thoughtLen", thoughtBuf.Len(),
 				"blocks", len(blocks))
-			// Clear approval buttons on any event except StreamToolCall.
-			// StreamToolCall arrives BEFORE Ask (the callback), so clearing
-			// on it would race with the callback setting the buttons.
-			if evt.Type != openagent.StreamToolCall {
+			// Clear approval buttons only on events that indicate the
+			// stream has advanced past the approval point (tool result,
+			// text output, done/error). StreamThought and StreamToolCall
+			// can be buffered in the stream channel while the event loop
+			// is blocked in pq.create; processing them after the Ask
+			// callback has set pendingApproval would wrongly clear the
+			// approval buttons (race with pq.create blocking).
+			switch evt.Type {
+			case openagent.StreamToolResult, openagent.StreamTextDelta,
+				openagent.StreamRetrying, openagent.StreamDone,
+				openagent.StreamError, openagent.StreamAborted:
 				clearApproval()
 			}
 			switch evt.Type {


### PR DESCRIPTION
Replace approval card buttons with three ACP-style buttons:
- Allow Once: approve this call only
- Allow Always: remember tool+args via ApprovalMemory, skip future asks in session
- Deny: reject the call

Also fixes a race where buffered StreamThought events during pq.create would incorrectly clear pendingApproval (clearApproval now only fires on result/delta/retry/done/error/abort events).