### PR TITLE
feat(wecom): approval card via button_interaction template card

### DIFF
--- a/channel/wecom/approval_card.go
+++ b/channel/wecom/approval_card.go
@@ -1,0 +1,65 @@
+package wecom
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// buildApprovalCard constructs a WeCom button_interaction template card
+// for a tool call approval request. The card shows the tool title in the
+// desc field (smaller font), then three action buttons.
+//
+// The approvalID is used as the card's task_id — the template_card_event
+// callback carries this task_id so the approver can correlate clicks
+// back to the pending approval.
+func buildApprovalCard(approvalID, toolTitle string) (json.RawMessage, error) {
+	card := map[string]any{
+		"card_type": "button_interaction",
+		"main_title": map[string]any{
+			"title": "需要权限",
+			"desc":  toolTitle,
+		},
+		"button_list": []map[string]any{
+			{"text": "允许", "style": 1, "key": "allow_once"},
+			{"text": "始终允许", "style": 1, "key": "allow_always"},
+			{"text": "拒绝", "style": 4, "key": "deny"},
+		},
+		"task_id": approvalID,
+	}
+
+	b, err := json.Marshal(card)
+	if err != nil {
+		return nil, fmt.Errorf("wecom approval card marshal: %w", err)
+	}
+	return b, nil
+}
+
+// buildResolvedCard constructs the updated template card shown after the
+// user has made a decision. The buttons are replaced with a single
+// disabled button showing the outcome, so the user cannot click again.
+func buildResolvedCard(approvalID, toolTitle, decision string) (json.RawMessage, error) {
+	buttonText := "✅ 已同意"
+	buttonStyle := 1
+	if decision == "deny" {
+		buttonText = "❌ 已拒绝"
+		buttonStyle = 4
+	}
+
+	card := map[string]any{
+		"card_type": "button_interaction",
+		"main_title": map[string]any{
+			"title": "需要权限",
+			"desc":  toolTitle,
+		},
+		"button_list": []map[string]any{
+			{"text": buttonText, "style": buttonStyle, "key": "done"},
+		},
+		"task_id": approvalID,
+	}
+
+	b, err := json.Marshal(card)
+	if err != nil {
+		return nil, fmt.Errorf("wecom resolved card marshal: %w", err)
+	}
+	return b, nil
+}

--- a/channel/wecom/approver.go
+++ b/channel/wecom/approver.go
@@ -1,0 +1,248 @@
+package wecom
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	openagent "github.com/yusheng-g/openagent-go"
+	"github.com/yusheng-g/openagent-go/governance"
+	opentool "github.com/yusheng-g/openagent-go/tool"
+)
+
+// wecomApprover implements governance.HumanApprover for the WeCom
+// channel. When the policy engine routes a tool call to the human layer,
+// Ask sends a button_interaction template card to the WeCom chat and
+// blocks until the user clicks a button (or the context is cancelled).
+//
+// Card action callbacks (button clicks) arrive via the WebSocket event
+// loop as aibot_event_callback frames with eventtype=
+// "template_card_event". The read loop dispatches these to
+// handleCardEvent, which resolves the pending approval and sends the
+// updated card via aibot_respond_update_msg (echoing the event
+// callback's req_id).
+type wecomApprover struct {
+	ch     *Channel
+	memory governance.ApprovalMemory
+
+	mu      sync.Mutex
+	pending map[string]*pendingApproval // approvalID → pending entry
+
+	preApprovalMu sync.Mutex
+	preApproval   func() // called before sending the approval card
+}
+
+// pendingApproval pairs a result channel with the tool info needed to
+// build the resolved card after the user clicks.
+type pendingApproval struct {
+	result    chan approvalResult
+	toolName  string
+	args      string
+	toolTitle string
+	sessionID string
+}
+
+// approvalResult is the outcome extracted from a card action click.
+type approvalResult struct {
+	action string // "allow" | "deny"
+	reason string // populated for deny
+}
+
+// newApprovalID generates a process-unique approval ID used as the
+// card's task_id. Format: approval_<unix-nano>_<random-hex-4>. The
+// timestamp guarantees uniqueness across restarts (the WeCom server
+// rejects duplicate task_ids with errcode 42014).
+func newApprovalID() string {
+	var buf [4]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return fmt.Sprintf("approval_%d", time.Now().UnixNano())
+	}
+	return fmt.Sprintf("approval_%d_%s", time.Now().UnixNano(), hex.EncodeToString(buf[:]))
+}
+
+// newWecomApprover creates an approver bound to the given channel.
+func newWecomApprover(ch *Channel) *wecomApprover {
+	return &wecomApprover{
+		ch:      ch,
+		pending: make(map[string]*pendingApproval),
+	}
+}
+
+// Approver returns the approver as a governance.HumanApprover, setting
+// the approval memory used by "allow_always" persistence.
+func (c *Channel) Approver(mem governance.ApprovalMemory) governance.HumanApprover {
+	c.approver.memory = mem
+	return c.approver
+}
+
+// SetPreApprovalHook registers a callback invoked by Ask immediately
+// before sending the approval card. The message handler uses this to
+// finish the current streaming reply (finish=true), because WeCom
+// rejects aibot_send_msg while a stream is open in the same chat
+// (errcode 6000 "data version conflict").
+func (c *Channel) SetPreApprovalHook(fn func()) {
+	c.approver.preApprovalMu.Lock()
+	c.approver.preApproval = fn
+	c.approver.preApprovalMu.Unlock()
+}
+
+// Ask implements governance.HumanApprover. It sends an approval card to
+// the WeCom chat and blocks until the user responds (or ctx is
+// cancelled).
+func (a *wecomApprover) Ask(ctx context.Context, call openagent.ToolCall, def openagent.FunctionDefinition, session openagent.Session) (governance.Decision, error) {
+	if a.ch == nil {
+		return governance.Decision{Action: governance.Deny, Reason: "approval channel not ready"}, nil
+	}
+
+	chatID := chatIDFromSession(session.ID)
+	if chatID == "" {
+		return governance.Decision{Action: governance.Deny, Reason: "cannot determine chat ID from session"}, nil
+	}
+
+	approvalID := newApprovalID()
+	toolName := def.Name
+	args := call.Function.Arguments
+	toolTitle := opentool.ToolTitle(toolName, args)
+
+	// Finish the current streaming reply before sending the approval
+	// card — WeCom rejects aibot_send_msg while a stream is open
+	// (errcode 6000 "data version conflict").
+	a.preApprovalMu.Lock()
+	hook := a.preApproval
+	a.preApprovalMu.Unlock()
+	if hook != nil {
+		hook()
+	}
+
+	cardJSON, err := buildApprovalCard(approvalID, toolTitle)
+	if err != nil {
+		return governance.Decision{Action: governance.Deny, Reason: "build approval card: " + err.Error()}, nil
+	}
+
+	if err := a.ch.SendTemplateCard(chatID, cardJSON); err != nil {
+		return governance.Decision{Action: governance.Deny, Reason: "send approval card: " + err.Error()}, nil
+	}
+
+	resultCh := make(chan approvalResult, 1)
+	entry := &pendingApproval{
+		result:    resultCh,
+		toolName:  toolName,
+		args:      args,
+		toolTitle: toolTitle,
+		sessionID: session.ID,
+	}
+
+	a.mu.Lock()
+	a.pending[approvalID] = entry
+	a.mu.Unlock()
+
+	defer func() {
+		a.mu.Lock()
+		delete(a.pending, approvalID)
+		a.mu.Unlock()
+	}()
+
+	select {
+	case <-ctx.Done():
+		return governance.Decision{Action: governance.Deny, Reason: "approval cancelled: " + ctx.Err().Error()}, nil
+	case r := <-resultCh:
+		switch r.action {
+		case "allow":
+			return governance.Decision{Action: governance.Allow, Reason: "approved by user"}, nil
+		default:
+			return governance.Decision{Action: governance.Deny, Reason: r.reason}, nil
+		}
+	}
+}
+
+// handleCardEvent processes a template_card_event callback. It resolves
+// the pending approval and sends the updated card via
+// aibot_respond_update_msg (echoing the event callback's req_id). The
+// WS event is acked with pong by the caller (handleFrame) before this
+// is called.
+//
+// reqID is the event callback's req_id — echoed in the update frame.
+func (a *wecomApprover) handleCardEvent(reqID string, ev *TemplateCardEvent) {
+	if ev == nil || ev.TaskID == "" {
+		slog.Warn("wecom: template card event missing task_id")
+		return
+	}
+
+	approvalID := ev.TaskID
+
+	a.mu.Lock()
+	entry, ok := a.pending[approvalID]
+	if ok {
+		delete(a.pending, approvalID)
+	}
+	a.mu.Unlock()
+
+	if !ok {
+		slog.Warn("wecom: approval not found or already resolved", "approval_id", approvalID)
+		return
+	}
+
+	var r approvalResult
+	switch ev.EventKey {
+	case "allow_once":
+		r = approvalResult{action: "allow"}
+	case "allow_always":
+		r = approvalResult{action: "allow"}
+		a.rememberAllowAlways(entry)
+	case "deny":
+		r = approvalResult{action: "deny", reason: "rejected by user"}
+	default:
+		slog.Warn("wecom: unknown approval action", "action", ev.EventKey)
+		return
+	}
+
+	// Non-blocking send: Ask is waiting on this channel.
+	select {
+	case entry.result <- r:
+	default:
+	}
+
+	// Send the updated card via aibot_respond_update_msg.
+	resolvedCard, err := buildResolvedCard(approvalID, entry.toolTitle, r.action)
+	if err != nil {
+		slog.Warn("wecom: build resolved card", "error", err)
+		return
+	}
+	if err := a.ch.UpdateTemplateCard(reqID, resolvedCard); err != nil {
+		slog.Warn("wecom: update resolved card", "error", err)
+	}
+}
+
+// rememberAllowAlways persists the approval decision for the session so
+// the same tool+args won't ask again (ACP "Allow Always" semantics).
+func (a *wecomApprover) rememberAllowAlways(entry *pendingApproval) {
+	if a.memory == nil {
+		return
+	}
+	d := governance.Decision{Action: governance.Allow}
+	keys := governance.MemoryKeys(entry.toolName, json.RawMessage(entry.args))
+	if len(keys) == 0 {
+		keys = []string{governance.ApprovalKey(entry.toolName, json.RawMessage(entry.args))}
+	}
+	for _, key := range keys {
+		if err := a.memory.Remember(context.Background(), entry.sessionID, key, d); err != nil {
+			slog.Warn("wecom: approve always persistence failed", "session", entry.sessionID, "error", err)
+		}
+	}
+}
+
+// chatIDFromSession extracts the WeCom chat ID from a session ID.
+// Channel session IDs follow the convention "wecom_<chatID>".
+func chatIDFromSession(sessionID string) string {
+	prefix := "wecom_"
+	if strings.HasPrefix(sessionID, prefix) {
+		return strings.TrimPrefix(sessionID, prefix)
+	}
+	return sessionID
+}

--- a/channel/wecom/protocol.go
+++ b/channel/wecom/protocol.go
@@ -74,16 +74,30 @@ type TextBody struct {
 // EventCallbackBody is the aibot_event_callback payload (interaction
 // events: enter_chat, template_card clicks, ...).
 type EventCallbackBody struct {
-	MsgID    string   `json:"msgid"`
-	BotID    string   `json:"aibotid"`
-	From     MsgFrom  `json:"from"`
-	MsgType  string   `json:"msgtype"`
-	Event    EventObj `json:"event"`
+	MsgID      string    `json:"msgid"`
+	BotID      string    `json:"aibotid"`
+	ChatID     string    `json:"chatid,omitempty"`
+	ChatType   string    `json:"chattype,omitempty"`
+	CreateTime int64     `json:"create_time,omitempty"`
+	From       MsgFrom   `json:"from"`
+	MsgType    string    `json:"msgtype"`
+	Event      EventObj  `json:"event"`
 }
 
-// EventObj carries the event discriminator.
+// EventObj carries the event discriminator and optional template card
+// event payload.
 type EventObj struct {
-	EventType string `json:"eventtype"`
+	EventType         string               `json:"eventtype"`
+	TemplateCardEvent *TemplateCardEvent   `json:"template_card_event,omitempty"`
+}
+
+// TemplateCardEvent is the payload carried by a template_card_event
+// callback — fired when a user clicks a button on a button_interaction
+// (or vote/multiple_interaction) template card.
+type TemplateCardEvent struct {
+	CardType string `json:"card_type"`
+	EventKey string `json:"event_key"`
+	TaskID   string `json:"task_id"`
 }
 
 // StreamReplyBody is the aibot_respond_msg payload for a streaming text
@@ -164,4 +178,22 @@ type SendMediaMsgBody struct {
 	Image   *MediaContent `json:"image,omitempty"`
 	Voice   *MediaContent `json:"voice,omitempty"`
 	Video   *VideoContent `json:"video,omitempty"`
+}
+
+// SendTemplateCardMsgBody is the aibot_send_msg payload for a
+// template_card message (e.g. button_interaction approval card).
+type SendTemplateCardMsgBody struct {
+	ChatID       string          `json:"chatid"`
+	MsgType      string          `json:"msgtype"`
+	TemplateCard json.RawMessage `json:"template_card"`
+}
+
+// UpdateTemplateCardBody is the aibot_respond_update_msg payload for
+// updating a template card after a user interaction. The req_id of the
+// frame must echo the event callback's req_id. Per the WeCom long-
+// connection docs (path/101463), the body uses response_type (not
+// msgtype) and does NOT carry userids.
+type UpdateTemplateCardBody struct {
+	ResponseType string          `json:"response_type"`
+	TemplateCard json.RawMessage `json:"template_card"`
 }

--- a/channel/wecom/wecom.go
+++ b/channel/wecom/wecom.go
@@ -44,12 +44,16 @@ type Channel struct {
 
 	pending   map[string]chan Frame // req_id → response (upload acks)
 	pendingMu sync.Mutex
+
+	approver *wecomApprover
 }
 
 // New returns a WeCom Channel bound to the robot credentials. Must be
 // started via Start().
 func New(botID, secret string) *Channel {
-	return &Channel{botID: botID, secret: secret, pending: make(map[string]chan Frame)}
+	ch := &Channel{botID: botID, secret: secret, pending: make(map[string]chan Frame)}
+	ch.approver = newWecomApprover(ch)
+	return ch
 }
 
 // SetOnReady registers the ready callback (nil clears it). Fired once
@@ -232,10 +236,27 @@ func (c *Channel) handleFrame(raw []byte, handler channel.MessageHandler) error 
 		return nil
 
 	case cmdEventCallback:
-		// v1: acknowledge interaction events (enter_chat etc.) without
-		// acting on them. Acknowledging keeps the server's state clean.
-		slog.Debug("wecom: event callback", "req_id", f.Headers.ReqID, "body", string(f.Body))
-		return c.writeJSON(Frame{Cmd: cmdPong, Headers: FrameHeaders{ReqID: f.Headers.ReqID}})
+		// Always ack with pong first (keeps the server's state clean).
+		_ = c.writeJSON(Frame{Cmd: cmdPong, Headers: FrameHeaders{ReqID: f.Headers.ReqID}})
+
+		var body EventCallbackBody
+		if err := json.Unmarshal(f.Body, &body); err != nil {
+			slog.Warn("wecom: event_callback decode failed", "body", string(f.Body))
+			return nil
+		}
+		if body.Event.EventType == "template_card_event" && body.Event.TemplateCardEvent != nil {
+			ev := body.Event.TemplateCardEvent
+			slog.Info("wecom: template card event",
+				"task_id", ev.TaskID, "event_key", ev.EventKey, "card_type", ev.CardType,
+				"from", body.From.UserID, "req_id", f.Headers.ReqID)
+			if c.approver != nil {
+				// Card update goes via aibot_respond_update_msg (WS).
+				c.approver.handleCardEvent(f.Headers.ReqID, ev)
+			}
+		} else {
+			slog.Debug("wecom: event callback (non-card)", "eventtype", body.Event.EventType, "req_id", f.Headers.ReqID)
+		}
+		return nil
 
 	case cmdPing:
 		// Answer pings immediately (keep-alive from the server side).
@@ -313,7 +334,9 @@ func (c *Channel) buildReply(reqID string, cb *MsgCallbackBody) channel.ReplyFun
 			if err := c.writeJSON(Frame{Cmd: cmdRespondMsg, Headers: FrameHeaders{ReqID: reqID}, Body: mustJSON(body)}); err != nil {
 				return "", err
 			}
-			return streamID, nil
+			finishedID := streamID
+			streamID = "" // reset: next call creates a fresh stream
+			return finishedID, nil
 		}
 		if streamID == "" {
 			streamID = newReqID()
@@ -479,6 +502,35 @@ func (c *Channel) SendMediaMessage(chatID, mediaType, mediaID string) error {
 		return fmt.Errorf("wecom: unknown media type %q", mediaType)
 	}
 	return c.writeJSON(Frame{Cmd: cmdSendMsg, Headers: FrameHeaders{ReqID: newReqID()},
+		Body: mustJSON(body)})
+}
+
+// SendTemplateCard proactively sends a template_card message via
+// aibot_send_msg. Used by the approver to send the approval card.
+// Blocks until the server acks the send — a failure (e.g. duplicate
+// task_id, errcode 42014) is returned so Ask can fail fast instead of
+// blocking forever.
+func (c *Channel) SendTemplateCard(chatID string, cardJSON json.RawMessage) error {
+	body := SendTemplateCardMsgBody{
+		ChatID:       chatID,
+		MsgType:      "template_card",
+		TemplateCard: cardJSON,
+	}
+	_, err := c.sendAndWait(Frame{Cmd: cmdSendMsg, Headers: FrameHeaders{ReqID: newReqID()},
+		Body: mustJSON(body)})
+	return err
+}
+
+// UpdateTemplateCard updates an existing template card via
+// aibot_respond_update_msg. reqID must echo the event callback's
+// req_id. Used by the approver to show the resolved state after a
+// button click.
+func (c *Channel) UpdateTemplateCard(reqID string, cardJSON json.RawMessage) error {
+	body := UpdateTemplateCardBody{
+		ResponseType: "update_template_card",
+		TemplateCard: cardJSON,
+	}
+	return c.writeJSON(Frame{Cmd: cmdRespondUpdateMsg, Headers: FrameHeaders{ReqID: reqID},
 		Body: mustJSON(body)})
 }
 

--- a/cmd/cli/server/wecom_manager.go
+++ b/cmd/cli/server/wecom_manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/yusheng-g/openagent-go/channel"
 	"github.com/yusheng-g/openagent-go/channel/wecom"
 	"github.com/yusheng-g/openagent-go/cmd/cli/config"
+	"github.com/yusheng-g/openagent-go/governance"
 	"github.com/yusheng-g/openagent-go/kernel"
 	"github.com/yusheng-g/openagent-go/session"
 	opentool "github.com/yusheng-g/openagent-go/tool"
@@ -230,6 +231,10 @@ func (m *WecomManager) startConnection(lock *ChannelLock, creds *wecom.BotCreds)
 		if m.workDir != "" {
 			deps.Tools = append(deps.Tools, wecom.NewSendFile(ch, m.workDir))
 		}
+		mem := governance.NewSessionApprovalMemory()
+		deps.HumanApprover = ch.Approver(mem)
+		deps.ApprovalMemory = mem
+		slog.Info("channel approver enabled", "channel", "wecom")
 
 		everReady := false
 		ch.SetOnReady(func() {
@@ -246,7 +251,7 @@ func (m *WecomManager) startConnection(lock *ChannelLock, creds *wecom.BotCreds)
 				m.setStatus(clirest.WecomStatus{Phase: clirest.WecomDisconnected, BotID: creds.BotID, LastError: err.Error()}, connDone)
 			}
 		})
-		err := ch.Start(connCtx, wecomMessageHandler(m.cfg, deps, m.metaStore))
+		err := ch.Start(connCtx, wecomMessageHandler(m.cfg, deps, m.metaStore, ch))
 		lock.Release()
 		// Publish before the cleanup (guard semantics — see FeishuManager).
 		m.setStatus(clirest.WecomStatus{Phase: clirest.WecomDisconnected, BotID: creds.BotID, LastError: errString(err)}, connDone)
@@ -365,7 +370,7 @@ func (m *WecomManager) SetCredentials(botID, secret string) error {
 // grows in place (finish=false refreshes → finish=true ends), throttled
 // to ~1 refresh/second so the user sees the answer build up without
 // spamming. req_id is echoed verbatim (the reply func captures it).
-func wecomMessageHandler(cfg *agent.Agent, deps kernel.Deps, metaStore session.Store) channel.MessageHandler {
+func wecomMessageHandler(cfg *agent.Agent, deps kernel.Deps, metaStore session.Store, ch *wecom.Channel) channel.MessageHandler {
 	return func(msgCtx context.Context, msg channel.IncomingMessage, reply channel.ReplyFunc) {
 		sessionID := "wecom_" + msg.ChatID
 		ensureChannelMeta(metaStore, sessionID, "wecom", msg.Text)
@@ -383,10 +388,10 @@ func wecomMessageHandler(cfg *agent.Agent, deps kernel.Deps, metaStore session.S
 				CreatedAt: time.Now(),
 				Metadata:  wecom.ReceiveMetadata(msg),
 			}
-			stream := kernel.New(cfg, deps).RunStream(msgCtx, session, openagent.UserMessage(msg.Text))
 
 			var b strings.Builder
 			var streamID string
+			var lastDisplay string
 			sentLen := 0
 			lastFlush := time.Now()
 			hasText := false
@@ -401,14 +406,27 @@ func wecomMessageHandler(cfg *agent.Agent, deps kernel.Deps, metaStore session.S
 				} else {
 					_, _ = reply(msgCtx, channel.ReplyMessage{UpdateID: streamID, Text: text})
 				}
+				lastDisplay = text
 				sentLen = b.Len()
 				lastFlush = time.Now()
 			}
 
-			// Thinking placeholder — gives immediate feedback before the
-			// LLM produces its first token (typically 1-2s).
-			streamID, _ = reply(msgCtx, channel.ReplyMessage{Text: "🤔 思考中..."})
-			lastFlush = time.Now()
+			// Register a pre-approval hook: when the approver is about
+			// to send the approval card, finish the current streaming
+			// reply first. WeCom rejects aibot_send_msg while a stream
+			// is open (errcode 6000). After the hook fires, streamID
+			// is cleared so the next flush starts a fresh stream.
+			ch.SetPreApprovalHook(func() {
+				if streamID != "" {
+					_, _ = reply(msgCtx, channel.ReplyMessage{UpdateID: wecom.FinishMarker, Text: lastDisplay})
+					streamID = ""
+					sentLen = 0
+					hasText = false
+					b.Reset()
+				}
+			})
+
+			stream := kernel.New(cfg, deps).RunStream(msgCtx, session, openagent.UserMessage(msg.Text))
 
 			for evt := range stream {
 				switch evt.Type {
@@ -431,6 +449,7 @@ func wecomMessageHandler(cfg *agent.Agent, deps kernel.Deps, metaStore session.S
 							display += "\n\n" + hint + "..."
 						}
 						_, _ = reply(msgCtx, channel.ReplyMessage{UpdateID: streamID, Text: display})
+						lastDisplay = display
 						lastFlush = time.Now()
 					}
 				case openagent.StreamError:

--- a/kernel/run.go
+++ b/kernel/run.go
@@ -145,7 +145,7 @@ func (rt *Runtime) run(ctx context.Context, session openagent.Session, prefix []
 				// Best-effort: keep the existing working set. The hard
 				// window check below surfaces any overflow (fail-loud).
 			} else {
-				workingMessages = messages
+				workingMessages = ctxpkg.TrimOrphanToolCalls(messages)
 				rt.compressed = ci.compressed
 				if ci.err != nil {
 					slog.Error("openagent: tool-turn compaction failed", "error", ci.err)


### PR DESCRIPTION
Add governance.HumanApprover for the WeCom channel:
- wecomApprover sends a button_interaction template card (允许/始终允许/拒绝) when the policy engine routes a tool call to the human layer
- template_card_event callbacks dispatched to approver, which resolves the pending approval and updates the card via aibot_respond_update_msg (correct body format: response_type, not msgtype)
- Pre-approval hook finishes the current streaming reply before sending the card (WeCom rejects aibot_send_msg while a stream is open, 6000)
- buildReply resets streamID after finish so post-approval stream works
- lastDisplay tracked so finished stream retains content (no blank bubble)
- task_id generated as approval_<timestamp>_<random> for cross-restart uniqueness (WeCom rejects duplicate task_ids, 42014)
- SendTemplateCard uses sendAndWait to detect send failures (fail fast)
- TrimOrphanToolCalls called in turn > 0 re-compaction to prevent DeepSeek 400 'insufficient tool messages'