### PR TITLE
fix(wechat): bump maxQRRefreshCount 3→5 to align with qrCacheTTL

### DIFF
--- a/channel/wechat/login.go
+++ b/channel/wechat/login.go
@@ -196,4 +196,7 @@ func readVerifyCode(ctx context.Context, isRetry bool) (string, error) {
 	return code, nil
 }
 
-const maxQRRefreshCount = 3
+// maxQRRefreshCount bounds QR refreshes before login aborts. Each QR
+// expires after ~120s server-side (measured empirically); 5 × 120 = 600s
+// matches qrCacheTTL so the frontend countdown and abort align.
+const maxQRRefreshCount = 5


### PR DESCRIPTION
Each QR expires after ~120s server-side; 3×120=360s aborted before the 600s frontend countdown ended. 5×120=600s aligns abort with countdown.