### PR TITLE
fix(cli): normalize empty settings.json to {} before unmarshal

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -41,6 +41,9 @@ func main() {
 	if err != nil && !os.IsNotExist(err) {
 		log.Fatalf("read settings: %v", err)
 	}
+	if len(raw) == 0 {
+		raw = []byte("{}")
+	}
 	var preCfg config.Config
 	if err := json.Unmarshal(raw, &preCfg); err != nil {
 		log.Fatalf("parse settings: %v", err)


### PR DESCRIPTION
When settings.json is absent, os.ReadFile returns nil. The IsNotExist guard skipped the read error but the subsequent json.Unmarshal(nil) crashed with 'parse settings: unexpected end of JSON input'. Now raw is normalized to []byte("{}") when empty, matching config.Load and UpdateSettings which already handle the missing-file case.

=================problem solved ===============================
~/.openagent$ openagent --version
parse settings: unexpected end of JSON input
