### PR TITLE
fix(kernel): context window overflow — summarizer-fail degrade + turn>0 recompact

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -1,6 +1,6 @@
 # BUGS.md — Known Issues & Technical Debt
 
-> Last updated 2026-08-07 (B20 prompt 超窗口上限: overhead 漏算 + 压缩仅 turn 0).
+> Last updated 2026-08-10 (B20 prompt 超窗口上限 — 已修复).
 > Format: `[P0]` = critical, `[P1]` = high, `[P2]` = medium, `[P3]` = low.
 
 ---
@@ -40,13 +40,24 @@
 
 修复：默认分支 `continue`（append 已知类型）。
 
-### B20. 压缩触发后 prompt 仍超上下文窗口
+### B20. ~~压缩触发后 prompt 仍超上下文窗口~~ ✅ 已修复（2026-08-10）
 
-现象：ACP 多轮对话报 `prompt exceeds model context window: 131793 > 131072`（压缩已在 70% 触发，仍超 100%）。
+现象：多轮对话报 `prompt exceeds model context window: 370053 > 131072`，第二次 `730119 > 131072`（≈2×，跨 session 全量读回翻倍）。
 
-根因：`estimatePromptOverhead`（`kernel/prompt.go:190-217`）漏算 buildPrompt 注入的 skills catalog / memories / resources / dynamic-template → budget 偏大、裁剪不足；压缩只在 turn 0（`kernel/run.go:100-102`），后续 tool 轮无补偿；叠加 tokenizer CJK 误差（cl100k 高估 ~60%）。
+两个独立根因，任一可单独触发超窗：
 
-修复：(a) `estimatePromptOverhead` 计入漏算组件；(b) turn>0 也检查压缩；(c) 或调低 budget 比例（70%→60%）。
+- **根因 A（主）**：`Compressor.Compact` 失败时（summarizer 模型 429/超时/网络），`prepareMemory` 原设计 fail-loud——`overflow = len(msgs)` 全量返回所有 post-summary 消息。summarizer 持续失败时每次都全量返回，跨 session 新 run 读回旧历史 + 自身新增 ≈ 2× 增长，精确解释 370053→730119 翻倍。修复：Compact 失败时降级裁剪到 budget（保留最新消息，丢最旧的；消息在 store 里不删，未来 summarizer 恢复仍可压缩）。
+- **根因 B（次）**：`prepareMemory` 只在 turn 0 调用（`kernel/run.go:100`）。turn>0 的 `workingMessages` 纯 append 无压缩无裁剪，多轮小工具结果累积无界增长。修复：turn>0 且有 SessionStore 时也调 `prepareMemory`（从 store fetch + 压缩 + 裁剪）。对齐（from/ThroughIndex/globalCutoff）由 prepareMemory 内部从 store 读保证，不索引 workingMessages（回避 prefix 不 commit / TrimOrphanToolCalls 削头 / input 重复三条对齐破坏路径）。
+
+**不是根因（已排除）**：
+
+- summary 无限膨胀：`prompt.go:74-77` 将 summary 截到 `MaxCompressedTokens`（默认 8192）后才进 prompt，有界。8192 解释不了 370053 量级。
+- tokenizer CJK 误差：cl100k 对 CJK 高估 ~60%，高估方向是提前触发压缩/提前报超窗（缓解），不加剧。60% 量级解释不了 370K 的数字。
+- `estimatePromptOverhead` 漏算 skills 目录（见下"残留"）。
+
+**残留（未修，有界）**：
+
+`estimatePromptOverhead`（`kernel/prompt.go:190-217`）只扣 static + DynamicContext + summary，不扣 skills 目录 + recalled memories + resources + 动态 preamble 模板。227 个真实 skill 的 frontmatter ≈ 18K tokens 不从 budget 扣，使 working set budget 偏大 ~18K，降低超窗阈值。不产生 370053 量级（skills 有界），但让"离超窗有多近"少 18K 裕度。未修原因：`estimatePromptOverhead` 在 `prepareMemory` 内部调（`prepare.go:88`），早于 `context.Build`（`run.go:121`，产生 ac.Skills），此时 skills 尚未发现。需处理时序问题，作为独立后续优化。
 
 ---
 

--- a/kernel/prepare.go
+++ b/kernel/prepare.go
@@ -179,10 +179,18 @@ func (rt *Runtime) prepareMemory(ctx context.Context, session openagent.Session)
 					overflow = len(msgs)
 				}
 			} else {
-				// Compaction failed: trimming would drop the head with no
-				// summary to cover it — keep the whole working set and let
-				// the hard window check surface the overflow (fail-loud).
-				overflow = len(msgs)
+ 				// Compaction failed: the summary does NOT cover the head.
+				// The original fail-loud design kept the whole working set
+				// and let the hard window check error. But when the summarizer
+				// fails persistently (429, timeout, network), this makes every
+				// turn return the FULL un-trimmed history — across sessions the
+				// prompt grows ~2× per run (370K → 730K) and every run crashes.
+				// Degrade instead: trim to budget from the tail (keep the most
+				// recent messages), losing the oldest un-summarized messages.
+				// They remain in the store (never deleted); a later successful
+				// compaction can still fold them into a summary. Losing history
+				// is better than crashing every run.
+				overflow = openagent.SafeCompressionBoundary(msgs, overflow)
 			}
 		}
 	}
@@ -203,7 +211,18 @@ func (rt *Runtime) prepareMemory(ctx context.Context, session openagent.Session)
 	if rt.deps.Compressor == nil {
 		return msgs, ci, nil
 	}
-	if ci.count == 0 {
+	if ci.count == 0 && ci.err == nil {
+		// No compaction advanced AND no failure — budget fit or silent no-op.
+		// Keep everything (trimming would drop the head with no summary).
+		return msgs, ci, nil
+	}
+	if ci.count == 0 && ci.err != nil {
+		// Compaction failed: trim to budget from the tail (degrade gracefully
+		// — see the comment at the failure site above). overflow was set to
+		// the SafeCompressionBoundary of the token-trim point.
+		if overflow < len(msgs) {
+			return msgs[overflow:], ci, nil
+		}
 		return msgs, ci, nil
 	}
 	return msgs[overflow:], ci, nil

--- a/kernel/run.go
+++ b/kernel/run.go
@@ -128,6 +128,31 @@ func (rt *Runtime) run(ctx context.Context, session openagent.Session, prefix []
 			}
 		}
 
+		// ① Tool-turn re-compaction (turn > 0): prepareMemory only ran on
+		// turn 0, so the working set has grown by raw append since. Re-run
+		// prepareMemory to fetch the full post-summary history from the
+		// store, compact overflow, and trim back to budget. This is the
+		// same path turn 0 takes — alignment (from/ThroughIndex/globalCutoff)
+		// is handled internally by prepareMemory reading from the store, NOT
+		// by indexing into workingMessages (which contains un-committed prefix
+		// and orphan-trimmed heads that would misalign a manual globalCutoff).
+		// Without this, accumulated tool results / cross-session history grows
+		// unbounded and the prompt exceeds the context window.
+		if turn > 0 && rt.deps.SessionStore != nil {
+			messages, ci, err := rt.prepareMemory(ctx, session)
+			if err != nil {
+				slog.Error("openagent: tool-turn memory prepare failed", "error", err)
+				// Best-effort: keep the existing working set. The hard
+				// window check below surfaces any overflow (fail-loud).
+			} else {
+				workingMessages = messages
+				rt.compressed = ci.compressed
+				if ci.err != nil {
+					slog.Error("openagent: tool-turn compaction failed", "error", ci.err)
+				}
+			}
+		}
+
 		// Keep the AgentContext in sync with the growing working set.
 		ac.Messages = workingMessages
 


### PR DESCRIPTION
## Problem

Multi-turn conversations intermittently hit `prompt exceeds model context window: 370053 > 131072`, then `730119 > 131072` on the next run (~2×, full history read back across sessions).

## Two independent root causes

### A (main): prepareMemory returns full history when summarizer fails

When `Compressor.Compact` fails (summarizer model 429/timeout/network), the original fail-loud design set `overflow = len(msgs)` — returning all post-summary messages untrimmed. With persistent summarizer failure, every turn returns the full history; across sessions the new run reads back the old history plus its own additions ≈ 2× growth, exactly matching the 370053→730119 doubling.

**Fix**: Degrade on Compact failure — trim to budget from the tail (keep newest messages, drop oldest). Messages are never deleted from the store; a later successful compaction can still fold them into a summary.

### B (secondary): prepareMemory only runs on turn 0

turn>0 `workingMessages` grows via raw append with no compaction or trimming. Multiple small tool results accumulate unboundedly.

**Fix**: Re-run `prepareMemory` on turn>0 when SessionStore is present (fetch from store + compact + trim). Alignment (from/ThroughIndex/globalCutoff) is handled internally by prepareMemory reading from the store, not by indexing workingMessages — avoids prefix-not-committed / TrimOrphanToolCalls / input-duplication misalignment.

## Ruled out (not root causes)

- **Summary unbounded growth**: summary is truncated to `MaxCompressedTokens` (default 8192) before entering the prompt — bounded, cannot explain 370K scale.
- **Tokenizer CJK error**: cl100k overestimates CJK by ~60%; the overestimate direction triggers compaction/window-check earlier (mitigating), not aggravating. 60% cannot explain 370K.
- **`estimatePromptOverhead` excluding skills catalog**: see "Residual" below.

## Residual (unfixed, bounded)

`estimatePromptOverhead` only subtracts static + DynamicContext + summary, not skills catalog + memories + resources + preamble. 227 skills ≈ 18K tokens are not deducted from the budget, lowering the overflow threshold but not producing 370K-scale prompts (skills are bounded). Unfixed because `estimatePromptOverhead` runs inside `prepareMemory`, before `context.Build` discovers skills — needs a timing fix, independent follow-up.

## Verification

Binary build + real GLM model ACP end-to-end test (32K window, same session, two consecutive reads of a large file):

| | Before fix | After fix |
|---|---|---|
| prompt 2 | `43961 > 32000` overflow FAIL | success |

## Changes

- `kernel/prepare.go` +24/-5: degrade on Compact failure + return logic distinguishes count/err
- `kernel/run.go` +25: call prepareMemory on turn>0
- `BUGS.md`: B20 marked fixed + root causes + residual