### PR TITLE
docs: fix README inaccuracies against actual codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ A fully pluggable, multi-agent AI agent framework in Go.
 - **Structured tool results** — `ToolResult` carries content/JSON/error/truncation; oversized output spills to disk automatically (line-wrapped, read/grep-friendly) instead of flooding the model context
 - **Approval policy engine** — layered chain (rules → safety → approval memory → human) with argument editing and persistent "always allow" decisions
 - **Self-evolution** — LLM extractor turns finished runs into durable knowledge, recalled into later sessions
-- **Three-layer memory** — Working (token-driven), Compressed (LLM incremental summary via `summarizer/`), Archive (FTS5/vector searchable, never deleted); all three are provider-pluggable, including a remote OpenViking context database
+- **Three-layer memory** — Working (token-driven), Compressed (LLM incremental summary via `summarizer/`), Archive (vector/keyword searchable, never deleted); all three are provider-pluggable, including a remote OpenViking context database
 - **Sandbox** — native OS-level confinement (Linux bwrap, macOS Seatbelt) for shell, file, and network operations
-- **WASM plugins** — agent-level: `agent:tools` and `agent:observers` plug into the tool/observer pipeline. CLI-level: `cli:settings`, `cli:commands`, `cli:observers` for settings injection, command extension, and lifecycle monitoring
+- **WASM plugins** — agent-level: `agent:tools` and `agent:observers` plug into the tool/observer pipeline. CLI-level: `cli:settings`, `cli:commands`, `cli:observers`, `cli:http` for settings injection, command extension, lifecycle monitoring, and custom HTTP routes. Any plugin can declare cron-scheduled jobs.
 - **Static context profiles** — `AGENTS.md` (working rules) and `SOUL.md` (persona & limits) with user-level and project-level resolution
-- **Slash commands** — built-in `/help`, `/mode`, `/model`, `/context`, `/cwd`, `/clear`, `/rename`, `/sessions`, extensible via `slash/` registry
+- **Slash commands** — built-in `/help`, `/mode`, `/model`, `/compact`, `/context`, `/cwd`, `/clear`, `/rename`, `/sessions`, extensible via `slash/` registry
 - **Full CLI** — `openagent-cli` with cobra commands, config-driven models, keyring secrets, WASM plugin runtime
 - **IM channels** — Feishu/Lark (WebSocket, card-based streaming output with markdown and tool call cards, one-click QR setup, inline approval buttons, /clear and /mode commands), personal WeChat (Tencent ilinkai channel, QR login with pairing code, /clear command), and WeCom 企业微信 (official long connection, native streaming replies, QR robot auto-creation, /clear command)
 - **RunHooks with state** — start/end callbacks share opaque state; OTEL spans nest, slog logs duration
@@ -42,6 +42,19 @@ go build -o openagent-cli ./cmd/cli/
 
 # One-shot chat with streaming output
 ./openagent-cli run "Hello, introduce yourself briefly"
+
+# Enable OS-native sandbox for shell commands
+./openagent-cli serve --sandbox --port 8080
+
+# Toggle capabilities on/off (defaults: memory/summarizer/skills/mcp/embedder on, guard/approver off)
+./openagent-cli serve --guard on --approver on
+
+# Suppress all log output
+./openagent-cli serve -q --port 8080
+
+# Manage secrets in the system keyring
+./openagent-cli keyring set mykey keyvalue
+./openagent-cli keyring get mykey
 ```
 
 ### Configuration
@@ -148,6 +161,7 @@ The Feishu connection is a **process-level daemon** — the frontend only trigge
 | `GET /api/channels/feishu/status` | Connection state (`connected`, `app_id`, `connected_at`) — call on page load, then poll every few seconds |
 | `POST /api/channels/feishu/connect` | Start the connection; with no persisted credentials it starts QR registration and returns `202 {status:"registration", qr_url}` for the frontend to render |
 | `POST /api/channels/feishu/disconnect` | Tear down the connection (releases the machine lock); a later `POST /connect` re-establishes it |
+| `GET /api/channels/feishu/qr` | The registration QR (URL + base64 PNG + remaining lifetime) — re-fetch after a page refresh; `POST /connect` is idempotent while registering and does not re-issue it |
 | `GET /api/settings/channels/feishu` | The feishu configuration (`app_id`, masked `app_secret`) — the secret never leaves the server unmasked |
 | `PUT /api/settings/channels/feishu` | Store the feishu configuration (`{app_id, app_secret}`, empty secret keeps the current one) — written to settings.json, applied on the next connect |
 | `DELETE /api/settings/channels/feishu` | Clear the feishu credentials (a running connection keeps working until the next connect) — the "re-register" flow is DELETE + `POST /connect`, which then has no credentials and runs QR registration |
@@ -322,7 +336,7 @@ stores, policies, hooks, and observers are interfaces injected at assembly.
 
 Plugins are **WASM modules** (.wasm files). Any language that compiles to WASM works — Rust, Go, TypeScript, Zig, etc. The host runtime (wazero) loads and executes them in a sandboxed environment.
 
-A plugin declares its type via metadata. Currently we provide a Rust SDK (`plugin/pdk/rust/`) that wraps the FFI contract, but the ABI is simple enough to implement from any language.
+A plugin declares its type(s) via metadata. A single module can implement multiple types (comma-separated, e.g. `"cli:settings,cli:http"`). We provide a Rust SDK (`plugin/pdk/rust/`, crate `openagent-pdk`) that wraps the FFI contract via the `Plugin` trait + `export!` macro — but the ABI is simple enough to implement from any language.
 
 | Plugin type | What it does |
 |-------------|--------------|
@@ -331,26 +345,31 @@ A plugin declares its type via metadata. Currently we provide a Rust SDK (`plugi
 | `cli:settings` | Transforms `settings.json` at startup (merge env vars, add providers, etc.) |
 | `cli:commands` | Registers extra cobra subcommands into the CLI |
 | `cli:observers` | Monitors CLI command lifecycle (startup/shutdown/command enter/exit) |
+| `cli:http` | Registers custom HTTP routes served at `/api/plugins/<name>/<path>` |
+
+Any plugin type can also declare **cron-scheduled jobs** in its metadata — the host registers them with the scheduler and calls back when they fire.
 
 ### How it works
 
-Each plugin type exposes one or two exported functions:
+Every plugin must export `metadata()` (returns JSON with type, name, description, schedules, routes), `alloc(size)` (host-to-guest memory allocation), and optionally `dealloc(ptr)` (memory reclamation). Each plugin type then adds its own entry-point exports:
 
 | Type | Exports | Signature |
 |------|---------|-----------|
-| `agent:tools` | `openagent_agent_tools()` → JSON | Returns `[{name, description, parameters}]` |
-| | `openagent_execute(name, args)` → string | Called when the agent invokes the tool |
-| `agent:observers` | `openagent_on_stage(event_json)` | Called on each stage enter/leave |
-| `cli:settings` | `openagent_cli_init(settings_json)` → JSON | Returns merged settings |
-| `cli:commands` | `openagent_cli_commands()` → JSON | Returns `[{use, short, long}]` |
-| | `openagent_cli_run(name, args_json)` → string | Called when the command runs |
-| `cli:observers` | `openagent_cli_on_startup()` / `...on_shutdown()` / etc. | Lifecycle callbacks |
+| `agent:tools` | `execute(ptr, len)` → packed JSON | Input: `ToolInput{args}`. Returns `ToolOutput{result, error}`. Tool name/description/parameters come from `metadata()`. |
+| `agent:observers` | `run(ptr, len)` → packed JSON | Input: `StageInput{name, phase, detail, error}`. Returns `StageOutput{action, reason}` — `"continue"` or `"abort"`. |
+| `cli:settings` | `init(ptr, len)` → packed JSON | Input: current settings JSON. Returns merged settings JSON. |
+| `cli:commands` | `commands()` → JSON | Returns `CommandDef[]` (name, use, short, long, args, flags, children, aliases, example). |
+| | `run_<name>(ptr, len)` → packed | One export per leaf command (dashes → underscores). Input: `CommandInput{args, flags}`. |
+| `cli:observers` | `on_startup()` / `on_shutdown()` | No-arg lifecycle callbacks. |
+| | `on_command_start(ptr, len)` / `on_command_end(ptr, len)` | Input: command path string (end includes error suffix). |
+| `cli:http` | `handle_request(ptr, len)` → packed JSON | Input: `HttpRequest{method, path, params, query, headers, body}`. Returns `HttpResp{status, headers, body}`. |
+| Scheduled jobs | `run_scheduled(ptr, len)` → packed JSON | Input: `ScheduledJobInput{id, scheduled_at}`. Returns `ScheduledJobResult{result, error}`. |
 
-The host runtime (wazero + `plugin/wasmhost/`) provides a set of importable host functions (`log_info`, `keyring_get`, `http_request`, `utc_now`, etc.) that plugins can call.
+The host runtime (wazero + `plugin/wasmhost/`) provides 28 importable host functions that plugins can call.
 
 ### Enabling plugins
 
-Place `.wasm` files in a directory and configure it in `settings.json`:
+Place `.wasm` files in a directory (or reference individual files) and configure in `settings.json`:
 
 ```json
 {
@@ -358,7 +377,7 @@ Place `.wasm` files in a directory and configure it in `settings.json`:
 }
 ```
 
-At startup the CLI scans all configured directories for `.wasm` files, reads their metadata, instantiates them, and wires them into the agent or CLI command tree.
+Each entry may be a directory (scanned for `*.wasm`) or a single `.wasm` file path. At startup the CLI reads each module's metadata, instantiates it, and wires it into the agent or CLI.
 
 ### Compiling a plugin (Rust example)
 
@@ -374,7 +393,7 @@ cargo build --release --target wasm32-unknown-unknown
 cp target/wasm32-unknown-unknown/release/example_agent_tool.wasm ~/.openagent/plugins/echo.wasm
 ```
 
-Or use the Makefile:
+Or use the Makefile (builds tool, observer, and envsync examples):
 
 ```bash
 make -C examples/plugin
@@ -383,49 +402,117 @@ make -C examples/plugin
 ### Writing a tool plugin (agent:tools)
 
 ```rust
-use openagent_sdk::tool::{register_tools, ToolDef};
+#![no_std]
+#![no_main]
+extern crate alloc;
+use openagent_pdk::prelude::*;
+use openagent_pdk::export::Plugin;
 
-#[no_mangle]
-pub extern "C" fn openagent_agent_tools() -> *const u8 {
-    register_tools(&[ToolDef {
-        name: "echo",
-        description: "Echo back the input message.",
-        parameters: r#"{"type":"object","properties":{"message":{"type":"string"}},"required":["message"]}"#,
-    }])
+struct EchoPlugin;
+impl Plugin for EchoPlugin {
+    fn plugin_type() -> &'static str { "agent:tools" }
+    fn name() -> &'static str { "echo" }
+    fn description() -> &'static str { "Echo back the input message." }
+    fn tool_parameters() -> Option<&'static str> {
+        Some(r#"{"type":"object","properties":{"message":{"type":"string"}},"required":["message"]}"#)
+    }
+    fn execute(args: &serde_json::Value) -> Result<String, String> {
+        let msg = args.get("message").and_then(|v| v.as_str()).unwrap_or("(empty)");
+        Ok(format!("echo: {}", msg))
+    }
 }
 
-#[no_mangle]
-pub extern "C" fn openagent_execute(name: &str, args: &str) -> String {
-    format!("echo: {}", extract_field(args, "message"))
-}
+openagent_pdk::export!(EchoPlugin);
 ```
 
 ### Writing an observer plugin (agent:observers)
 
 ```rust
-use openagent_sdk::observer::StageEvent;
+#![no_std]
+#![no_main]
+extern crate alloc;
+use openagent_pdk::prelude::*;
+use openagent_pdk::export::Plugin;
 
-#[no_mangle]
-pub extern "C" fn openagent_on_stage(event_json: &str) {
-    let e: StageEvent = serde_json::from_str(event_json).unwrap();
-    if e.phase == "enter" {
-        // log_info is an imported host function
+struct LoggerPlugin;
+impl Plugin for LoggerPlugin {
+    fn plugin_type() -> &'static str { "agent:observers" }
+    fn name() -> &'static str { "observer_logger" }
+    fn stage_filter() -> (&'static str, &'static str) { ("*", "*") }
+
+    fn observe_stage(event: &StageInput) -> StageOutput {
+        host::log_info(&format!("stage={} phase={}", event.name, event.phase));
+        StageOutput { action: String::from("continue"), reason: String::new() }
     }
 }
+
+openagent_pdk::export!(LoggerPlugin);
+```
+
+### Writing a scheduled-job plugin
+
+```rust
+#![no_std]
+#![no_main]
+extern crate alloc;
+use openagent_pdk::prelude::*;
+use openagent_pdk::export::Plugin;
+
+struct EnvSyncPlugin;
+impl Plugin for EnvSyncPlugin {
+    fn name() -> &'static str { "envsync" }
+    fn description() -> &'static str { "Sync keyring secret into env every 5 min" }
+
+    fn scheduled_jobs() -> Vec<ScheduledJob> {
+        vec![ScheduledJob {
+            id: "sync-keyring-env".into(),
+            cron: "*/5 * * * *".into(),
+            description: "sync keyring secret into env".into(),
+        }]
+    }
+
+    fn run_scheduled_job(job: &ScheduledJobInput) -> Result<String, String> {
+        let secret = host::keyring_get("openagent", "PLUGIN_SECRET")?;
+        host::env_set("OPENAGENT_PLUGIN_SECRET", &secret)?;
+        Ok(format!("job {} synced {} bytes", job.id, secret.len()))
+    }
+}
+
+openagent_pdk::export!(EnvSyncPlugin);
 ```
 
 ### Host API (importable from any language)
 
-| Function | Purpose |
-|----------|---------|
-| `log_info(msg)` / `log_warn(msg)` / `log_error(msg)` | Logging through the host |
-| `utc_now() -> i64` | Current time in nanoseconds |
-| `keyring_get(service, key) -> string` | Read from system keyring |
-| `keyring_set(service, key, value)` | Write to system keyring |
-| `keyring_delete(service, key)` | Delete from system keyring |
-| `http_request(method, url, headers_json, body) -> {status, body}` | Outbound HTTP |
+| Category | Function | Purpose |
+|----------|----------|---------|
+| Logging | `log_info(msg)` / `log_warn(msg)` / `log_error(msg)` | Logging through the host |
+| Time | `utc_now() -> u64` | Current time in nanoseconds |
+| Keyring | `keyring_get(service, key) -> string` | Read from system keyring |
+| | `keyring_set(service, key, value)` | Write to system keyring |
+| | `keyring_delete(service, key)` | Delete from system keyring |
+| HTTP | `http_request(method, url, headers_json, body) -> {status, body}` | Outbound HTTP |
+| Process | `exec_command(cmd, args, cwd, env, env_replace, timeout_ms) -> {stdout, stderr, exit_code}` | Run a child process |
+| Env | `env_get(key) -> string` | Read host process env var |
+| | `env_set(key, value)` | Set host process env var |
+| | `env_unset(key)` | Unset host process env var |
+| | `env_list() -> [{key, value}]` | List full host environment |
+| Filesystem | `fs_read(path) -> base64` | Read file as base64 |
+| | `fs_write(path, data)` | Write file |
+| | `fs_readdir(path) -> [{name, is_dir}]` | List directory |
+| | `file_md5(path) -> string` | MD5 hash of a file |
+| | `directory_md5(path) -> string` | Aggregate MD5 of a directory |
+| Runtime | `runtime_session_id() -> string` | Current session ID |
+| | `runtime_user_id() -> string` | Current user ID |
+| | `runtime_turn_count() -> string` | Current turn count |
+| | `runtime_model_id() -> string` | Current model ID |
+| | `runtime_provider() -> string` | Current provider name |
+| | `runtime_get_metadata(key) -> string` | Read session metadata |
+| | `runtime_set_metadata(key, value)` | Write session metadata |
+| | `runtime_set_model_config(json)` | Replace model (provider/model_id/api_key/base_url) |
+| | `runtime_set_system_prompts(json)` | Override system prompts |
+| | `runtime_set_max_turns(n)` | Override max turns |
 
-Full example: `examples/plugin/`. Rust SDK: `plugin/pdk/rust/`.
+Full examples: `examples/plugin/`. Rust SDK: `plugin/pdk/rust/`.
 
 ## Examples
 
@@ -440,19 +527,22 @@ Full example: `examples/plugin/`. Rust SDK: `plugin/pdk/rust/`.
 | `examples/observer/` | Pipeline observer |
 | `examples/delegate/` | Agent as tool delegation |
 | `examples/sandbox/` | Native sandbox tools |
-| `examples/plugin/` | WASM tool + observer plugins |
+| `examples/plugin/` | WASM tool, observer, and scheduled-job plugins |
 | `examples/skill/` | On-demand skill loading |
 | `examples/acp/` | ACP agent protocol (server + client) |
 | `examples/artifact/` | Result policy — large tool results spill to disk |
 | `examples/browser-agent/` | Browser agent via Playwright MCP |
 | `examples/mcp-client/` | MCP client demo (IaC pipeline) |
+| `examples/frontend/` | Vue.js frontend control panel (channel status, settings, QR rendering) |
 | `cmd/cli/` | Full-featured CLI with WASM plugin runtime |
+| `cmd/tui/` | TUI chat client (bubbletea v2, streaming, human-in-the-loop approval) |
 
 ## Packages
 
 | Package | Purpose |
 |---------|---------|
 | `openagent` | Core types — Agent (pure config), Team, ToolResult, token helpers |
+| `agent/` | Agent config builders — options, goal instructions, sub-agent router |
 | `kernel/` | Runtime — the 8-node execution engine (memory → prompt → guard → model → guard → policy → tools → store) |
 | `execution/` | Tool execution — parallel jobs, retry, streaming, result policy |
 | `governance/` | Approval policy engine — rules → safety → memory → human, persistent decisions |
@@ -465,26 +555,36 @@ Full example: `examples/plugin/`. Rust SDK: `plugin/pdk/rust/`.
 | `slash/` | Slash command registry and dispatch |
 | `summarizer/` | LLM-based incremental conversation compression |
 | `session/` | Session store interface + token-budget compression |
-| `session/sqlite/` | SQLite session store |
+| `session/sqlite/` | SQLite session store (FTS5 full-text index) |
 | `session/file/` | File-backed session store |
-| `provider/memory/` | Durable knowledge backends (sqlite, file) |
+| `provider/memory/` | Durable knowledge backends (sqlite with vector recall, file) |
 | `provider/skill/` | On-demand skill matching/loading |
 | `provider/resource/` | External reference resources |
 | `provider/openviking/` | OpenViking context database client (memory/skill/resource over HTTP) |
-| `model/openai/` | OpenAI ChatCompletion + streaming |
+| `model/openai/` | OpenAI ChatCompletion + streaming + embeddings |
+| `embedder/` | Embedding backends — BGE (offline ONNX Runtime) and OpenAI-compatible API |
 | `tokenizer/` | tiktoken model-aware token counting (sampled estimate for huge texts) |
 | `sandbox/native/` | OS-level process confinement (bwrap/Seatbelt) |
 | `eventbus/` | Session-scoped pub/sub for SSE |
-| `plugin/wasmhost/` | Shared WASM host module (keyring, HTTP, logging, utc_now) |
+| `plugin/wasmhost/` | Shared WASM host module (keyring, HTTP, filesystem, env, logging, runtime) |
 | `plugin/agent/wasm/` | Agent-scoped WASM plugin host |
 | `plugin/cli/` | CLI plugin manager and types |
-| `plugin/cli/wasm/` | CLI-scoped WASM runtime, loader, observer hub |
-| `plugin/pdk/rust/` | Rust SDK crate for building WASM plugins |
+| `plugin/cli/wasm/` | CLI-scoped WASM runtime, loader, observer hub, HTTP route dispatcher |
+| `plugin/pdk/rust/` | Rust SDK crate (`openagent-pdk`) for building WASM plugins |
 | `skill/fs/` | Filesystem skill loader |
 | `mcp/` | Model Context Protocol client |
 | `guard/llm/` | LLM-based input/output guard |
 | `hooks/otel/` | OpenTelemetry hooks |
 | `hooks/slog/` | Structured logging hooks |
+| `hooks/redact/` | Masks sensitive env-var values in tool results |
 | `tool/` | Built-in tools (shell, read, write, ls, grep, edit, websearch, webfetch, ACP fs, ACP terminal) |
-| `channel/` | IM platform adapters — Feishu WebSocket, card rendering |
-| `cmd/cli/` | CLI runtime, WASM host, Rust SDK examples |
+| `channel/` | IM platform adapters — Feishu (WebSocket, card rendering), WeChat (ilinkai HTTP), WeCom (长连接 streaming) |
+| `keyring/` | System keychain wrapper (Linux Secret Service/kernel keyring, macOS Keychain, Windows Credential Manager) |
+| `process/` | Background shell-process lifecycle management (track, persist output, kill across turns) |
+| `scheduler/` | Cron-based job scheduling for WASM plugin scheduled tasks |
+| `utils/` | Shared helpers — SSRF-hardened HTTP client, filepath validation, flock, JSON |
+| `iac/` | Terraform wrapper — binary install/mirror management, init/plan/apply/destroy |
+| `version/` | Build-time binary identity (name + version via ldflags) |
+| `cmd/cli/` | CLI runtime, WASM host, REST/ACP server, settings, channel managers |
+| `cmd/tui/` | TUI chat client (bubbletea v2) |
+| `cmd/mcp/` | IaC MCP server — cloud deployment tools (HuaweiCloud, Aliyun) over MCP stdio |

--- a/README.zh.md
+++ b/README.zh.md
@@ -15,11 +15,11 @@
 - **结构化工具结果** — `ToolResult` 携带内容/JSON/错误/截断状态；超长输出自动落盘（按行包装、read/grep 可读），不淹没模型上下文
 - **审批策略引擎** — 分层策略链（规则 → 安全 → 审批记忆 → 人工），支持参数编辑和跨重启的 "始终允许" 决策
 - **自我进化** — LLM 提取器将完成的对话转化为持久知识，在后续会话中召回
-- **三层记忆系统** — Working（token 驱动）、Compressed（LLM 增量摘要，`summarizer/`）、Archive（FTS5/向量检索，永不删除）；三层均可插拔 Provider，含远程 OpenViking 上下文数据库
+- **三层记忆系统** — Working（token 驱动）、Compressed（LLM 增量摘要，`summarizer/`）、Archive（向量/关键词检索，永不删除）；三层均可插拔 Provider，含远程 OpenViking 上下文数据库
 - **沙箱环境** — 原生 OS 级别隔离（Linux bwrap、macOS Seatbelt），安全执行 shell、文件、网络操作
-- **WASM 插件** — Agent 级：`agent:tools` 和 `agent:observers` 接入工具/观测器管线。CLI 级：`cli:settings`、`cli:commands`、`cli:observers`，用于设置注入、命令扩展和生命周期监控
+- **WASM 插件** — Agent 级：`agent:tools` 和 `agent:observers` 接入工具/观测器管线。CLI 级：`cli:settings`、`cli:commands`、`cli:observers`、`cli:http`，用于设置注入、命令扩展、生命周期监控和自定义 HTTP 路由。任意插件均可声明 cron 定时任务。
 - **静态上下文配置** — `AGENTS.md`（工作规则）和 `SOUL.md`（性格与底线），支持用户级和项目级覆盖
-- **Slash 命令** — 内置 `/help`、`/mode`、`/model`、`/context`、`/cwd`、`/clear`、`/rename`、`/sessions`，通过 `slash/` 注册表扩展
+- **Slash 命令** — 内置 `/help`、`/mode`、`/model`、`/compact`、`/context`、`/cwd`、`/clear`、`/rename`、`/sessions`，通过 `slash/` 注册表扩展
 - **完整 CLI** — `openagent-cli`，cobra 命令、配置驱动模型、keyring 密钥管理、WASM 插件运行时
 - **IM 频道** — 飞书/Lark（WebSocket，卡片式流式输出：Markdown 渲染、工具调用卡片，一键扫码创建应用，内嵌审批按钮、/clear 和 /mode 命令）、个人微信（腾讯 ilinkai 官方通道，扫码登录 + 配对码，/clear 命令）、企业微信（官方长连接，原生流式回复，扫码自动创建机器人，/clear 命令）
 - **RunHooks 状态传递** — Start/End 回调共享不透明状态，OTEL 正确嵌套 span，slog 精确计时
@@ -42,6 +42,19 @@ go build -o openagent-cli ./cmd/cli/
 
 # 一次性流式对话
 ./openagent-cli run "你好，请介绍一下你自己"
+
+# 启用 OS 原生沙箱执行 shell 命令
+./openagent-cli serve --sandbox --port 8080
+
+# 按需开关能力（默认：memory/summarizer/skills/mcp/embedder 开，guard/approver 关）
+./openagent-cli serve --guard on --approver on
+
+# 静默所有日志输出
+./openagent-cli serve -q --port 8080
+
+# 管理系统密钥环里
+./openagent-cli keyring set mykey keyvalue
+./openagent-cli keyring get mykey
 ```
 
 ### 配置
@@ -148,6 +161,7 @@ export BOCHA_API_KEY=<你的-key>   # 在 https://open.bochaai.com 获取
 | `GET /api/channels/feishu/status` | 连接状态（`connected`、`app_id`、`connected_at`）——页面加载时调用，之后每几秒轮询 |
 | `POST /api/channels/feishu/connect` | 启动连接；无持久化凭据时触发扫码注册，返回 `202 {status:"registration", qr_url}` 供前端渲染二维码 |
 | `POST /api/channels/feishu/disconnect` | 断开连接（释放机器锁）；之后 `POST /connect` 重新建立 |
+| `GET /api/channels/feishu/qr` | 注册二维码（URL + base64 PNG + 剩余有效期）——刷新页面后重新获取；`POST /connect` 在注册期间幂等，不会重复签发 |
 | `GET /api/settings/channels/feishu` | 飞书配置（`app_id`、脱敏 `app_secret`）——secret 绝不完整出服务端 |
 | `PUT /api/settings/channels/feishu` | 保存飞书配置（`{app_id, app_secret}`，secret 留空 = 保持原值）——写入 settings.json，下次连接生效 |
 | `DELETE /api/settings/channels/feishu` | 清除飞书凭据（运行中的连接继续用旧凭据直到下次连接）——"重新注册"流程 = DELETE + `POST /connect`（此时无凭据，走扫码注册） |
@@ -319,7 +333,7 @@ OpenViking 是一个上下文数据库，提供服务端记忆、技能和资源
 
 插件是 **WASM 模块**（.wasm 文件）。任何能编译到 WASM 的语言都可以 — Rust、Go、TypeScript、Zig 等。宿主运行时（wazero）在沙箱环境中加载和执行它们。
 
-每个插件通过元数据声明自己的类型。目前我们提供了 Rust SDK（`plugin/pdk/rust/`）封装了 FFI 契约，但 ABI 足够简单，任何语言都能直接实现。
+每个插件通过元数据声明自己的类型（可逗号分隔实现多类型，如 `"cli:settings,cli:http"`）。我们提供了 Rust SDK（`plugin/pdk/rust/`，crate 名 `openagent-pdk`），通过 `Plugin` trait + `export!` 宏封装 FFI 契约 — 但 ABI 足够简单，任何语言都能直接实现。
 
 | 插件类型 | 功能 |
 |----------|------|
@@ -328,26 +342,31 @@ OpenViking 是一个上下文数据库，提供服务端记忆、技能和资源
 | `cli:settings` | 启动时转换 settings.json（合并环境变量、添加 provider 等） |
 | `cli:commands` | 注册额外的 cobra 子命令到 CLI |
 | `cli:observers` | 监控 CLI 命令生命周期（启动/关闭/命令 enter/exit） |
+| `cli:http` | 注册自定义 HTTP 路由，服务于 `/api/plugins/<name>/<path>` |
+
+任意插件类型还可声明 **cron 定时任务** — 宿主通过调度器注册，触发时回调插件。
 
 ### 工作原理
 
-每种插件类型暴露一或两个导出函数：
+每个插件必须导出 `metadata()`（返回包含 type、name、description、schedules、routes 的 JSON）、`alloc(size)`（宿主到客端的内存分配）和可选的 `dealloc(ptr)`（内存回收）。各类型再添加自己的入口导出：
 
 | 类型 | 导出函数 | 签名 |
 |------|---------|------|
-| `agent:tools` | `openagent_agent_tools()` → JSON | 返回 `[{name, description, parameters}]` |
-| | `openagent_execute(name, args)` → string | agent 调用工具时执行 |
-| `agent:observers` | `openagent_on_stage(event_json)` | 每个阶段 enter/leave 时调用 |
-| `cli:settings` | `openagent_cli_init(settings_json)` → JSON | 返回合并后的 settings |
-| `cli:commands` | `openagent_cli_commands()` → JSON | 返回 `[{use, short, long}]` |
-| | `openagent_cli_run(name, args_json)` → string | 命令执行时调用 |
-| `cli:observers` | `openagent_cli_on_startup()` / `...on_shutdown()` 等 | 生命周期回调 |
+| `agent:tools` | `execute(ptr, len)` → packed JSON | 输入 `ToolInput{args}`，返回 `ToolOutput{result, error}`。工具名/描述/参数来自 `metadata()`。 |
+| `agent:observers` | `run(ptr, len)` → packed JSON | 输入 `StageInput{name, phase, detail, error}`，返回 `StageOutput{action, reason}` — `"continue"` 或 `"abort"`。 |
+| `cli:settings` | `init(ptr, len)` → packed JSON | 输入当前 settings JSON，返回合并后的 settings。 |
+| `cli:commands` | `commands()` → JSON | 返回 `CommandDef[]`（name、use、short、long、args、flags、children、aliases、example）。 |
+| | `run_<name>(ptr, len)` → packed | 每个叶子命令一个导出（短横线转下划线）。输入 `CommandInput{args, flags}`。 |
+| `cli:observers` | `on_startup()` / `on_shutdown()` | 无参生命周期回调。 |
+| | `on_command_start(ptr, len)` / `on_command_end(ptr, len)` | 输入命令路径字符串（end 含错误后缀）。 |
+| `cli:http` | `handle_request(ptr, len)` → packed JSON | 输入 `HttpRequest{method, path, params, query, headers, body}`，返回 `HttpResp{status, headers, body}`。 |
+| 定时任务 | `run_scheduled(ptr, len)` → packed JSON | 输入 `ScheduledJobInput{id, scheduled_at}`，返回 `ScheduledJobResult{result, error}`。 |
 
-宿主运行时（wazero + `plugin/wasmhost/`）提供了一组可导入的 host 函数（`log_info`、`keyring_get`、`http_request`、`utc_now` 等），插件可以调用。
+宿主运行时（wazero + `plugin/wasmhost/`）提供 28 个可导入的 host 函数供插件调用。
 
 ### 启用插件
 
-将 `.wasm` 文件放入目录并在 `settings.json` 中配置：
+将 `.wasm` 文件放入目录（或直接引用单个文件）并在 `settings.json` 中配置：
 
 ```json
 {
@@ -355,7 +374,7 @@ OpenViking 是一个上下文数据库，提供服务端记忆、技能和资源
 }
 ```
 
-CLI 启动时会扫描所有配置目录下的 `.wasm` 文件，读取元数据、实例化，并接入 agent 或 CLI 命令树。
+每个条目可以是目录（扫描 `*.wasm`）或单个 `.wasm` 文件路径。CLI 启动时读取每个模块的元数据、实例化，并接入 agent 或 CLI。
 
 ### 编译插件（Rust 示例）
 
@@ -371,7 +390,7 @@ cargo build --release --target wasm32-unknown-unknown
 cp target/wasm32-unknown-unknown/release/example_agent_tool.wasm ~/.openagent/plugins/echo.wasm
 ```
 
-或使用 Makefile 一步完成：
+或使用 Makefile 一步完成（构建 tool、observer、envsync 三个示例）：
 
 ```bash
 make -C examples/plugin
@@ -380,47 +399,115 @@ make -C examples/plugin
 ### 编写工具插件 (agent:tools)
 
 ```rust
-use openagent_sdk::tool::{register_tools, ToolDef};
+#![no_std]
+#![no_main]
+extern crate alloc;
+use openagent_pdk::prelude::*;
+use openagent_pdk::export::Plugin;
 
-#[no_mangle]
-pub extern "C" fn openagent_agent_tools() -> *const u8 {
-    register_tools(&[ToolDef {
-        name: "echo",
-        description: "回显输入消息。",
-        parameters: r#"{"type":"object","properties":{"message":{"type":"string"}},"required":["message"]}"#,
-    }])
+struct EchoPlugin;
+impl Plugin for EchoPlugin {
+    fn plugin_type() -> &'static str { "agent:tools" }
+    fn name() -> &'static str { "echo" }
+    fn description() -> &'static str { "回显输入消息。" }
+    fn tool_parameters() -> Option<&'static str> {
+        Some(r#"{"type":"object","properties":{"message":{"type":"string"}},"required":["message"]}"#)
+    }
+    fn execute(args: &serde_json::Value) -> Result<String, String> {
+        let msg = args.get("message").and_then(|v| v.as_str()).unwrap_or("(empty)");
+        Ok(format!("echo: {}", msg))
+    }
 }
 
-#[no_mangle]
-pub extern "C" fn openagent_execute(name: &str, args: &str) -> String {
-    format!("echo: {}", extract_field(args, "message"))
-}
+openagent_pdk::export!(EchoPlugin);
 ```
 
 ### 编写观测器插件 (agent:observers)
 
 ```rust
-use openagent_sdk::observer::StageEvent;
+#![no_std]
+#![no_main]
+extern crate alloc;
+use openagent_pdk::prelude::*;
+use openagent_pdk::export::Plugin;
 
-#[no_mangle]
-pub extern "C" fn openagent_on_stage(event_json: &str) {
-    let e: StageEvent = serde_json::from_str(event_json).unwrap();
-    if e.phase == "enter" {
-        // log_info 是可导入的 host 函数
+struct LoggerPlugin;
+impl Plugin for LoggerPlugin {
+    fn plugin_type() -> &'static str { "agent:observers" }
+    fn name() -> &'static str { "observer_logger" }
+    fn stage_filter() -> (&'static str, &'static str) { ("*", "*") }
+
+    fn observe_stage(event: &StageInput) -> StageOutput {
+        host::log_info(&format!("stage={} phase={}", event.name, event.phase));
+        StageOutput { action: String::from("continue"), reason: String::new() }
     }
 }
+
+openagent_pdk::export!(LoggerPlugin);
+```
+
+### 编写定时任务插件
+
+```rust
+#![no_std]
+#![no_main]
+extern crate alloc;
+use openagent_pdk::prelude::*;
+use openagent_pdk::export::Plugin;
+
+struct EnvSyncPlugin;
+impl Plugin for EnvSyncPlugin {
+    fn name() -> &'static str { "envsync" }
+    fn description() -> &'static str { "每 5 分钟将 keyring 密钥同步到环境变量" }
+
+    fn scheduled_jobs() -> Vec<ScheduledJob> {
+        vec![ScheduledJob {
+            id: "sync-keyring-env".into(),
+            cron: "*/5 * * * *".into(),
+            description: "sync keyring secret into env".into(),
+        }]
+    }
+
+    fn run_scheduled_job(job: &ScheduledJobInput) -> Result<String, String> {
+        let secret = host::keyring_get("openagent", "PLUGIN_SECRET")?;
+        host::env_set("OPENAGENT_PLUGIN_SECRET", &secret)?;
+        Ok(format!("job {} synced {} bytes", job.id, secret.len()))
+    }
+}
+
+openagent_pdk::export!(EnvSyncPlugin);
 ```
 
 ### Host API（任何语言都可调用）
 
-| 函数 | 用途 |
-|------|------|
-| `log_info(msg)` / `log_warn(msg)` / `log_error(msg)` | 通过宿主记录日志 |
-| `utc_now() -> i64` | 当前纳秒时间戳 |
-| `keyring_get(service, key) -> string` | 读取系统密钥环 |
-| `keyring_set(service, key, value)` | 写入系统密钥环 |
-| `keyring_delete(service, key)` | 删除系统密钥环 |
-| `http_request(method, url, headers_json, body) -> {status, body}` | 发送 HTTP 请求 |
+| 类别 | 函数 | 用途 |
+|------|------|------|
+| 日志 | `log_info(msg)` / `log_warn(msg)` / `log_error(msg)` | 通过宿主记录日志 |
+| 时间 | `utc_now() -> u64` | 当前纳秒时间戳 |
+| 密钥环 | `keyring_get(service, key) -> string` | 读取系统密钥环 |
+| | `keyring_set(service, key, value)` | 写入系统密钥环 |
+| | `keyring_delete(service, key)` | 删除系统密钥环 |
+| HTTP | `http_request(method, url, headers_json, body) -> {status, body}` | 发送 HTTP 请求 |
+| 进程 | `exec_command(cmd, args, cwd, env, env_replace, timeout_ms) -> {stdout, stderr, exit_code}` | 执行子进程 |
+| 环境变量 | `env_get(key) -> string` | 读取宿主进程环境变量 |
+| | `env_set(key, value)` | 设置宿主进程环境变量 |
+| | `env_unset(key)` | 删除宿主进程环境变量 |
+| | `env_list() -> [{key, value}]` | 列出完整宿主环境 |
+| 文件系统 | `fs_read(path) -> base64` | 读取文件（base64） |
+| | `fs_write(path, data)` | 写入文件 |
+| | `fs_readdir(path) -> [{name, is_dir}]` | 列出目录 |
+| | `file_md5(path) -> string` | 文件 MD5 哈希 |
+| | `directory_md5(path) -> string` | 目录聚合 MD5 |
+| 运行时 | `runtime_session_id() -> string` | 当前会话 ID |
+| | `runtime_user_id() -> string` | 当前用户 ID |
+| | `runtime_turn_count() -> string` | 当前轮次计数 |
+| | `runtime_model_id() -> string` | 当前模型 ID |
+| | `runtime_provider() -> string` | 当前 provider 名称 |
+| | `runtime_get_metadata(key) -> string` | 读取会话元数据 |
+| | `runtime_set_metadata(key, value)` | 写入会话元数据 |
+| | `runtime_set_model_config(json)` | 替换模型（provider/model_id/api_key/base_url） |
+| | `runtime_set_system_prompts(json)` | 覆盖系统提示词 |
+| | `runtime_set_max_turns(n)` | 覆盖最大轮次 |
 
 完整示例见 `examples/plugin/`。Rust SDK：`plugin/pdk/rust/`。
 
@@ -437,19 +524,22 @@ pub extern "C" fn openagent_on_stage(event_json: &str) {
 | `examples/observer/` | Pipeline 观测器 |
 | `examples/delegate/` | Agent 作为工具委托 |
 | `examples/sandbox/` | 原生沙箱工具 |
-| `examples/plugin/` | WASM 工具 + 观测器插件 |
+| `examples/plugin/` | WASM 工具、观测器、定时任务插件 |
 | `examples/skill/` | 按需加载技能 |
 | `examples/acp/` | ACP agent 协议（server + client） |
 | `examples/artifact/` | 结果策略 — 大型工具结果落盘 |
 | `examples/browser-agent/` | 基于 Playwright MCP 的浏览器 agent |
 | `examples/mcp-client/` | MCP 客户端示例（IaC 流水线） |
+| `examples/frontend/` | Vue.js 前端控制面板（频道状态、设置、二维码渲染） |
 | `cmd/cli/` | 完整 CLI，含 WASM 插件运行时 |
+| `cmd/tui/` | TUI 聊天客户端（bubbletea v2，流式输出，人工审批） |
 
 ## 包
 
 | 包 | 用途 |
 |----|------|
 | `openagent` | 核心类型 — Agent（纯配置）、Team、ToolResult、token 辅助 |
+| `agent/` | Agent 配置构建器 — 选项、目标指令、子 agent 路由 |
 | `kernel/` | Runtime — 8 节点执行引擎（记忆 → 提示词 → 守卫 → 模型 → 守卫 → 策略 → 工具 → 存储） |
 | `execution/` | 工具执行 — 并行任务、重试、流式、结果策略 |
 | `governance/` | 审批策略引擎 — 规则 → 安全 → 记忆 → 人工，持久化决策 |
@@ -462,26 +552,36 @@ pub extern "C" fn openagent_on_stage(event_json: &str) {
 | `slash/` | Slash 命令注册表和分发 |
 | `summarizer/` | 基于 LLM 的增量对话压缩 |
 | `session/` | 会话存储接口 + token 预算压缩 |
-| `session/sqlite/` | SQLite 会话存储 |
+| `session/sqlite/` | SQLite 会话存储（FTS5 全文索引） |
 | `session/file/` | 文件会话存储 |
-| `provider/memory/` | 持久知识后端（sqlite、file） |
+| `provider/memory/` | 持久知识后端（sqlite 向量检索、file） |
 | `provider/skill/` | 按需技能匹配/加载 |
 | `provider/resource/` | 外部参考资料 |
 | `provider/openviking/` | OpenViking 上下文数据库客户端（memory/skill/resource 走 HTTP） |
-| `model/openai/` | OpenAI ChatCompletion + 流式 |
+| `model/openai/` | OpenAI ChatCompletion + 流式 + 向量嵌入 |
+| `embedder/` | 嵌入后端 — BGE（离线 ONNX Runtime）和 OpenAI 兼容 API |
 | `tokenizer/` | tiktoken 模型感知 token 计数（超长文本抽样估算） |
 | `sandbox/native/` | OS 级进程隔离（bwrap/Seatbelt） |
 | `eventbus/` | 会话级发布订阅（SSE） |
-| `plugin/wasmhost/` | 共享 WASM host 模块（keyring、HTTP、日志、utc_now） |
+| `plugin/wasmhost/` | 共享 WASM host 模块（keyring、HTTP、文件系统、env、日志、runtime） |
 | `plugin/agent/wasm/` | Agent 级 WASM 插件宿主 |
 | `plugin/cli/` | CLI 插件管理和类型 |
-| `plugin/cli/wasm/` | CLI 级 WASM 运行时、加载器、observer hub |
-| `plugin/pdk/rust/` | Rust SDK crate，用于构建 WASM 插件 |
+| `plugin/cli/wasm/` | CLI 级 WASM 运行时、加载器、observer hub、HTTP 路由分发 |
+| `plugin/pdk/rust/` | Rust SDK crate（`openagent-pdk`），用于构建 WASM 插件 |
 | `skill/fs/` | 文件系统技能加载器 |
 | `mcp/` | Model Context Protocol 客户端 |
 | `guard/llm/` | 基于 LLM 的输入/输出守卫 |
 | `hooks/otel/` | OpenTelemetry 钩子 |
 | `hooks/slog/` | 结构化日志钩子 |
+| `hooks/redact/` | 工具结果中脱敏环境变量值 |
 | `tool/` | 内置工具 (shell, read, write, ls, grep, edit, websearch, webfetch, ACP fs, ACP terminal) |
-| `channel/` | IM 平台适配器 — 飞书 WebSocket、卡片渲染 |
-| `cmd/cli/` | CLI 运行时、WASM 宿主、Rust SDK 示例 |
+| `channel/` | IM 平台适配器 — 飞书（WebSocket、卡片渲染）、个人微信（ilinkai HTTP）、企业微信（长连接流式） |
+| `keyring/` | 系统密钥环封装（Linux Secret Service/kernel keyring、macOS Keychain、Windows Credential Manager） |
+| `process/` | 后台 shell 进程生命周期管理（跟踪、持久化输出、跨轮次终止） |
+| `scheduler/` | WASM 插件定时任务的 Cron 调度器 |
+| `utils/` | 共享工具 — SSRF 加固 HTTP 客户端、路径校验、flock、JSON |
+| `iac/` | Terraform 封装 — 二进制安装/镜像管理、init/plan/apply/destroy |
+| `version/` | 编译时二进制标识（名称 + 版本，经 ldflags 注入） |
+| `cmd/cli/` | CLI 运行时、WASM 宿主、REST/ACP 服务、设置、频道管理 |
+| `cmd/tui/` | TUI 聊天客户端（bubbletea v2） |
+| `cmd/mcp/` | IaC MCP 服务 — 云部署工具（华为云、阿里云），走 MCP stdio |


### PR DESCRIPTION
- Fix Plugin section: correct export function names (remove nonexistent openagent_* prefixes), update Rust SDK examples to use actual openagent-pdk crate with Plugin trait + export! macro, expand host API table from 8 to 28 functions, add cli:http plugin type and scheduled jobs feature
- Fix three-layer memory: Archive uses vector/keyword search, not FTS5 (FTS5 is in session/sqlite session store)
- Add missing /compact slash command to Features list
- Add GET /api/channels/feishu/qr endpoint to Feishu REST table
- Add undocumented serve flags (--sandbox, capability toggles, -q, keyring)
- Add 11 missing packages to Packages table (embedder, iac, keyring, process, scheduler, utils, version, cmd/mcp, cmd/tui, hooks/redact, agent) and fix channel/model-openai descriptions
- Add examples/frontend/ and cmd/tui/ to Examples table
- Fix plugins config to note single .wasm file paths are also accepted