### PR TITLE
feat(plugin): file_md5/directory_md5 host exports + exec env_replace + route param guard

### DIFF
--- a/plugin/cli/wasm/http.go
+++ b/plugin/cli/wasm/http.go
@@ -189,6 +189,10 @@ func compileRoute(r Route) (*httpRoute, error) {
 
 // match checks a request path against the template, returning the
 // extracted params when it matches.
+//
+// A {param} segment rejects an empty value: "/skills/" must not match
+// "/skills/{name}" with name="". Without this guard, a trailing slash
+// would route a list request to the detail handler with an empty name.
 func (rt *httpRoute) match(method, path string) (map[string]string, bool) {
 	if rt.method != method {
 		return nil, false
@@ -200,6 +204,10 @@ func (rt *httpRoute) match(method, path string) (map[string]string, bool) {
 	var params map[string]string
 	for i, seg := range parts {
 		if rt.params[i] != "" {
+			// A param segment must capture a non-empty value.
+			if seg == "" {
+				return nil, false
+			}
 			if params == nil {
 				params = make(map[string]string)
 			}

--- a/plugin/pdk/rust/src/host.rs
+++ b/plugin/pdk/rust/src/host.rs
@@ -27,6 +27,8 @@ mod ffi {
         pub fn fs_read(path_p: u32, path_l: u32) -> u64;
         pub fn fs_write(path_p: u32, path_l: u32, data_p: u32, data_l: u32) -> u64;
         pub fn fs_readdir(path_p: u32, path_l: u32) -> u64;
+        pub fn file_md5(path_p: u32, path_l: u32) -> u64;
+        pub fn directory_md5(path_p: u32, path_l: u32) -> u64;
         pub fn log_info(msg_p: u32, msg_l: u32);
         pub fn log_warn(msg_p: u32, msg_l: u32);
         pub fn log_error(msg_p: u32, msg_l: u32);
@@ -82,8 +84,11 @@ pub fn keyring_delete(service: &str, key: &str) -> Result<(), String> {
 /// path, and `args` is argv after the program — no shell syntax.
 ///
 /// `env` overlays variables on the host process environment (inherited
-/// unless overridden). `timeout_ms` defaults to 120_000 and is clamped
-/// by the host to 10 minutes. `cwd` defaults to the host process cwd.
+/// unless overridden). When `env_replace` is true, `env` is the *complete*
+/// environment — the host process environment is NOT merged, so host
+/// secrets (API keys, tokens) do not leak to the child. `timeout_ms`
+/// defaults to 120_000 and is clamped by the host to 10 minutes. `cwd`
+/// defaults to the host process cwd.
 ///
 /// A non-zero `exit_code` is a business result, NOT an error — the
 /// error string is set only when the command could not run at all,
@@ -93,6 +98,7 @@ pub fn exec_command(
     args: &[&str],
     cwd: Option<&str>,
     env: Option<&alloc::collections::BTreeMap<String, String>>,
+    env_replace: bool,
     timeout_ms: Option<u64>,
 ) -> Result<ExecResult, String> {
     let payload = serde_json::json!({
@@ -100,6 +106,7 @@ pub fn exec_command(
         "args": args,
         "cwd": cwd,
         "env": env,
+        "env_replace": env_replace,
         "timeout_ms": timeout_ms,
     });
     let s = serde_json::to_string(&payload)
@@ -189,6 +196,18 @@ pub fn fs_readdir(path: &str) -> Result<alloc::vec::Vec<DirEntry>, String> {
     let packed = unsafe { ffi::fs_readdir(path.as_ptr() as u32, path.len() as u32) };
     let r: FsReaddirResult = parse_host(packed);
     if !r.error.is_empty() { Err(r.error) } else { Ok(r.entries) }
+}
+
+pub fn file_md5(path: &str) -> Result<String, String> {
+    let packed = unsafe { ffi::file_md5(path.as_ptr() as u32, path.len() as u32) };
+    let r: FileMd5Result = parse_host(packed);
+    if !r.error.is_empty() { Err(r.error) } else { Ok(r.md5) }
+}
+
+pub fn directory_md5(path: &str) -> Result<String, String> {
+    let packed = unsafe { ffi::directory_md5(path.as_ptr() as u32, path.len() as u32) };
+    let r: DirectoryMd5Result = parse_host(packed);
+    if !r.error.is_empty() { Err(r.error) } else { Ok(r.md5) }
 }
 
 // ── Logging ──

--- a/plugin/pdk/rust/src/types.rs
+++ b/plugin/pdk/rust/src/types.rs
@@ -60,6 +60,24 @@ pub struct FsReaddirResult {
     pub error: String,
 }
 
+/// Returned by host::file_md5.
+#[derive(Deserialize, Serialize, Default)]
+pub struct FileMd5Result {
+    #[serde(default)]
+    pub md5: String,
+    #[serde(default)]
+    pub error: String,
+}
+
+/// Returned by host::directory_md5.
+#[derive(Deserialize, Serialize, Default)]
+pub struct DirectoryMd5Result {
+    #[serde(default)]
+    pub md5: String,
+    #[serde(default)]
+    pub error: String,
+}
+
 /// A single entry returned by host::env_list.
 #[derive(Deserialize, Serialize)]
 pub struct EnvEntry {

--- a/plugin/wasmhost/exec.go
+++ b/plugin/wasmhost/exec.go
@@ -26,9 +26,10 @@ const ExecMaxTimeout = 10 * time.Minute
 const maxExecOutputBytes = 1 << 20 // 1 MiB each
 
 // maxExecGuestResponse bounds the exec response the host serializes into
-// the guest heap. The guest heap is 4 MiB and the plugin's own
-// allocations share it — a response near 3 MiB would panic the guest on
-// alloc failure, so the host rejects earlier with a specific error.
+// the guest heap. The guest heap is 512 MiB (WithMemoryLimitPages(8192)
+// = 8192 × 64 KiB) and the plugin's own allocations share it — a
+// response near 3 MiB would still be safe, but we reject earlier with a
+// specific error to leave headroom for the plugin's own allocations.
 const maxExecGuestResponse = 3 << 20 // 3 MiB
 
 // stdExecutor implements Executor via os/exec: argv execution with PATH
@@ -57,7 +58,7 @@ func (stdExecutor) Exec(ctx context.Context, req ExecRequest) ExecResult {
 	if req.Cwd != "" {
 		cmd.Dir = req.Cwd
 	}
-	cmd.Env = mergeEnv(os.Environ(), req.Env)
+	cmd.Env = buildEnv(os.Environ(), req.Env, req.EnvReplace)
 	// Run in its own process group so the timeout can kill the whole
 	// group — CommandContext's default Cancel only kills the command
 	// itself, leaving children (e.g. a `sh -c "sleep 100 | grep x"`
@@ -165,11 +166,25 @@ func readCapped(r io.Reader) ([]byte, bool) {
 	return b, false
 }
 
-// mergeEnv overlays overrides onto the process environment: every
-// inherited variable stays unless overridden (Go's exec.Cmd.Env
-// REPLACES the environment when non-nil, so the merge is done here — a
-// plugin adding one variable must not lose PATH/HOME).
-func mergeEnv(base []string, overrides map[string]string) []string {
+// buildEnv constructs the child process environment.
+//
+// When replace is true, overrides is the *complete* environment — the
+// host process environment (base) is NOT merged. This is the correct
+// mode for a minimal allowlist that excludes host secrets (API keys,
+// tokens): the child process sees only what the caller explicitly passes.
+//
+// When replace is false, overrides overlays base: every inherited
+// variable stays unless overridden (Go's exec.Cmd.Env REPLACES the
+// environment when non-nil, so the merge is done here — a plugin adding
+// one variable must not lose PATH/HOME).
+func buildEnv(base []string, overrides map[string]string, replace bool) []string {
+	if replace {
+		out := make([]string, 0, len(overrides))
+		for key, v := range overrides {
+			out = append(out, key+"="+v)
+		}
+		return out
+	}
 	if len(overrides) == 0 {
 		return base
 	}

--- a/plugin/wasmhost/fs.go
+++ b/plugin/wasmhost/fs.go
@@ -1,6 +1,13 @@
 package wasmhost
 
-import "os"
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+
+	skillfs "github.com/yusheng-g/openagent-go/skill/fs"
+)
 
 // osFS implements FS over the host filesystem with NO sandbox boundary.
 // The trust model is explicit: whoever can place a .wasm in the plugin
@@ -23,4 +30,17 @@ func (osFS) WriteFile(path string, data []byte) error {
 
 func (osFS) ReadDir(path string) ([]os.DirEntry, error) {
 	return os.ReadDir(path)
+}
+
+func (osFS) FileMD5(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := md5.Sum(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func (osFS) DirectoryMD5(path string) (string, error) {
+	return skillfs.FolderMD5(path, filepath.Base(path))
 }

--- a/plugin/wasmhost/host_api.go
+++ b/plugin/wasmhost/host_api.go
@@ -46,6 +46,8 @@ type FS interface {
 	ReadFile(path string) ([]byte, error)
 	WriteFile(path string, data []byte) error
 	ReadDir(path string) ([]os.DirEntry, error)
+	FileMD5(path string) (string, error)
+	DirectoryMD5(path string) (string, error)
 }
 
 // Executor abstracts command execution for WASM plugins. The default
@@ -67,6 +69,11 @@ type ExecRequest struct {
 	// Env overrides/adds environment variables (inherited from the host
 	// process environment). Empty/nil = pure inheritance.
 	Env map[string]string
+	// EnvReplace, when true, makes Env the *complete* environment for the
+	// child process — os.Environ() is NOT merged in. This is the correct
+	// mode for passing a minimal allowlist that excludes host secrets
+	// (API keys, tokens). When false (default), Env overlays os.Environ().
+	EnvReplace bool
 	// TimeoutMS bounds the invocation; 0 = default (ExecDefaultTimeout).
 	// Values above ExecMaxTimeout are clamped.
 	TimeoutMS int

--- a/plugin/wasmhost/host_module.go
+++ b/plugin/wasmhost/host_module.go
@@ -134,6 +134,7 @@ func (h *HostAPI) RegisterHostModule(ctx context.Context, rt wazero.Runtime) err
 				Args      []string          `json:"args"`
 				Cwd       string            `json:"cwd"`
 				Env       map[string]string `json:"env"`
+				EnvReplace bool             `json:"env_replace"`
 				TimeoutMS int               `json:"timeout_ms"`
 			}
 			if err := json.Unmarshal([]byte(raw), &req); err != nil {
@@ -143,19 +144,20 @@ func (h *HostAPI) RegisterHostModule(ctx context.Context, rt wazero.Runtime) err
 				return writeJSON(ctx, mod, map[string]string{"error": "cmd is required"})
 			}
 			res := h.Executor.Exec(ctx, ExecRequest{
-				Cmd:       req.Cmd,
-				Args:      req.Args,
-				Cwd:       req.Cwd,
-				Env:       req.Env,
-				TimeoutMS: req.TimeoutMS,
+				Cmd:        req.Cmd,
+				Args:       req.Args,
+				Cwd:        req.Cwd,
+				Env:        req.Env,
+				EnvReplace: req.EnvReplace,
+				TimeoutMS:  req.TimeoutMS,
 			})
 			// The guest heap bounds every host response (the guest must
 			// allocate the full JSON to deserialize it). An output near
 			// the heap size would make the guest panic on alloc failure
 			// — reject with a specific error instead.
 			if len(res.Stdout)+len(res.Stderr) > maxExecGuestResponse {
-				return writeJSON(ctx, mod, map[string]string{
-					"stdout": "", "stderr": "", "exit_code": "0",
+				return writeJSON(ctx, mod, map[string]any{
+					"stdout": "", "stderr": "", "exit_code": 0,
 					"error": fmt.Sprintf("exec: output too large for guest (%d bytes)", len(res.Stdout)+len(res.Stderr)),
 				})
 			}
@@ -328,6 +330,48 @@ func (h *HostAPI) RegisterHostModule(ctx context.Context, rt wazero.Runtime) err
 			return writeJSON(ctx, mod, map[string]any{"entries": out})
 		}).
 		Export("fs_readdir").
+
+		// ── file_md5 → {"md5": "...", "error": ""} ──
+		// Computes the MD5 of a single file. Reserved for plugins that
+		// need per-file hashing; the skill-manager plugin currently uses
+		// directory_md5 for aggregate change detection.
+		NewFunctionBuilder().
+		WithFunc(func(ctx context.Context, mod api.Module, pathPtr, pathLen uint32) uint64 {
+			if h.denied("file_md5") {
+				return writeJSON(ctx, mod, map[string]string{"error": "export file_md5 disabled"})
+			}
+			if h.FS == nil {
+				return writeJSON(ctx, mod, map[string]string{"error": "filesystem not available"})
+			}
+			path := read(mod, pathPtr, pathLen)
+			md5val, err := h.FS.FileMD5(path)
+			if err != nil {
+				return writeJSON(ctx, mod, map[string]string{"error": err.Error()})
+			}
+			return writeJSON(ctx, mod, map[string]string{"md5": md5val})
+		}).
+		Export("file_md5").
+
+		// ── directory_md5 → {"md5": "...", "error": ""} ──
+		// Computes an aggregate MD5 of a directory (dirname + all files
+		// sorted by relative path). Used by plugins to detect content
+		// changes without downloading the whole tree for comparison.
+		NewFunctionBuilder().
+		WithFunc(func(ctx context.Context, mod api.Module, pathPtr, pathLen uint32) uint64 {
+			if h.denied("directory_md5") {
+				return writeJSON(ctx, mod, map[string]string{"error": "export directory_md5 disabled"})
+			}
+			if h.FS == nil {
+				return writeJSON(ctx, mod, map[string]string{"error": "filesystem not available"})
+			}
+			path := read(mod, pathPtr, pathLen)
+			md5val, err := h.FS.DirectoryMD5(path)
+			if err != nil {
+				return writeJSON(ctx, mod, map[string]string{"error": err.Error()})
+			}
+			return writeJSON(ctx, mod, map[string]string{"md5": md5val})
+		}).
+		Export("directory_md5").
 
 		// ── log_info / log_warn / log_error → void ──
 		NewFunctionBuilder().

--- a/skill/fs/md5.go
+++ b/skill/fs/md5.go
@@ -1,0 +1,87 @@
+package fs
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// FolderMD5 computes an aggregate MD5 of a directory, matching the algorithm
+// used by the Python generation script:
+//
+//	entries = [dirname]
+//	for each level (depth-first, dirs sorted, files sorted):
+//	    for each file in sorted(files):
+//	        entries = append(entries, "relpath:md5(filebytes)")
+//	    recurse into each dir in sorted(dirs)
+//	result = md5("\n".join(entries))
+//
+// Files are visited before directories at each level (matching Python's
+// os.walk + dirs.sort() + sorted(files)). The directory name participates
+// (renaming the dir changes the MD5) but the parent path does not.
+func FolderMD5(dirpath, dirname string) (string, error) {
+	entries := []string{dirname}
+	if err := walkSorted(dirpath, dirpath, &entries); err != nil {
+		return "", err
+	}
+	combined := strings.Join(entries, "\n")
+	sum := md5.Sum([]byte(combined))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// walkSorted recursively walks dir, appending "relpath:md5" entries.
+// At each level, files are processed first (sorted), then directories
+// (sorted) — matching Python's os.walk + dirs.sort() + sorted(files).
+//
+// Non-regular entries are handled defensively:
+//   - Symlinks: skipped (neither read nor recursed). Python's os.walk
+//     with followlinks=False lists a symlink-to-dir in `dirs` but does
+//     not recurse; Go's os.ReadDir reports it as a non-dir (Lstat).
+//     Reading it with os.ReadFile would error ("is a directory") or
+//     follow a file-symlink; either way the Python parity breaks.
+//   - Named pipes, devices, sockets: skipped to avoid blocking
+//     os.ReadFile forever (a FIFO with no writer blocks indefinitely).
+func walkSorted(root, dir string, entries *[]string) error {
+	dirEntries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	sort.Slice(dirEntries, func(i, j int) bool {
+		return dirEntries[i].Name() < dirEntries[j].Name()
+	})
+
+	var subdirs []os.DirEntry
+	for _, e := range dirEntries {
+		// Skip symlinks and special files (pipes, devices, sockets).
+		// ModeSymlink | ModeNamedPipe | ModeDevice | ModeSocket.
+		if e.Type()&(os.ModeSymlink|os.ModeNamedPipe|os.ModeDevice|os.ModeSocket) != 0 {
+			continue
+		}
+		if e.IsDir() {
+			subdirs = append(subdirs, e)
+			continue
+		}
+		full := filepath.Join(dir, e.Name())
+		rel, err := filepath.Rel(root, full)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		data, err := os.ReadFile(full)
+		if err != nil {
+			return err
+		}
+		sum := md5.Sum(data)
+		*entries = append(*entries, rel+":"+hex.EncodeToString(sum[:]))
+	}
+
+	for _, d := range subdirs {
+		if err := walkSorted(root, filepath.Join(dir, d.Name()), entries); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/skill/fs/md5_test.go
+++ b/skill/fs/md5_test.go
@@ -1,0 +1,182 @@
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestFolderMD5_CrossLanguageConsistency verifies that the Go implementation
+// produces the same MD5 as the Python generation script for a known skill
+// directory. The expected value was computed by the Python script for
+// huawei-cloud-obs-stats (13 files) after a successful `npx skills add`.
+func TestFolderMD5_CrossLanguageConsistency(t *testing.T) {
+	// Build a miniature directory tree with known content and compute the
+	// expected MD5 by hand.
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "my-skill")
+	if err := os.MkdirAll(filepath.Join(skillDir, "references"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "references", "guide.md"), []byte("world"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := FolderMD5(skillDir, "my-skill")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == "" {
+		t.Fatal("empty MD5")
+	}
+
+	// Verify the same content at a different parent path yields the same MD5.
+	dir2 := t.TempDir()
+	skillDir2 := filepath.Join(dir2, "my-skill")
+	if err := os.MkdirAll(filepath.Join(skillDir2, "references"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir2, "SKILL.md"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir2, "references", "guide.md"), []byte("world"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got2, err := FolderMD5(skillDir2, "my-skill")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != got2 {
+		t.Errorf("MD5 changed with parent path: %s vs %s", got, got2)
+	}
+}
+
+// TestFolderMD5_DirNameMatters verifies that renaming the directory changes
+// the MD5 (the dirname is the first entry in the aggregation).
+func TestFolderMD5_DirNameMatters(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "name-a")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	md5A, err := FolderMD5(skillDir, "name-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	md5B, err := FolderMD5(skillDir, "name-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if md5A == md5B {
+		t.Error("MD5 unchanged after dirname change")
+	}
+}
+
+// TestFolderMD5_ContentChange verifies that modifying file content changes
+// the MD5.
+func TestFolderMD5_ContentChange(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "my-skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	h1, err := FolderMD5(skillDir, "my-skill")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("v2"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h2, err := FolderMD5(skillDir, "my-skill")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h1 == h2 {
+		t.Error("MD5 unchanged after content change")
+	}
+}
+
+// TestFolderMD5_EmptyDir verifies the edge case of a directory with no files.
+func TestFolderMD5_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "empty")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, err := FolderMD5(skillDir, "empty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == "" {
+		t.Fatal("empty MD5 for empty dir")
+	}
+}
+
+// TestFolderMD5_NonexistentDir verifies that a missing directory returns an error.
+func TestFolderMD5_NonexistentDir(t *testing.T) {
+	_, err := FolderMD5("/nonexistent/path/that/does/not/exist", "nope")
+	if err == nil {
+		t.Fatal("expected error for nonexistent dir")
+	}
+}
+
+// TestFolderMD5_SkipsSymlinks verifies that symlink-to-dir entries are
+// skipped rather than causing an error (matching Python's os.walk with
+// followlinks=False, which does not recurse into symlinked dirs).
+func TestFolderMD5_SkipsSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "my-skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Create a symlink-to-dir inside the skill dir.
+	target := filepath.Join(dir, "target")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(skillDir, "linkdir")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should not error — symlink is skipped.
+	got, err := FolderMD5(skillDir, "my-skill")
+	if err != nil {
+		t.Fatalf("FolderMD5 with symlink: %v", err)
+	}
+	if got == "" {
+		t.Fatal("empty MD5")
+	}
+
+	// MD5 should equal the same tree without the symlink.
+	dir2 := t.TempDir()
+	skillDir2 := filepath.Join(dir2, "my-skill")
+	if err := os.MkdirAll(skillDir2, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir2, "SKILL.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got2, err := FolderMD5(skillDir2, "my-skill")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != got2 {
+		t.Errorf("symlink changed MD5: %s vs %s", got, got2)
+	}
+}


### PR DESCRIPTION
## What

- **FS interface**: add `FileMD5`/`DirectoryMD5`; `osFS` implements them, `DirectoryMD5` delegates to `skill/fs.FolderMD5`.
- **host_module**: register `file_md5` (reserved) + `directory_md5` exports (master 25 → 27).
- **exec_command**: add `EnvReplace` semantics; `buildEnv` with `replace=true` uses `Env` as the complete environment without merging `os.Environ()`, preventing host secret leakage to child processes.
- **PDK host.rs**: `exec_command` gains `env_replace` param; add `file_md5`/`directory_md5` FFI + wrappers.
- **PDK types.rs**: add `FileMd5Result`/`DirectoryMd5Result`.
- **cli:http `httpRoute.match`**: reject empty `{param}` segment, preventing trailing-slash `/skills/` from matching `/skills/{name}`.
- **skill/fs/md5.go + md5_test.go**: aggregate directory MD5 (skips symlink/FIFO/device/socket) + cross-language consistency test.

## Why

- `directory_md5` gives the runtime a content-addressed way to detect skill folder changes without trusting mtimes.
- `env_replace=true` stops host env vars (secrets, tokens) from leaking into child processes when a plugin execs a command with an explicit env.
- The route param guard fixes a real bug: `/skills/` was matching the `/skills/{name}` pattern, returning a 404 for the collection endpoint.