### PR TITLE
feat(wecom): wecom_sendfile tool + streaming UX fix

### DIFF
--- a/channel/wecom/protocol.go
+++ b/channel/wecom/protocol.go
@@ -7,22 +7,28 @@ const wsEndpoint = "wss://openws.work.weixin.qq.com"
 
 // Wire commands.
 const (
-	cmdSubscribe          = "aibot_subscribe"
-	cmdMsgCallback        = "aibot_msg_callback"
-	cmdEventCallback      = "aibot_event_callback"
-	cmdRespondMsg         = "aibot_respond_msg"
-	cmdRespondWelcomeMsg  = "aibot_respond_welcome_msg"
-	cmdRespondUpdateMsg   = "aibot_respond_update_msg"
-	cmdSendMsg            = "aibot_send_msg"
-	cmdPing               = "ping"
-	cmdPong               = "pong"
+	cmdSubscribe         = "aibot_subscribe"
+	cmdMsgCallback       = "aibot_msg_callback"
+	cmdEventCallback     = "aibot_event_callback"
+	cmdRespondMsg        = "aibot_respond_msg"
+	cmdRespondWelcomeMsg = "aibot_respond_welcome_msg"
+	cmdRespondUpdateMsg  = "aibot_respond_update_msg"
+	cmdSendMsg           = "aibot_send_msg"
+	cmdUploadMediaInit   = "aibot_upload_media_init"
+	cmdUploadMediaChunk  = "aibot_upload_media_chunk"
+	cmdUploadMediaFinish = "aibot_upload_media_finish"
+	cmdPing              = "ping"
+	cmdPong              = "pong"
 )
 
-// Frame is the envelope for every WS message (requests and callbacks).
+// Frame is the envelope for every WS message (requests, callbacks, and
+// responses). Response frames (acks) carry ErrCode/ErrMsg instead of Cmd.
 type Frame struct {
-	Cmd     string          `json:"cmd"`
+	Cmd     string          `json:"cmd,omitempty"`
 	Headers FrameHeaders    `json:"headers"`
 	Body    json.RawMessage `json:"body,omitempty"`
+	ErrCode int             `json:"errcode,omitempty"`
+	ErrMsg  string          `json:"errmsg,omitempty"`
 }
 
 // FrameHeaders carries the request id used to correlate callbacks and
@@ -99,4 +105,63 @@ type Ack struct {
 	Headers FrameHeaders `json:"headers"`
 	ErrCode int          `json:"errcode"`
 	ErrMsg  string       `json:"errmsg"`
+}
+
+// ── Media upload (three-step chunked upload via WS) ──
+
+// UploadMediaInitBody is the aibot_upload_media_init request payload.
+type UploadMediaInitBody struct {
+	Type        string `json:"type"`           // "file" | "image" | "voice" | "video"
+	Filename    string `json:"filename"`       // display name with extension
+	TotalSize   int    `json:"total_size"`     // file size in bytes
+	TotalChunks int    `json:"total_chunks"`   // number of chunks
+	MD5         string `json:"md5,omitempty"`  // file MD5 hex digest
+}
+
+// UploadMediaInitResult is the init response body.
+type UploadMediaInitResult struct {
+	UploadID string `json:"upload_id"`
+}
+
+// UploadMediaChunkBody is the aibot_upload_media_chunk request payload.
+type UploadMediaChunkBody struct {
+	UploadID   string `json:"upload_id"`
+	ChunkIndex int    `json:"chunk_index"` // 0-based
+	Base64Data string `json:"base64_data"`
+}
+
+// UploadMediaFinishBody is the aibot_upload_media_finish request payload.
+type UploadMediaFinishBody struct {
+	UploadID string `json:"upload_id"`
+}
+
+// UploadMediaFinishResult is the finish response body.
+type UploadMediaFinishResult struct {
+	Type      string `json:"type"`
+	MediaID   string `json:"media_id"`
+	CreatedAt int64  `json:"created_at"` // Unix timestamp
+}
+
+// ── Media message bodies ──
+
+// MediaContent carries a media_id reference.
+type MediaContent struct {
+	MediaID string `json:"media_id"`
+}
+
+// VideoContent carries a media_id plus optional title/description.
+type VideoContent struct {
+	MediaID     string `json:"media_id"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// SendMediaMsgBody is the aibot_send_msg payload for a media message.
+type SendMediaMsgBody struct {
+	ChatID  string        `json:"chatid"`
+	MsgType string        `json:"msgtype"`
+	File    *MediaContent `json:"file,omitempty"`
+	Image   *MediaContent `json:"image,omitempty"`
+	Voice   *MediaContent `json:"voice,omitempty"`
+	Video   *VideoContent `json:"video,omitempty"`
 }

--- a/channel/wecom/sendfile.go
+++ b/channel/wecom/sendfile.go
@@ -1,0 +1,171 @@
+package wecom
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	openagent "github.com/yusheng-g/openagent-go"
+	"github.com/yusheng-g/openagent-go/channel"
+	"github.com/yusheng-g/openagent-go/tool"
+)
+
+const (
+	wecomMaxFileSize  = 20 * 1024 * 1024 // 20MB — absolute limit
+	wecomMaxImageSize = 10 * 1024 * 1024 // 10MB — image limit
+	wecomMaxVideoSize = 10 * 1024 * 1024 // 10MB — video limit
+	wecomMaxVoiceSize = 2 * 1024 * 1024  // 2MB — voice limit (AMR only)
+)
+
+// metaWecomChatID is the Session.Metadata key carrying the WeCom chat_id
+// so channel-specific tools (e.g. SendFile) can send messages back to
+// the originating chat.
+const metaWecomChatID = "wecom_chat_id"
+
+var wecomImageExts = map[string]bool{
+	".jpg": true, ".jpeg": true, ".png": true, ".webp": true,
+	".gif": true, ".tiff": true, ".bmp": true, ".ico": true,
+}
+
+var wecomVideoExts = map[string]bool{
+	".mp4": true,
+}
+
+var wecomVoiceExts = map[string]bool{
+	".amr": true,
+}
+
+// SendFile is a Tool that sends a file from the workspace to the current
+// WeCom chat. It uploads the file via the WS three-step chunked upload
+// and sends a media message via aibot_send_msg.
+type SendFile struct {
+	ch      *Channel
+	workDir string
+}
+
+// NewSendFile creates a SendFile tool bound to a Channel (for WS access)
+// and a workspace root (for path resolution).
+func NewSendFile(ch *Channel, workDir string) *SendFile {
+	abs, _ := filepath.Abs(workDir)
+	return &SendFile{ch: ch, workDir: abs}
+}
+
+func (t *SendFile) Definition() openagent.FunctionDefinition {
+	return openagent.FunctionDefinition{
+		Name:        "wecom_sendfile",
+		Description: "Deliver a file to the user in the current WeCom chat. Only use this tool when you need to send a file to the WeCom user (e.g. delivering generated output, reports, images). This uploads the file and sends it as a WeCom media message — not for file manipulation. Supports images (jpg/png/gif/etc), video (mp4), voice (amr), and documents (pdf/doc/xls/etc). The file must already exist on disk.",
+		Parameters:  openagent.SchemaOf[SendFileParams](),
+	}
+}
+
+func (t *SendFile) Execute(ctx context.Context, args json.RawMessage) *openagent.ToolResult {
+	params, err := openagent.ParseArgs[SendFileParams](args)
+	if err != nil {
+		return openagent.ErrorResult(fmt.Errorf("wecom_sendfile: %w", err), false, "")
+	}
+
+	abs, err := tool.ValidatePath(t.workDir, params.Path)
+	if err != nil {
+		return openagent.ErrorResult(fmt.Errorf("wecom_sendfile: %w", err), false, "")
+	}
+
+	info, err := os.Stat(abs)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return openagent.ErrorResult(fmt.Errorf("wecom_sendfile: file not found: %s", params.Path), false, "")
+		}
+		return openagent.ErrorResult(fmt.Errorf("wecom_sendfile: %w", err), false, "")
+	}
+	if info.IsDir() {
+		return openagent.ErrorResult(fmt.Errorf("wecom_sendfile: not a file: %s", params.Path), false, "")
+	}
+	if info.Size() == 0 {
+		return openagent.ErrorResult(fmt.Errorf("wecom_sendfile: empty file: %s", params.Path), false, "")
+	}
+
+	chatID, ok := wecomChatIDFromContext(ctx)
+	if !ok {
+		return openagent.ErrorResult(fmt.Errorf("wecom_sendfile: no WeCom chat context (this tool only works within a WeCom channel session)"), false, "")
+	}
+
+	fileName := params.FileName
+	if fileName == "" {
+		fileName = filepath.Base(abs)
+	}
+
+	ext := strings.ToLower(filepath.Ext(abs))
+	mediaType := "file"
+	if wecomImageExts[ext] {
+		mediaType = "image"
+	} else if wecomVideoExts[ext] {
+		mediaType = "video"
+	} else if wecomVoiceExts[ext] {
+		mediaType = "voice"
+	}
+
+	// Size checks with auto-downgrade (image/video/voice → file).
+	if mediaType == "image" && info.Size() > wecomMaxImageSize {
+		slog.Info("wecom_sendfile: image exceeds 10MB, downgrading to file", "size", info.Size())
+		mediaType = "file"
+	}
+	if mediaType == "video" && info.Size() > wecomMaxVideoSize {
+		slog.Info("wecom_sendfile: video exceeds 10MB, downgrading to file", "size", info.Size())
+		mediaType = "file"
+	}
+	if mediaType == "voice" && info.Size() > wecomMaxVoiceSize {
+		slog.Info("wecom_sendfile: voice exceeds 2MB, downgrading to file", "size", info.Size())
+		mediaType = "file"
+	}
+	if mediaType == "file" && info.Size() > wecomMaxFileSize {
+		return openagent.ErrorResult(fmt.Errorf("wecom_sendfile: file too large (%d bytes, max %d)", info.Size(), wecomMaxFileSize), false, "")
+	}
+
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		return openagent.ErrorResult(fmt.Errorf("wecom_sendfile: read: %w", err), false, "")
+	}
+
+	mediaID, err := t.ch.UploadMedia(data, mediaType, fileName)
+	if err != nil {
+		return openagent.ErrorResult(fmt.Errorf("wecom_sendfile: upload: %w", err), false, "")
+	}
+
+	if err := t.ch.SendMediaMessage(chatID, mediaType, mediaID); err != nil {
+		return openagent.ErrorResult(fmt.Errorf("wecom_sendfile: send: %w", err), false, "")
+	}
+
+	slog.Info("wecom_sendfile: file sent", "fileName", fileName, "mediaType", mediaType, "mediaID", mediaID)
+	return &openagent.ToolResult{Content: fmt.Sprintf("Sent %s %s (media_id=%s)", mediaType, fileName, mediaID)}
+}
+
+// SendFileParams are the arguments to wecom_sendfile.
+type SendFileParams struct {
+	Path     string `json:"path" jsonschema:"description=File path in the workspace to send"`
+	FileName string `json:"file_name,omitempty" jsonschema:"description=Display name for the file (default: basename of path)"`
+}
+
+// wecomChatIDFromContext extracts the WeCom chat_id from the session
+// metadata injected by wecomMessageHandler.
+func wecomChatIDFromContext(ctx context.Context) (string, bool) {
+	s, sessionOK := openagent.SessionFromContext(ctx)
+	if !sessionOK || s.Metadata == nil {
+		return "", false
+	}
+	cid, _ := s.Metadata[metaWecomChatID].(string)
+	if cid == "" {
+		return "", false
+	}
+	return cid, true
+}
+
+// ReceiveMetadata returns the session metadata map that carries the
+// WeCom chat_id for an incoming message, so channel-specific tools
+// (e.g. SendFile) can send messages back to the originating chat.
+// Exported for wecomMessageHandler to use.
+func ReceiveMetadata(msg channel.IncomingMessage) map[string]any {
+	return map[string]any{metaWecomChatID: msg.ChatID}
+}

--- a/channel/wecom/wecom.go
+++ b/channel/wecom/wecom.go
@@ -2,7 +2,9 @@ package wecom
 
 import (
 	"context"
+	"crypto/md5"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -39,12 +41,15 @@ type Channel struct {
 	onReady        func()
 	onReconnecting func()
 	onError        func(err error)
+
+	pending   map[string]chan Frame // req_id → response (upload acks)
+	pendingMu sync.Mutex
 }
 
 // New returns a WeCom Channel bound to the robot credentials. Must be
 // started via Start().
 func New(botID, secret string) *Channel {
-	return &Channel{botID: botID, secret: secret}
+	return &Channel{botID: botID, secret: secret, pending: make(map[string]chan Frame)}
 }
 
 // SetOnReady registers the ready callback (nil clears it). Fired once
@@ -162,6 +167,20 @@ func (c *Channel) runOnce(ctx context.Context, handler channel.MessageHandler, e
 		if err != nil {
 			return fmt.Errorf("wecom read: %w", err)
 		}
+		// Check if this is a response to a pending request (upload acks).
+		// Response frames carry the same req_id as the request and may
+		// have no "cmd" field — match by req_id before dispatching.
+		var peek Frame
+		if json.Unmarshal(raw, &peek) == nil {
+			c.pendingMu.Lock()
+			if ch, ok := c.pending[peek.Headers.ReqID]; ok {
+				delete(c.pending, peek.Headers.ReqID)
+				c.pendingMu.Unlock()
+				ch <- peek
+				continue
+			}
+			c.pendingMu.Unlock()
+		}
 		if err := c.handleFrame(raw, handler); err != nil {
 			return err
 		}
@@ -223,6 +242,10 @@ func (c *Channel) handleFrame(raw []byte, handler channel.MessageHandler) error 
 		return c.writeJSON(Frame{Cmd: cmdPong, Headers: FrameHeaders{ReqID: f.Headers.ReqID}})
 
 	default:
+		if f.Cmd == "" {
+			slog.Debug("wecom: ack response", "req_id", f.Headers.ReqID, "errcode", f.ErrCode, "errmsg", f.ErrMsg)
+			return nil
+		}
 		slog.Debug("wecom: unhandled frame", "cmd", f.Cmd)
 		return nil
 	}
@@ -311,6 +334,152 @@ func (c *Channel) buildReply(reqID string, cb *MsgCallbackBody) channel.ReplyFun
 		}
 		return streamID, nil
 	}
+}
+
+// ── Media upload + send ──
+
+const (
+	uploadChunkSize      = 512 * 1024     // 512KB before base64
+	uploadMaxChunks      = 100            // ~50MB limit
+	uploadRetryMax       = 2              // per-chunk retry count
+	uploadRetryBaseDelay = 500 * time.Millisecond
+	uploadTimeout        = 30 * time.Second
+)
+
+// sendAndWait writes a frame and blocks until the matching response
+// (same req_id) arrives from the read loop. Used by the three-step
+// upload protocol where each step's ack carries data (upload_id,
+// media_id) that the caller needs.
+func (c *Channel) sendAndWait(frame Frame) (Frame, error) {
+	reqID := frame.Headers.ReqID
+	ch := make(chan Frame, 1)
+	c.pendingMu.Lock()
+	c.pending[reqID] = ch
+	c.pendingMu.Unlock()
+	defer func() {
+		c.pendingMu.Lock()
+		delete(c.pending, reqID)
+		c.pendingMu.Unlock()
+	}()
+	if err := c.writeJSON(frame); err != nil {
+		return Frame{}, err
+	}
+	select {
+	case resp := <-ch:
+		if resp.ErrCode != 0 {
+			return resp, fmt.Errorf("wecom: errcode=%d errmsg=%s", resp.ErrCode, resp.ErrMsg)
+		}
+		return resp, nil
+	case <-time.After(uploadTimeout):
+		return Frame{}, fmt.Errorf("wecom: request timeout (req_id=%s)", reqID)
+	}
+}
+
+// UploadMedia performs the three-step chunked upload (init → chunks →
+// finish) over the WebSocket long connection and returns the media_id.
+// The media_id is valid for 3 days.
+func (c *Channel) UploadMedia(data []byte, mediaType, filename string) (string, error) {
+	totalChunks := (len(data) + uploadChunkSize - 1) / uploadChunkSize
+	if totalChunks == 0 {
+		totalChunks = 1
+	}
+	if totalChunks > uploadMaxChunks {
+		return "", fmt.Errorf("wecom: file too large (%d chunks, max %d)", totalChunks, uploadMaxChunks)
+	}
+	md5sum := md5.Sum(data)
+
+	// Step 1: init.
+	initReqID := newReqID()
+	initFrame := Frame{Cmd: cmdUploadMediaInit, Headers: FrameHeaders{ReqID: initReqID},
+		Body: mustJSON(UploadMediaInitBody{
+			Type:        mediaType,
+			Filename:    filename,
+			TotalSize:   len(data),
+			TotalChunks: totalChunks,
+			MD5:         fmt.Sprintf("%x", md5sum),
+		})}
+	initResp, err := c.sendAndWait(initFrame)
+	if err != nil {
+		return "", fmt.Errorf("wecom upload init: %w", err)
+	}
+	var initResult UploadMediaInitResult
+	if err := json.Unmarshal(initResp.Body, &initResult); err != nil {
+		return "", fmt.Errorf("wecom upload init decode: %w", err)
+	}
+	if initResult.UploadID == "" {
+		return "", fmt.Errorf("wecom upload init: no upload_id returned")
+	}
+	uploadID := initResult.UploadID
+
+	// Step 2: chunks (serial with retry).
+	for i := 0; i < totalChunks; i++ {
+		start := i * uploadChunkSize
+		end := start + uploadChunkSize
+		if end > len(data) {
+			end = len(data)
+		}
+		b64 := base64.StdEncoding.EncodeToString(data[start:end])
+		var lastErr error
+		for attempt := 0; attempt <= uploadRetryMax; attempt++ {
+			chunkReqID := newReqID()
+			chunkFrame := Frame{Cmd: cmdUploadMediaChunk, Headers: FrameHeaders{ReqID: chunkReqID},
+				Body: mustJSON(UploadMediaChunkBody{
+					UploadID:   uploadID,
+					ChunkIndex: i,
+					Base64Data: b64,
+				})}
+			if _, err := c.sendAndWait(chunkFrame); err != nil {
+				lastErr = err
+				if attempt < uploadRetryMax {
+					time.Sleep(time.Duration(attempt+1) * uploadRetryBaseDelay)
+					continue
+				}
+			} else {
+				lastErr = nil
+				break
+			}
+		}
+		if lastErr != nil {
+			return "", fmt.Errorf("wecom upload chunk %d: %w", i, lastErr)
+		}
+	}
+
+	// Step 3: finish.
+	finishReqID := newReqID()
+	finishFrame := Frame{Cmd: cmdUploadMediaFinish, Headers: FrameHeaders{ReqID: finishReqID},
+		Body: mustJSON(UploadMediaFinishBody{UploadID: uploadID})}
+	finishResp, err := c.sendAndWait(finishFrame)
+	if err != nil {
+		return "", fmt.Errorf("wecom upload finish: %w", err)
+	}
+	var finishResult UploadMediaFinishResult
+	if err := json.Unmarshal(finishResp.Body, &finishResult); err != nil {
+		return "", fmt.Errorf("wecom upload finish decode: %w", err)
+	}
+	if finishResult.MediaID == "" {
+		return "", fmt.Errorf("wecom upload finish: no media_id returned")
+	}
+	return finishResult.MediaID, nil
+}
+
+// SendMediaMessage proactively sends a media message via aibot_send_msg.
+// chatID is the user ID (single chat) or chat ID (group).
+func (c *Channel) SendMediaMessage(chatID, mediaType, mediaID string) error {
+	body := SendMediaMsgBody{ChatID: chatID, MsgType: mediaType}
+	switch mediaType {
+	case "file":
+		body.File = &MediaContent{MediaID: mediaID}
+	case "image":
+		body.Image = &MediaContent{MediaID: mediaID}
+	case "voice":
+		body.Voice = &MediaContent{MediaID: mediaID}
+	case "video":
+		body.Video = &VideoContent{MediaID: mediaID}
+	default:
+		return fmt.Errorf("wecom: unknown media type %q", mediaType)
+	}
+	return c.writeJSON(Frame{Cmd: cmdSendMsg, Headers: FrameHeaders{ReqID: newReqID()},
+		Body: mustJSON(body)})
 }
 
 // ── Internal ──

--- a/cmd/cli/server/channel.go
+++ b/cmd/cli/server/channel.go
@@ -794,6 +794,10 @@ func formatInput(name, args string) string {
 		if path := jsonStr(m, "path"); path != "" {
 			return "`" + filepath.Base(path) + "`"
 		}
+	case "wecom_sendfile":
+		if path := jsonStr(m, "path"); path != "" {
+			return "`" + filepath.Base(path) + "`"
+		}
 	}
 	return channel.CodeBlock(trunc(args, 200))
 }
@@ -826,6 +830,8 @@ func toolEmoji(name string) string {
 	case "load_skill":
 		return "📦"
 	case "feishu_sendfile":
+		return "📎"
+	case "wecom_sendfile":
 		return "📎"
 	default:
 		return "🔧"

--- a/cmd/cli/server/wecom_manager.go
+++ b/cmd/cli/server/wecom_manager.go
@@ -16,6 +16,7 @@ import (
 	"github.com/yusheng-g/openagent-go/cmd/cli/config"
 	"github.com/yusheng-g/openagent-go/kernel"
 	"github.com/yusheng-g/openagent-go/session"
+	opentool "github.com/yusheng-g/openagent-go/tool"
 
 	clirest "github.com/yusheng-g/openagent-go/cmd/cli/rest"
 )
@@ -39,12 +40,13 @@ import (
 var _ clirest.WecomChannel = (*WecomManager)(nil)
 
 type WecomManager struct {
-	baseCtx  context.Context
-	profiles string
-	cfg      *agent.Agent
-	deps     kernel.Deps
-	wecomCfg *config.WecomConfig // settings.json channels.wecom (may be nil)
-	metaStore session.Store     // session metadata store (nil = no meta tagging)
+	baseCtx   context.Context
+	profiles  string
+	cfg       *agent.Agent
+	deps      kernel.Deps
+	wecomCfg  *config.WecomConfig // settings.json channels.wecom (may be nil)
+	workDir   string              // workspace root for wecom_sendfile tool
+	metaStore session.Store       // session metadata store (nil = no meta tagging)
 
 	mu     sync.Mutex
 	lock   *ChannelLock
@@ -66,6 +68,7 @@ func NewWecomManager(env ChannelEnv, wecomCfg *config.WecomConfig) *WecomManager
 		wecomCfg:  wecomCfg,
 		cfg:       env.Cfg,
 		deps:      env.Deps,
+		workDir:   env.WorkDir,
 		metaStore: env.MetaStore,
 		status:    clirest.WecomStatus{Phase: clirest.WecomIdle},
 	}
@@ -218,6 +221,16 @@ func (m *WecomManager) startConnection(lock *ChannelLock, creds *wecom.BotCreds)
 	go func() {
 		defer close(connDone)
 		ch := wecom.New(creds.BotID, creds.Secret)
+
+		// Clone deps so the channel-specific SendFile tool does not
+		// pollute the shared deps (other channels and the REST/ACP
+		// paths share the same base deps).
+		deps := m.deps
+		deps.Tools = append([]openagent.Tool{}, m.deps.Tools...)
+		if m.workDir != "" {
+			deps.Tools = append(deps.Tools, wecom.NewSendFile(ch, m.workDir))
+		}
+
 		everReady := false
 		ch.SetOnReady(func() {
 			everReady = true
@@ -233,7 +246,7 @@ func (m *WecomManager) startConnection(lock *ChannelLock, creds *wecom.BotCreds)
 				m.setStatus(clirest.WecomStatus{Phase: clirest.WecomDisconnected, BotID: creds.BotID, LastError: err.Error()}, connDone)
 			}
 		})
-		err := ch.Start(connCtx, wecomMessageHandler(m.cfg, m.deps, m.metaStore))
+		err := ch.Start(connCtx, wecomMessageHandler(m.cfg, deps, m.metaStore))
 		lock.Release()
 		// Publish before the cleanup (guard semantics — see FeishuManager).
 		m.setStatus(clirest.WecomStatus{Phase: clirest.WecomDisconnected, BotID: creds.BotID, LastError: errString(err)}, connDone)
@@ -368,6 +381,7 @@ func wecomMessageHandler(cfg *agent.Agent, deps kernel.Deps, metaStore session.S
 				ID:        sessionID,
 				Model:     cfg.Model,
 				CreatedAt: time.Now(),
+				Metadata:  wecom.ReceiveMetadata(msg),
 			}
 			stream := kernel.New(cfg, deps).RunStream(msgCtx, session, openagent.UserMessage(msg.Text))
 
@@ -375,6 +389,7 @@ func wecomMessageHandler(cfg *agent.Agent, deps kernel.Deps, metaStore session.S
 			var streamID string
 			sentLen := 0
 			lastFlush := time.Now()
+			hasText := false
 
 			flush := func() {
 				text := b.String()
@@ -390,21 +405,48 @@ func wecomMessageHandler(cfg *agent.Agent, deps kernel.Deps, metaStore session.S
 				lastFlush = time.Now()
 			}
 
+			// Thinking placeholder — gives immediate feedback before the
+			// LLM produces its first token (typically 1-2s).
+			streamID, _ = reply(msgCtx, channel.ReplyMessage{Text: "🤔 思考中..."})
+			lastFlush = time.Now()
+
 			for evt := range stream {
 				switch evt.Type {
 				case openagent.StreamTextDelta:
 					b.WriteString(evt.Text)
-					// ~1 refresh/s, or sooner when a chunk accumulated.
-					if time.Since(lastFlush) >= time.Second || b.Len()-sentLen >= 200 {
+					if !hasText {
+						hasText = true
 						flush()
+					} else if time.Since(lastFlush) >= time.Second || b.Len()-sentLen >= 200 {
+						flush()
+					}
+				case openagent.StreamToolCall:
+					for _, tc := range evt.Message.ToolCalls {
+						title := opentool.ToolTitle(tc.Function.Name, tc.Function.Arguments)
+						hint := toolEmoji(tc.Function.Name) + " " + title
+						display := b.String()
+						if display == "" {
+							display = hint + "..."
+						} else {
+							display += "\n\n" + hint + "..."
+						}
+						_, _ = reply(msgCtx, channel.ReplyMessage{UpdateID: streamID, Text: display})
+						lastFlush = time.Now()
 					}
 				case openagent.StreamError:
 					if evt.Error != nil {
 						b.WriteString("\n[error: " + evt.Error.Error() + "]")
 					}
+				case openagent.StreamAborted:
+					if b.Len() == 0 {
+						b.WriteString("已取消")
+					}
 				}
 			}
 			// Terminal: flush what remains and end the stream (finish=true).
+			if b.Len() == 0 {
+				b.WriteString("✅ 已完成")
+			}
 			if streamID == "" || b.Len() > sentLen {
 				flush()
 			}

--- a/tool/title.go
+++ b/tool/title.go
@@ -47,6 +47,10 @@ func ToolTitle(name string, args string) string {
 		if params.Path != "" {
 			return name + " " + filepath.Base(params.Path)
 		}
+	case "wecom_sendfile":
+		if params.Path != "" {
+			return name + " " + filepath.Base(params.Path)
+		}
 	case "shell":
 		if params.Description != "" {
 			return name + " " + TruncateToolArg(params.Description, 60)


### PR DESCRIPTION
- Add wecom_sendfile tool: 3-step chunked WS media upload protocol (init → chunk ×N → finish), type detection (image/video/voice/file), size checks with auto-downgrade, ReceiveMetadata for handler injection
- protocol.go: upload command constants, upload/result structs, Frame gains ErrCode/ErrMsg fields, Cmd made omitempty, CreatedAt as int64
- wecom.go: pending map + sendAndWait for response correlation, UploadMedia/SendMediaMessage/ReplyMedia methods, ack frames (cmd="") logged at DEBUG instead of "unhandled frame"
- wecom_manager.go: inject wecom_sendfile tool per connection, streaming UX fix — send thinking placeholder immediately, handle StreamToolCall to show tool activity during execution gaps, flush first text delta immediately to replace placeholder, handle StreamAborted, default completion message for file-only responses
- channel.go + title.go: wecom_sendfile cases in toolEmoji/ToolTitle