### PR TITLE
feat(feishu): feishu_sendfile tool for sending workspace files to chat & refactor RunChannels/NewXxxManager params 

### DIFF
--- a/channel/feishu/feishu.go
+++ b/channel/feishu/feishu.go
@@ -165,6 +165,10 @@ func (c *Channel) SetOnError(f func(err error)) { c.onError = f }
 // Name implements channel.Channel.
 func (c *Channel) Name() string { return "feishu" }
 
+// Client returns the underlying lark client (nil before Start).
+// Used by same-package tools (e.g. SendFile) that need the IM API.
+func (c *Channel) Client() *lark.Client { return c.client }
+
 // Start implements channel.Channel. It opens a WebSocket connection to
 // Feishu and blocks until ctx is cancelled.
 func (c *Channel) Start(ctx context.Context, handler channel.MessageHandler) error {

--- a/channel/feishu/sendfile.go
+++ b/channel/feishu/sendfile.go
@@ -1,0 +1,248 @@
+package feishu
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	lark "github.com/larksuite/oapi-sdk-go/v3"
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+
+	openagent "github.com/yusheng-g/openagent-go"
+	"github.com/yusheng-g/openagent-go/channel"
+	"github.com/yusheng-g/openagent-go/tool"
+)
+
+const (
+	maxFileSize = 30 * 1024 * 1024 // 30MB — Feishu file upload limit
+	maxImgSize  = 10 * 1024 * 1024 // 10MB — Feishu image upload limit
+)
+
+// metaReceiveIDType / metaReceiveID are the Session.Metadata keys that
+// carry the Feishu receive_id so channel-specific tools can send messages
+// back to the originating chat.
+const (
+	metaReceiveIDType = "feishu_receive_id_type"
+	metaReceiveID     = "feishu_receive_id"
+)
+
+// imageExts maps file extensions to whether the file is an image.
+var imageExts = map[string]bool{
+	".jpg": true, ".jpeg": true, ".png": true, ".webp": true,
+	".gif": true, ".tiff": true, ".bmp": true, ".ico": true,
+}
+
+// nativeFileTypeByExt maps extensions to their dedicated Feishu file_type.
+// Extensions not listed here are NOT rejected — they use the generic
+// "stream" type via fileTypeForExt. This is an optimization map, not a
+// whitelist.
+var nativeFileTypeByExt = map[string]string{
+	".pdf":  "pdf",
+	".doc":  "doc",
+	".docx": "doc",
+	".xls":  "xls",
+	".xlsx": "xls",
+	".ppt":  "ppt",
+	".pptx": "ppt",
+	".opus": "opus",
+	".mp4":  "mp4",
+}
+
+// fileTypeForExt returns the Feishu file_type for a file extension.
+// Known extensions get their dedicated type; all others get "stream".
+func fileTypeForExt(ext string) string {
+	if t, ok := nativeFileTypeByExt[ext]; ok {
+		return t
+	}
+	return "stream"
+}
+
+// SendFile is a Tool that sends a file from the workspace to the current
+// Feishu chat. It uploads the file via the Feishu IM API and sends a
+// file/image message to the user.
+type SendFile struct {
+	ch      *Channel
+	workDir string
+}
+
+// NewSendFile creates a SendFile tool bound to a Channel (for API access)
+// and a workspace root (for path resolution).
+func NewSendFile(ch *Channel, workDir string) *SendFile {
+	abs, _ := filepath.Abs(workDir)
+	return &SendFile{ch: ch, workDir: abs}
+}
+
+func (t *SendFile) Definition() openagent.FunctionDefinition {
+	return openagent.FunctionDefinition{
+		Name:        "feishu_sendfile",
+		Description: "Deliver a file to the user in the current Feishu chat. Only use this tool when you need to send a file to the Feishu user (e.g. delivering generated output, reports, images). This uploads the file and sends it as a Feishu message — not for file manipulation. Supports images (jpg/png/gif/etc) and documents (pdf/doc/xls/ppt/mp4/opus/etc). The file must already exist on disk.",
+		Parameters:  openagent.SchemaOf[SendFileParams](),
+	}
+}
+
+func (t *SendFile) Execute(ctx context.Context, args json.RawMessage) *openagent.ToolResult {
+	params, err := openagent.ParseArgs[SendFileParams](args)
+	if err != nil {
+		return openagent.ErrorResult(fmt.Errorf("feishu_sendfile: %w", err), false, "")
+	}
+
+	abs, err := tool.ValidatePath(t.workDir, params.Path)
+	if err != nil {
+		return openagent.ErrorResult(fmt.Errorf("feishu_sendfile: %w", err), false, "")
+	}
+
+	info, err := os.Stat(abs)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return openagent.ErrorResult(fmt.Errorf("feishu_sendfile: file not found: %s", params.Path), false, "")
+		}
+		return openagent.ErrorResult(fmt.Errorf("feishu_sendfile: %w", err), false, "")
+	}
+	if info.IsDir() {
+		return openagent.ErrorResult(fmt.Errorf("feishu_sendfile: not a file: %s", params.Path), false, "")
+	}
+	if info.Size() == 0 {
+		return openagent.ErrorResult(fmt.Errorf("feishu_sendfile: empty file: %s", params.Path), false, "")
+	}
+
+	receiveIDType, receiveID, ok := receiveFromContext(ctx)
+	if !ok {
+		return openagent.ErrorResult(fmt.Errorf("feishu_sendfile: no Feishu chat context (this tool only works within a Feishu channel session)"), false, "")
+	}
+
+	client := t.ch.Client()
+	if client == nil {
+		return openagent.ErrorResult(fmt.Errorf("feishu_sendfile: Feishu client not initialized"), false, "")
+	}
+
+	fileName := params.FileName
+	if fileName == "" {
+		fileName = filepath.Base(abs)
+	}
+
+	ext := strings.ToLower(filepath.Ext(abs))
+	isImage := imageExts[ext]
+
+	if isImage {
+		if info.Size() > maxImgSize {
+			return openagent.ErrorResult(fmt.Errorf("feishu_sendfile: image too large (%d bytes, max %d)", info.Size(), maxImgSize), false, "")
+		}
+		return t.sendImage(ctx, client, abs, fileName, receiveIDType, receiveID)
+	}
+
+	if info.Size() > maxFileSize {
+		return openagent.ErrorResult(fmt.Errorf("feishu_sendfile: file too large (%d bytes, max %d)", info.Size(), maxFileSize), false, "")
+	}
+	fileType := fileTypeForExt(ext)
+	return t.sendFile(ctx, client, abs, fileName, fileType, receiveIDType, receiveID)
+}
+
+func (t *SendFile) sendImage(ctx context.Context, client *lark.Client, path, fileName, receiveIDType, receiveID string) *openagent.ToolResult {
+	f, err := os.Open(path)
+	if err != nil {
+		return openagent.ErrorResult(fmt.Errorf("feishu_sendfile: open: %w", err), false, "")
+	}
+	defer f.Close()
+
+	resp, err := client.Im.Image.Create(ctx,
+		larkim.NewCreateImageReqBuilder().
+			Body(larkim.NewCreateImageReqBodyBuilder().
+				ImageType(larkim.CreateImageImageTypeMessage).
+				Image(f).
+				Build()).
+			Build())
+	if err != nil {
+		return openagent.ErrorResult(fmt.Errorf("feishu_sendfile: upload image: %w", err), false, "")
+	}
+	if !resp.Success() {
+		return openagent.ErrorResult(fmt.Errorf("feishu_sendfile: upload image failed: code=%d msg=%s", resp.Code, resp.Msg), false, "")
+	}
+	if resp.Data == nil || resp.Data.ImageKey == nil {
+		return openagent.ErrorResult(fmt.Errorf("feishu_sendfile: upload image returned no image_key"), false, "")
+	}
+
+	imageKey := *resp.Data.ImageKey
+	content, _ := json.Marshal(map[string]string{"image_key": imageKey})
+	msgID, err := createMessage(ctx, client, receiveIDType, receiveID, "image", string(content))
+	if err != nil {
+		return openagent.ErrorResult(fmt.Errorf("feishu_sendfile: send image message: %w", err), false, "")
+	}
+	slog.Info("feishu_sendfile: image sent", "fileName", fileName, "imageKey", imageKey, "msgID", msgID)
+	return &openagent.ToolResult{Content: fmt.Sprintf("Sent image %s (image_key=%s, message_id=%s)", fileName, imageKey, msgID)}
+}
+
+func (t *SendFile) sendFile(ctx context.Context, client *lark.Client, path, fileName, fileType, receiveIDType, receiveID string) *openagent.ToolResult {
+	f, err := os.Open(path)
+	if err != nil {
+		return openagent.ErrorResult(fmt.Errorf("feishu_sendfile: open: %w", err), false, "")
+	}
+	defer f.Close()
+
+	resp, err := client.Im.File.Create(ctx,
+		larkim.NewCreateFileReqBuilder().
+			Body(larkim.NewCreateFileReqBodyBuilder().
+				FileType(fileType).
+				FileName(fileName).
+				File(f).
+				Build()).
+			Build())
+	if err != nil {
+		return openagent.ErrorResult(fmt.Errorf("feishu_sendfile: upload file: %w", err), false, "")
+	}
+	if !resp.Success() {
+		return openagent.ErrorResult(fmt.Errorf("feishu_sendfile: upload file failed: code=%d msg=%s", resp.Code, resp.Msg), false, "")
+	}
+	if resp.Data == nil || resp.Data.FileKey == nil {
+		return openagent.ErrorResult(fmt.Errorf("feishu_sendfile: upload file returned no file_key"), false, "")
+	}
+
+	fileKey := *resp.Data.FileKey
+	content, _ := json.Marshal(map[string]string{"file_key": fileKey})
+	msgID, err := createMessage(ctx, client, receiveIDType, receiveID, "file", string(content))
+	if err != nil {
+		return openagent.ErrorResult(fmt.Errorf("feishu_sendfile: send file message: %w", err), false, "")
+	}
+	slog.Info("feishu_sendfile: file sent", "fileName", fileName, "fileType", fileType, "fileKey", fileKey, "msgID", msgID)
+	return &openagent.ToolResult{Content: fmt.Sprintf("Sent file %s (file_key=%s, message_id=%s)", fileName, fileKey, msgID)}
+}
+
+// SendFileParams are the arguments to feishu_sendfile.
+type SendFileParams struct {
+	Path     string `json:"path" jsonschema:"description=File path in the workspace to send"`
+	FileName string `json:"file_name,omitempty" jsonschema:"description=Display name for the file (default: basename of path)"`
+}
+
+// receiveFromContext extracts the Feishu receive_id_type and receive_id
+// from the session metadata injected by feishuMessageHandler.
+func receiveFromContext(ctx context.Context) (receiveIDType, receiveID string, ok bool) {
+	s, sessionOK := openagent.SessionFromContext(ctx)
+	if !sessionOK || s.Metadata == nil {
+		return "", "", false
+	}
+	rit, _ := s.Metadata[metaReceiveIDType].(string)
+	rid, _ := s.Metadata[metaReceiveID].(string)
+	if rit == "" || rid == "" {
+		return "", "", false
+	}
+	return rit, rid, true
+}
+
+// ReceiveMetadata returns the session metadata map that carries the
+// Feishu receive_id for an incoming message, so channel-specific tools
+// (e.g. SendFile) can send messages back to the originating chat.
+// Exported for feishuMessageHandler to use without duplicating the
+// group/private resolve logic.
+func ReceiveMetadata(msg channel.IncomingMessage) map[string]any {
+	idType, id := "open_id", msg.UserID
+	if msg.ChatType == "group" {
+		idType, id = "chat_id", msg.ChatID
+	}
+	return map[string]any{
+		metaReceiveIDType: idType,
+		metaReceiveID:     id,
+	}
+}

--- a/channel/feishu/sendfile_test.go
+++ b/channel/feishu/sendfile_test.go
@@ -1,0 +1,141 @@
+package feishu
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	openagent "github.com/yusheng-g/openagent-go"
+)
+
+func TestSendFileParams(t *testing.T) {
+	def := (&SendFile{}).Definition()
+	if def.Name != "feishu_sendfile" {
+		t.Fatalf("tool name = %q, want %q", def.Name, "feishu_sendfile")
+	}
+	if def.Parameters == nil {
+		t.Fatal("parameters should not be nil")
+	}
+}
+
+func TestReceiveFromContext(t *testing.T) {
+	t.Run("with metadata", func(t *testing.T) {
+		ctx := openagent.WithSession(context.Background(), openagent.Session{
+			Metadata: map[string]any{
+				"feishu_receive_id_type": "chat_id",
+				"feishu_receive_id":      "oc_123",
+			},
+		})
+		rit, rid, ok := receiveFromContext(ctx)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if rit != "chat_id" {
+			t.Errorf("receiveIDType = %q, want %q", rit, "chat_id")
+		}
+		if rid != "oc_123" {
+			t.Errorf("receiveID = %q, want %q", rid, "oc_123")
+		}
+	})
+
+	t.Run("without session", func(t *testing.T) {
+		_, _, ok := receiveFromContext(context.Background())
+		if ok {
+			t.Fatal("expected ok=false for bare context")
+		}
+	})
+
+	t.Run("with session but no metadata", func(t *testing.T) {
+		ctx := openagent.WithSession(context.Background(), openagent.Session{})
+		_, _, ok := receiveFromContext(ctx)
+		if ok {
+			t.Fatal("expected ok=false for session without metadata")
+		}
+	})
+}
+
+func TestSendFileExecute_FileNotFound(t *testing.T) {
+	dir := t.TempDir()
+	sf := NewSendFile(&Channel{}, dir)
+	args, _ := json.Marshal(SendFileParams{Path: "nonexistent.txt"})
+	result := sf.Execute(context.Background(), args)
+	if result.Error == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+}
+
+func TestSendFileExecute_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.txt")
+	os.WriteFile(path, []byte{}, 0644)
+
+	sf := NewSendFile(&Channel{}, dir)
+	args, _ := json.Marshal(SendFileParams{Path: "empty.txt"})
+	result := sf.Execute(context.Background(), args)
+	if result.Error == nil {
+		t.Fatal("expected error for empty file")
+	}
+}
+
+func TestSendFileExecute_Directory(t *testing.T) {
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "subdir")
+	os.MkdirAll(subdir, 0755)
+
+	sf := NewSendFile(&Channel{}, dir)
+	args, _ := json.Marshal(SendFileParams{Path: "subdir"})
+	result := sf.Execute(context.Background(), args)
+	if result.Error == nil {
+		t.Fatal("expected error for directory")
+	}
+}
+
+func TestSendFileExecute_NoChatContext(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.txt")
+	os.WriteFile(path, []byte("hello"), 0644)
+
+	sf := NewSendFile(&Channel{}, dir)
+	args, _ := json.Marshal(SendFileParams{Path: "test.txt"})
+	result := sf.Execute(context.Background(), args)
+	if result.Error == nil {
+		t.Fatal("expected error when no Feishu chat context")
+	}
+}
+
+func TestImageExtsAndFileTypeForExt(t *testing.T) {
+	cases := []struct {
+		ext      string
+		isImage  bool
+		fileType string
+	}{
+		{".jpg", true, ""},
+		{".png", true, ""},
+		{".gif", true, ""},
+		{".pdf", false, "pdf"},
+		{".doc", false, "doc"},
+		{".docx", false, "doc"},
+		{".xls", false, "xls"},
+		{".xlsx", false, "xls"},
+		{".ppt", false, "ppt"},
+		{".pptx", false, "ppt"},
+		{".mp4", false, "mp4"},
+		{".opus", false, "opus"},
+		{".txt", false, "stream"},
+		{".zip", false, "stream"},
+	}
+	for _, c := range cases {
+		gotImage := imageExts[c.ext]
+		if gotImage != c.isImage {
+			t.Errorf("imageExts[%q] = %v, want %v", c.ext, gotImage, c.isImage)
+		}
+		if !c.isImage {
+			gotType := fileTypeForExt(c.ext)
+			if gotType != c.fileType {
+				t.Errorf("fileTypeForExt(%q) = %q, want %q", c.ext, gotType, c.fileType)
+			}
+		}
+	}
+}

--- a/cmd/cli/server/acp.go
+++ b/cmd/cli/server/acp.go
@@ -187,7 +187,15 @@ func RunACP(ctx context.Context, cfg *config.Config, caps config.Capabilities) e
 		channelDeps.Tools = buildTools(sb, cwd, []string{"shell", "read", "write", "ls", "grep", "websearch", "webfetch"})
 	}
 
-	if _, _, _, err := RunChannels(ctx, cfg.Profiles, channelCfg, channelDeps, cfg.Channels, cfg.DefaultMode, sessionStore); err != nil {
+	if _, _, _, err := RunChannels(ChannelEnv{
+		Ctx:         ctx,
+		Profiles:    cfg.Profiles,
+		Cfg:         channelCfg,
+		Deps:        channelDeps,
+		DefaultMode: cfg.DefaultMode,
+		WorkDir:     cwd,
+		MetaStore:   sessionStore,
+	}, cfg.Channels); err != nil {
 		slog.Warn("channel error", "error", err)
 	}
 

--- a/cmd/cli/server/channel.go
+++ b/cmd/cli/server/channel.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -19,6 +20,18 @@ import (
 	"github.com/yusheng-g/openagent-go/cmd/cli/config"
 )
 
+// ChannelEnv carries the shared runtime environment for all channel
+// connection managers. Each manager reads only the fields it needs.
+type ChannelEnv struct {
+	Ctx         context.Context
+	Profiles    string
+	Cfg         *agent.Agent
+	Deps        kernel.Deps
+	DefaultMode string // feishu approval mode ("manual" | "auto"; empty = "manual")
+	WorkDir     string // workspace root for channel-specific tools (feishu SendFile)
+	MetaStore   session.Store // session metadata store (nil = no meta tagging)
+}
+
 // RunChannels wires the feishu, wechat, and wecom connection managers.
 // All managers are ALWAYS created with their settings credentials — the
 // frontend control panel needs the status/connect endpoints even when no
@@ -30,24 +43,22 @@ import (
 // entry points are --channel <name> (Explicit, fail-fast: the user asked
 // for the bot, so running silently without it would read as "connected"
 // while delivering nothing) and the frontend's POST /connect.
-// defaultMode is the initial session mode for channel chats ("manual"
-// or "auto"; empty = "manual").
-func RunChannels(ctx context.Context, profiles string, cfg *agent.Agent, deps kernel.Deps, channelsCfg config.ChannelsConfig, defaultMode string, metaStore session.Store) (*FeishuManager, *WechatManager, *WecomManager, error) {
-	feishuMgr := NewFeishuManager(ctx, profiles, channelsCfg.Feishu, cfg, deps, defaultMode, metaStore)
+func RunChannels(env ChannelEnv, channelsCfg config.ChannelsConfig) (*FeishuManager, *WechatManager, *WecomManager, error) {
+	feishuMgr := NewFeishuManager(env, channelsCfg.Feishu)
 	if channelsCfg.Feishu != nil && channelsCfg.Feishu.Explicit {
 		if err := feishuMgr.Connect(); err != nil {
 			return nil, nil, nil, err
 		}
 	}
 
-	wechatMgr := NewWechatManager(ctx, profiles, channelsCfg.Wechat, cfg, deps, metaStore)
+	wechatMgr := NewWechatManager(env, channelsCfg.Wechat)
 	if channelsCfg.Wechat != nil && channelsCfg.Wechat.Explicit {
 		if err := wechatMgr.Connect(); err != nil {
 			return nil, nil, nil, err
 		}
 	}
 
-	wecomMgr := NewWecomManager(ctx, profiles, channelsCfg.Wecom, cfg, deps, metaStore)
+	wecomMgr := NewWecomManager(env, channelsCfg.Wecom)
 	if channelsCfg.Wecom != nil && channelsCfg.Wecom.Explicit {
 		if err := wecomMgr.Connect(); err != nil {
 			return nil, nil, nil, err
@@ -779,6 +790,10 @@ func formatInput(name, args string) string {
 		if path != "" {
 			return "`" + path + "`"
 		}
+	case "feishu_sendfile":
+		if path := jsonStr(m, "path"); path != "" {
+			return "`" + filepath.Base(path) + "`"
+		}
 	}
 	return channel.CodeBlock(trunc(args, 200))
 }
@@ -810,6 +825,8 @@ func toolEmoji(name string) string {
 		return "🧠"
 	case "load_skill":
 		return "📦"
+	case "feishu_sendfile":
+		return "📎"
 	default:
 		return "🔧"
 	}

--- a/cmd/cli/server/channel_manager.go
+++ b/cmd/cli/server/channel_manager.go
@@ -43,6 +43,7 @@ type FeishuManager struct {
 	deps        kernel.Deps
 	feishuCfg   *config.FeishuConfig // settings.json channels.feishu (may be nil)
 	defaultMode string               // "manual" | "auto" (empty = "manual")
+	workDir     string               // workspace root for channel-specific tools
 	metaStore   session.Store        // session metadata store (nil = no meta tagging)
 
 	mu     sync.Mutex
@@ -60,20 +61,21 @@ type FeishuManager struct {
 }
 
 // NewFeishuManager creates the process-level feishu connection manager.
-// baseCtx is the serve process context — the connection and the QR
+// env.Ctx is the serve process context — the connection and the QR
 // registration run on it, so neither is torn down by an HTTP request
 // returning. feishuCfg is the settings.json channels.feishu block (nil
 // when the user did not configure credentials — the manager then runs
 // the QR registration flow).
-func NewFeishuManager(baseCtx context.Context, profiles string, feishuCfg *config.FeishuConfig, cfg *agent.Agent, deps kernel.Deps, defaultMode string, metaStore session.Store) *FeishuManager {
+func NewFeishuManager(env ChannelEnv, feishuCfg *config.FeishuConfig) *FeishuManager {
 	return &FeishuManager{
-		baseCtx:     baseCtx,
-		profiles:    profiles,
+		baseCtx:     env.Ctx,
+		profiles:    env.Profiles,
 		feishuCfg:   feishuCfg,
-		cfg:         cfg,
-		deps:        deps,
-		defaultMode: defaultMode,
-		metaStore:   metaStore,
+		cfg:         env.Cfg,
+		deps:        env.Deps,
+		defaultMode: env.DefaultMode,
+		workDir:     env.WorkDir,
+		metaStore:   env.MetaStore,
 		status:      clirest.FeishuStatus{Phase: clirest.FeishuIdle},
 	}
 }
@@ -280,6 +282,13 @@ func (m *FeishuManager) startConnection(lock *ChannelLock, creds FeishuCredentia
 		ch := feishu.New(creds.AppID, creds.AppSecret, m.defaultMode)
 		mem := governance.NewSessionApprovalMemory()
 		deps := m.deps
+		// Clone the tools slice so the channel-specific SendFile tool
+		// does not pollute the shared deps.Tools (other channels and
+		// the REST/ACP paths share the same deps).
+		deps.Tools = append([]openagent.Tool{}, m.deps.Tools...)
+		if m.workDir != "" {
+			deps.Tools = append(deps.Tools, feishu.NewSendFile(ch, m.workDir))
+		}
 		deps.HumanApprover = ch.Approver(mem)
 		deps.ApprovalMemory = mem
 		slog.Info("channel approver enabled", "channel", "feishu")
@@ -548,10 +557,15 @@ func feishuMessageHandler(cfg *agent.Agent, deps kernel.Deps, ch channel.Channel
 			// (RunHooks via SessionFromContext, e.g. the artifact hook's
 			// context-window threshold) read the same model the runner
 			// uses.
+			//
+			// Metadata carries the Feishu receive_id so channel-specific
+			// tools (e.g. feishu_sendfile) can send messages back to the
+			// originating chat without a separate context key.
 			session := openagent.Session{
 				ID:        sessionID,
 				Model:     cfg.Model,
 				CreatedAt: time.Now(),
+				Metadata:  feishu.ReceiveMetadata(msg),
 			}
 			rt := kernel.New(cfg, deps)
 			// In auto mode, disable human approval so tools execute

--- a/cmd/cli/server/feishu_setup_test.go
+++ b/cmd/cli/server/feishu_setup_test.go
@@ -196,7 +196,7 @@ func TestClearCredentialsPreservesOtherFields(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Now clear via the manager path used by the DELETE endpoint.
-	m := NewFeishuManager(context.Background(), ".openagent/profile", nil, nil, kernel.Deps{}, "", nil)
+	m := NewFeishuManager(ChannelEnv{Ctx: context.Background(), Profiles: ".openagent/profile", Deps: kernel.Deps{}}, nil)
 	if err := m.ClearCredentials(); err != nil {
 		t.Fatal(err)
 	}
@@ -235,7 +235,7 @@ func TestClearCredentialsPreservesOtherFields(t *testing.T) {
 // total.
 func TestFeishuQRCacheRoundTrip(t *testing.T) {
 	profiles := filepath.Join(t.TempDir(), "profile")
-	m := NewFeishuManager(context.Background(), profiles, nil, nil, kernel.Deps{}, "", nil)
+	m := NewFeishuManager(ChannelEnv{Ctx: context.Background(), Profiles: profiles, Deps: kernel.Deps{}}, nil)
 
 	if err := saveFeishuQR(profiles, "https://qr.example/x", 300); err != nil {
 		t.Fatal(err)
@@ -271,7 +271,7 @@ func TestFeishuQRCacheRoundTrip(t *testing.T) {
 // to surface the expiry on its next cycle.
 func TestFeishuQRExpired(t *testing.T) {
 	profiles := filepath.Join(t.TempDir(), "profile")
-	m := NewFeishuManager(context.Background(), profiles, nil, nil, kernel.Deps{}, "", nil)
+	m := NewFeishuManager(ChannelEnv{Ctx: context.Background(), Profiles: profiles, Deps: kernel.Deps{}}, nil)
 
 	if err := saveFeishuQR(profiles, "https://qr.example/x", 300); err != nil {
 		t.Fatal(err)
@@ -294,7 +294,7 @@ func TestFeishuQRExpired(t *testing.T) {
 // not cancel it, and the SDK polls without a client timeout) must return
 // within disconnectTimeout instead of hanging the endpoint.
 func TestDisconnectTimesOutOnStuckFlow(t *testing.T) {
-	m := NewFeishuManager(context.Background(), filepath.Join(t.TempDir(), "profile"), nil, nil, kernel.Deps{}, "", nil)
+	m := NewFeishuManager(ChannelEnv{Ctx: context.Background(), Profiles: filepath.Join(t.TempDir(), "profile"), Deps: kernel.Deps{}}, nil)
 	cancelled := make(chan struct{})
 	m.mu.Lock()
 	m.cancel = func() { close(cancelled) }
@@ -322,7 +322,7 @@ func TestDisconnectTimesOutOnStuckFlow(t *testing.T) {
 // registration goroutine finishing late would clobber the state of a
 // newer connection.
 func TestSetStatusGuardDropsStalePublish(t *testing.T) {
-	m := NewFeishuManager(context.Background(), filepath.Join(t.TempDir(), "profile"), nil, nil, kernel.Deps{}, "", nil)
+	m := NewFeishuManager(ChannelEnv{Ctx: context.Background(), Profiles: filepath.Join(t.TempDir(), "profile"), Deps: kernel.Deps{}}, nil)
 	current := make(chan struct{})
 	m.mu.Lock()
 	m.done = current
@@ -345,7 +345,7 @@ func TestSetStatusGuardDropsStalePublish(t *testing.T) {
 // cleanup (the buggy ordering) makes the guard see m.done != guard and
 // drop the publish, leaving the status stuck on the previous phase.
 func TestFlowTerminalPublishSurvivesOwnCleanup(t *testing.T) {
-	m := NewFeishuManager(context.Background(), filepath.Join(t.TempDir(), "profile"), nil, nil, kernel.Deps{}, "", nil)
+	m := NewFeishuManager(ChannelEnv{Ctx: context.Background(), Profiles: filepath.Join(t.TempDir(), "profile"), Deps: kernel.Deps{}}, nil)
 	done := make(chan struct{})
 	m.mu.Lock()
 	m.done = done

--- a/cmd/cli/server/http.go
+++ b/cmd/cli/server/http.go
@@ -125,7 +125,15 @@ func RunREST(ctx context.Context, cfg *config.Config, caps config.Capabilities) 
 	// flagged channel). Both managers are ALWAYS created (even when no
 	// channel is configured) so the CLI-level REST API can query status
 	// and trigger connect/registration on demand.
-	feishuMgr, wechatMgr, wecomMgr, err := RunChannels(ctx, cfg.Profiles, agentCfg, deps, cfg.Channels, cfg.DefaultMode, store)
+	feishuMgr, wechatMgr, wecomMgr, err := RunChannels(ChannelEnv{
+		Ctx:         ctx,
+		Profiles:    cfg.Profiles,
+		Cfg:         agentCfg,
+		Deps:        deps,
+		DefaultMode: cfg.DefaultMode,
+		WorkDir:     workDir,
+		MetaStore:   store,
+	}, cfg.Channels)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/server/wechat_manager.go
+++ b/cmd/cli/server/wechat_manager.go
@@ -65,16 +65,16 @@ type WechatManager struct {
 }
 
 // NewWechatManager creates the process-level wechat connection manager.
-// baseCtx is the serve process context. wechatCfg is the settings.json
+// env.Ctx is the serve process context. wechatCfg is the settings.json
 // channels.wechat block (nil when not configured — QR login then).
-func NewWechatManager(baseCtx context.Context, profiles string, wechatCfg *config.WechatConfig, cfg *agent.Agent, deps kernel.Deps, metaStore session.Store) *WechatManager {
+func NewWechatManager(env ChannelEnv, wechatCfg *config.WechatConfig) *WechatManager {
 	return &WechatManager{
-		baseCtx:   baseCtx,
-		profiles:  profiles,
+		baseCtx:   env.Ctx,
+		profiles:  env.Profiles,
 		wechatCfg: wechatCfg,
-		cfg:       cfg,
-		deps:      deps,
-		metaStore: metaStore,
+		cfg:       env.Cfg,
+		deps:      env.Deps,
+		metaStore: env.MetaStore,
 		status:    clirest.WechatStatus{Phase: clirest.WechatIdle},
 	}
 }

--- a/cmd/cli/server/wechat_setup_test.go
+++ b/cmd/cli/server/wechat_setup_test.go
@@ -120,7 +120,7 @@ func TestClearWechatCredentialsPreservesOtherFields(t *testing.T) {
 	if err := saveWechatToSettings(WechatCredentials{Token: "tok-new"}); err != nil {
 		t.Fatal(err)
 	}
-	m := NewWechatManager(context.Background(), ".openagent/profile", nil, nil, kernel.Deps{}, nil)
+	m := NewWechatManager(ChannelEnv{Ctx: context.Background(), Profiles: ".openagent/profile", Deps: kernel.Deps{}}, nil)
 	if err := m.ClearCredentials(); err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +155,7 @@ func TestClearWechatCredentialsPreservesOtherFields(t *testing.T) {
 // never grows the remaining lifetime.
 func TestWechatQRCacheRoundTrip(t *testing.T) {
 	profiles := filepath.Join(t.TempDir(), "profile")
-	m := NewWechatManager(context.Background(), profiles, nil, nil, kernel.Deps{}, nil)
+	m := NewWechatManager(ChannelEnv{Ctx: context.Background(), Profiles: profiles, Deps: kernel.Deps{}}, nil)
 
 	if err := saveWechatQR(profiles, "https://qr.example/x", 300); err != nil {
 		t.Fatal(err)
@@ -183,7 +183,7 @@ func TestWechatQRCacheRoundTrip(t *testing.T) {
 // An expired QR reports expireIn 0.
 func TestWechatQRExpired(t *testing.T) {
 	profiles := filepath.Join(t.TempDir(), "profile")
-	m := NewWechatManager(context.Background(), profiles, nil, nil, kernel.Deps{}, nil)
+	m := NewWechatManager(ChannelEnv{Ctx: context.Background(), Profiles: profiles, Deps: kernel.Deps{}}, nil)
 
 	if err := saveWechatQR(profiles, "https://qr.example/x", 300); err != nil {
 		t.Fatal(err)
@@ -204,7 +204,7 @@ func TestWechatQRExpired(t *testing.T) {
 
 // SubmitVerifyCode is rejected when no registration is waiting.
 func TestWechatSubmitVerifyCodeNotPending(t *testing.T) {
-	m := NewWechatManager(context.Background(), filepath.Join(t.TempDir(), "profile"), nil, nil, kernel.Deps{}, nil)
+	m := NewWechatManager(ChannelEnv{Ctx: context.Background(), Profiles: filepath.Join(t.TempDir(), "profile"), Deps: kernel.Deps{}}, nil)
 	if err := m.SubmitVerifyCode("123456"); err != clirest.ErrWechatVerifyCodeNotPending {
 		t.Fatalf("err = %v, want ErrWechatVerifyCodeNotPending", err)
 	}
@@ -215,7 +215,7 @@ func TestWechatSubmitVerifyCodeNotPending(t *testing.T) {
 // closed channel. The channel is cleared, not closed (see the failure
 // path comment in ConnectAsync).
 func TestWechatSubmitVerifyCodeRacingFailureNoPanic(t *testing.T) {
-	m := NewWechatManager(context.Background(), filepath.Join(t.TempDir(), "profile"), nil, nil, kernel.Deps{}, nil)
+	m := NewWechatManager(ChannelEnv{Ctx: context.Background(), Profiles: filepath.Join(t.TempDir(), "profile"), Deps: kernel.Deps{}}, nil)
 	m.mu.Lock()
 	m.status = clirest.WechatStatus{Phase: clirest.WechatRegistering}
 	m.verifyCodeCh = make(chan string, 1)
@@ -237,7 +237,7 @@ func TestWechatSubmitVerifyCodeRacingFailureNoPanic(t *testing.T) {
 // cancelled (a disconnect) — otherwise the registration goroutine holds
 // the flock for the full verifyCodeTimeout and reconnects keep failing.
 func TestWechatWaitVerifyCodeCancels(t *testing.T) {
-	m := NewWechatManager(context.Background(), filepath.Join(t.TempDir(), "profile"), nil, nil, kernel.Deps{}, nil)
+	m := NewWechatManager(ChannelEnv{Ctx: context.Background(), Profiles: filepath.Join(t.TempDir(), "profile"), Deps: kernel.Deps{}}, nil)
 	m.mu.Lock()
 	m.status = clirest.WechatStatus{Phase: clirest.WechatRegistering}
 	m.verifyCodeCh = make(chan string)
@@ -263,7 +263,7 @@ func TestWechatWaitVerifyCodeCancels(t *testing.T) {
 
 // A pairing code submitted to an in-flight registration is delivered.
 func TestWechatSubmitVerifyCodeDelivered(t *testing.T) {
-	m := NewWechatManager(context.Background(), filepath.Join(t.TempDir(), "profile"), nil, nil, kernel.Deps{}, nil)
+	m := NewWechatManager(ChannelEnv{Ctx: context.Background(), Profiles: filepath.Join(t.TempDir(), "profile"), Deps: kernel.Deps{}}, nil)
 	m.mu.Lock()
 	m.status = clirest.WechatStatus{Phase: clirest.WechatRegistering}
 	m.verifyCodeCh = make(chan string, 1)
@@ -368,7 +368,7 @@ func TestEnsureChannelMeta(t *testing.T) {
 // A disconnect whose flow is stuck must return within disconnectTimeout
 // instead of hanging the endpoint.
 func TestWechatDisconnectTimesOutOnStuckFlow(t *testing.T) {
-	m := NewWechatManager(context.Background(), filepath.Join(t.TempDir(), "profile"), nil, nil, kernel.Deps{}, nil)
+	m := NewWechatManager(ChannelEnv{Ctx: context.Background(), Profiles: filepath.Join(t.TempDir(), "profile"), Deps: kernel.Deps{}}, nil)
 	cancelled := make(chan struct{})
 	m.mu.Lock()
 	m.cancel = func() { close(cancelled) }
@@ -393,7 +393,7 @@ func TestWechatDisconnectTimesOutOnStuckFlow(t *testing.T) {
 // setStatus guards: a stale flow's publish is dropped, the current
 // owner's goes through.
 func TestWechatSetStatusGuardDropsStalePublish(t *testing.T) {
-	m := NewWechatManager(context.Background(), filepath.Join(t.TempDir(), "profile"), nil, nil, kernel.Deps{}, nil)
+	m := NewWechatManager(ChannelEnv{Ctx: context.Background(), Profiles: filepath.Join(t.TempDir(), "profile"), Deps: kernel.Deps{}}, nil)
 	current := make(chan struct{})
 	m.mu.Lock()
 	m.done = current
@@ -413,7 +413,7 @@ func TestWechatSetStatusGuardDropsStalePublish(t *testing.T) {
 // A flow's own terminal publish must not be dropped by its cleanup
 // (publish-first ordering).
 func TestWechatFlowTerminalPublishSurvivesOwnCleanup(t *testing.T) {
-	m := NewWechatManager(context.Background(), filepath.Join(t.TempDir(), "profile"), nil, nil, kernel.Deps{}, nil)
+	m := NewWechatManager(ChannelEnv{Ctx: context.Background(), Profiles: filepath.Join(t.TempDir(), "profile"), Deps: kernel.Deps{}}, nil)
 	done := make(chan struct{})
 	m.mu.Lock()
 	m.done = done

--- a/cmd/cli/server/wecom_manager.go
+++ b/cmd/cli/server/wecom_manager.go
@@ -57,17 +57,17 @@ type WecomManager struct {
 }
 
 // NewWecomManager creates the process-level wecom connection manager.
-// baseCtx is the serve process context. wecomCfg is the settings.json
+// env.Ctx is the serve process context. wecomCfg is the settings.json
 // channels.wecom block (nil when not configured — QR authorization).
-func NewWecomManager(baseCtx context.Context, profiles string, wecomCfg *config.WecomConfig, cfg *agent.Agent, deps kernel.Deps, metaStore session.Store) *WecomManager {
+func NewWecomManager(env ChannelEnv, wecomCfg *config.WecomConfig) *WecomManager {
 	return &WecomManager{
-		baseCtx:  baseCtx,
-		profiles: profiles,
-		wecomCfg: wecomCfg,
-		cfg:      cfg,
-		deps:     deps,
-		metaStore: metaStore,
-		status:   clirest.WecomStatus{Phase: clirest.WecomIdle},
+		baseCtx:   env.Ctx,
+		profiles:  env.Profiles,
+		wecomCfg:  wecomCfg,
+		cfg:       env.Cfg,
+		deps:      env.Deps,
+		metaStore: env.MetaStore,
+		status:    clirest.WecomStatus{Phase: clirest.WecomIdle},
 	}
 }
 

--- a/cmd/cli/server/wecom_setup_test.go
+++ b/cmd/cli/server/wecom_setup_test.go
@@ -76,7 +76,7 @@ func TestClearWecomCredentialsPreservesOtherFields(t *testing.T) {
 	if err := saveWecomToSettings(WecomCredentials{BotID: "bot-new", Secret: "sec-new"}); err != nil {
 		t.Fatal(err)
 	}
-	m := NewWecomManager(context.Background(), ".openagent/profile", nil, nil, kernel.Deps{}, nil)
+	m := NewWecomManager(ChannelEnv{Ctx: context.Background(), Profiles: ".openagent/profile", Deps: kernel.Deps{}}, nil)
 	if err := m.ClearCredentials(); err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +107,7 @@ func TestClearWecomCredentialsPreservesOtherFields(t *testing.T) {
 // The QR cache round-trips URL, image, and absolute expiry.
 func TestWecomQRCacheRoundTrip(t *testing.T) {
 	profiles := filepath.Join(t.TempDir(), "profile")
-	m := NewWecomManager(context.Background(), profiles, nil, nil, kernel.Deps{}, nil)
+	m := NewWecomManager(ChannelEnv{Ctx: context.Background(), Profiles: profiles, Deps: kernel.Deps{}}, nil)
 
 	if err := saveWecomQR(profiles, "https://auth.example/x", 300); err != nil {
 		t.Fatal(err)
@@ -135,7 +135,7 @@ func TestWecomQRCacheRoundTrip(t *testing.T) {
 // An expired QR reports expireIn 0.
 func TestWecomQRExpired(t *testing.T) {
 	profiles := filepath.Join(t.TempDir(), "profile")
-	m := NewWecomManager(context.Background(), profiles, nil, nil, kernel.Deps{}, nil)
+	m := NewWecomManager(ChannelEnv{Ctx: context.Background(), Profiles: profiles, Deps: kernel.Deps{}}, nil)
 
 	if err := saveWecomQR(profiles, "https://auth.example/x", 300); err != nil {
 		t.Fatal(err)
@@ -156,7 +156,7 @@ func TestWecomQRExpired(t *testing.T) {
 
 // SetCredentials is rejected while QR authorization is in flight.
 func TestWecomSetCredentialsRejectedWhileRegistering(t *testing.T) {
-	m := NewWecomManager(context.Background(), filepath.Join(t.TempDir(), "profile"), nil, nil, kernel.Deps{}, nil)
+	m := NewWecomManager(ChannelEnv{Ctx: context.Background(), Profiles: filepath.Join(t.TempDir(), "profile"), Deps: kernel.Deps{}}, nil)
 	m.mu.Lock()
 	m.status = clirest.WecomStatus{Phase: clirest.WecomRegistering}
 	m.mu.Unlock()
@@ -171,7 +171,7 @@ func TestWecomSetCredentialsRejectedWhileRegistering(t *testing.T) {
 
 // A disconnect whose flow is stuck must return within disconnectTimeout.
 func TestWecomDisconnectTimesOutOnStuckFlow(t *testing.T) {
-	m := NewWecomManager(context.Background(), filepath.Join(t.TempDir(), "profile"), nil, nil, kernel.Deps{}, nil)
+	m := NewWecomManager(ChannelEnv{Ctx: context.Background(), Profiles: filepath.Join(t.TempDir(), "profile"), Deps: kernel.Deps{}}, nil)
 	cancelled := make(chan struct{})
 	m.mu.Lock()
 	m.cancel = func() { close(cancelled) }
@@ -196,7 +196,7 @@ func TestWecomDisconnectTimesOutOnStuckFlow(t *testing.T) {
 // setStatus guards: stale publishes are dropped, the current owner's go
 // through.
 func TestWecomSetStatusGuardDropsStalePublish(t *testing.T) {
-	m := NewWecomManager(context.Background(), filepath.Join(t.TempDir(), "profile"), nil, nil, kernel.Deps{}, nil)
+	m := NewWecomManager(ChannelEnv{Ctx: context.Background(), Profiles: filepath.Join(t.TempDir(), "profile"), Deps: kernel.Deps{}}, nil)
 	current := make(chan struct{})
 	m.mu.Lock()
 	m.done = current
@@ -215,7 +215,7 @@ func TestWecomSetStatusGuardDropsStalePublish(t *testing.T) {
 
 // A flow's own terminal publish must not be dropped by its cleanup.
 func TestWecomFlowTerminalPublishSurvivesOwnCleanup(t *testing.T) {
-	m := NewWecomManager(context.Background(), filepath.Join(t.TempDir(), "profile"), nil, nil, kernel.Deps{}, nil)
+	m := NewWecomManager(ChannelEnv{Ctx: context.Background(), Profiles: filepath.Join(t.TempDir(), "profile"), Deps: kernel.Deps{}}, nil)
 	done := make(chan struct{})
 	m.mu.Lock()
 	m.done = done

--- a/tool/file.go
+++ b/tool/file.go
@@ -14,11 +14,11 @@ import (
 	openagent "github.com/yusheng-g/openagent-go"
 )
 
-// validatePath resolves p against workDir into a safe absolute path.
+// ValidatePath resolves p against workDir into a safe absolute path.
 // Accepts both relative paths (joined with workDir) and absolute paths.
 // Resolves symlinks but does NOT enforce workspace boundaries —
 // that policy belongs to the sandbox and the governance policy chain.
-func validatePath(workDir, p string) (string, error) {
+func ValidatePath(workDir, p string) (string, error) {
 	var abs string
 	var err error
 	if filepath.IsAbs(p) {
@@ -72,7 +72,7 @@ func (t *ReadFile) Execute(ctx context.Context, args json.RawMessage) *openagent
 		params.Line = 1
 	}
 
-	abs, err := validatePath(t.workDir, params.Path)
+	abs, err := ValidatePath(t.workDir, params.Path)
 	if err != nil {
 		return openagent.ErrorResult(err, false, "")
 	}
@@ -199,7 +199,7 @@ func (t *WriteFile) Execute(ctx context.Context, args json.RawMessage) *openagen
 		return openagent.ErrorResult(fmt.Errorf("write: content too large (%d bytes, max %d)", len(params.Content), maxSize), false, "")
 	}
 
-	abs, err := validatePath(t.workDir, params.Path)
+	abs, err := ValidatePath(t.workDir, params.Path)
 	if err != nil {
 		return openagent.ErrorResult(err, false, "")
 	}
@@ -245,7 +245,7 @@ func (t *ListDir) Execute(ctx context.Context, args json.RawMessage) *openagent.
 		return openagent.ErrorResult(fmt.Errorf("ls: %w", err), false, "")
 	}
 
-	dir, err := validatePath(t.workDir, params.Path)
+	dir, err := ValidatePath(t.workDir, params.Path)
 	if err != nil {
 		// Empty path defaults to workspace root.
 		if params.Path == "" {
@@ -326,7 +326,7 @@ func (t *EditFile) Execute(ctx context.Context, args json.RawMessage) *openagent
 		return openagent.ErrorResult(fmt.Errorf("edit: %w", err), false, "")
 	}
 
-	abs, err := validatePath(t.workDir, params.Path)
+	abs, err := ValidatePath(t.workDir, params.Path)
 	if err != nil {
 		return openagent.ErrorResult(err, false, "")
 	}

--- a/tool/file_test.go
+++ b/tool/file_test.go
@@ -29,9 +29,9 @@ func TestReadFileResolvesTraversal(t *testing.T) {
 	out := r.Execute(context.Background(), []byte(`{"path":"../etc/passwd"}`))
 	if out.Error != nil {
 		// May fail if /etc/passwd doesn't exist or is unreadable on this system,
-		// but should NOT be rejected by validatePath.
+		// but should NOT be rejected by ValidatePath.
 		if strings.Contains(out.Error.Message, "path outside workspace") {
-			t.Errorf("boundary enforcement should be in approver, not validatePath: %v", out.Error.Message)
+			t.Errorf("boundary enforcement should be in approver, not ValidatePath: %v", out.Error.Message)
 		} else {
 			t.Logf("✅ traversal resolved (non-workspace, approver's job to reject): %v", out.Error.Message)
 		}
@@ -44,7 +44,7 @@ func TestReadFileAbsoluteOutsideWorkspace(t *testing.T) {
 	dir := t.TempDir()
 	r := NewReadFile(dir)
 
-	// validatePath accepts absolute paths (boundary enforcement is the Approver's job).
+	// ValidatePath accepts absolute paths (boundary enforcement is the Approver's job).
 	// The call may succeed or fail depending on whether /etc/passwd exists and is readable.
 	out := r.Execute(context.Background(), []byte(`{"path":"/etc/passwd"}`))
 	if out.Error != nil {
@@ -62,7 +62,7 @@ func TestReadFileAcceptsAbsolutePathWithinWorkspace(t *testing.T) {
 	r := NewReadFile(dir)
 	out := r.Execute(context.Background(), []byte(`{"path":"`+absPath+`"}`))
 	if out.Error != nil {
-		// Acceptable: file exists but validatePath resolved symlinks, etc.
+		// Acceptable: file exists but ValidatePath resolved symlinks, etc.
 		t.Logf("absolute path result: err=%v, out=%s", out.Error.Message, out.Content)
 	} else if !strings.Contains(out.Content, "hello") {
 		t.Errorf("expected 'hello', got: %s", out.Content)

--- a/tool/grep.go
+++ b/tool/grep.go
@@ -40,7 +40,7 @@ func (t *Grep) Execute(ctx context.Context, args json.RawMessage) *openagent.Too
 		return openagent.ErrorResult(fmt.Errorf("grep: %w", err), false, "")
 	}
 
-	searchDir, err := validatePath(t.workDir, params.Path)
+	searchDir, err := ValidatePath(t.workDir, params.Path)
 	if err != nil {
 		// Empty path defaults to workspace root.
 		if params.Path == "" {

--- a/tool/title.go
+++ b/tool/title.go
@@ -43,6 +43,10 @@ func ToolTitle(name string, args string) string {
 		if params.Path != "" {
 			return name + " " + params.Path
 		}
+	case "feishu_sendfile":
+		if params.Path != "" {
+			return name + " " + filepath.Base(params.Path)
+		}
 	case "shell":
 		if params.Description != "" {
 			return name + " " + TruncateToolArg(params.Description, 60)


### PR DESCRIPTION
**feat(feishu): feishu_sendfile tool for sending workspace files to chat**

Add a channel-specific tool that lets the agent send files from the
workspace to the current Feishu chat. Uploads via Im.File.Create /
Im.Image.Create (by extension) then sends a file/image message via
createMessage. receive_id is propagated through Session.Metadata by
feishuMessageHandler so the tool resolves the originating chat without
a new context key.

- Export tool.ValidatePath for cross-package reuse
- Channel.Client() accessor for same-package tools
- FeishuManager gains workDir; startConnection clones deps.Tools before
  injecting SendFile (shared deps stay clean)
- RunChannels / NewFeishuManager signature updated (workDir param)
- formatInput / toolEmoji / ToolTitle cover feishu_sendfile

**refactor(channel): consolidate RunChannels/NewXxxManager params into ChannelEnv struct**

Replace 6-8 positional parameters with a single ChannelEnv struct
shared across RunChannels, NewFeishuManager, NewWechatManager, and
NewWecomManager. Each manager reads only the fields it needs; the
per-channel config stays a separate second parameter.
