### PR TITLE
fix(wechat): single QR with 120s lifetime, no refresh loop

### DIFF
--- a/channel/wechat/login.go
+++ b/channel/wechat/login.go
@@ -23,7 +23,7 @@ type LoginOptions struct {
 	// OnScanned fires when the QR has been scanned — the frontend shows
 	// "scanned, confirm on your phone".
 	OnScanned func()
-	// OnExpired fires when the QR expired and a new one is requested.
+	// OnExpired fires when the QR expired (login will abort).
 	OnExpired func()
 	// OnVerifyCode is called when the server requires a pairing code (the
 	// digits shown in WeChat on the user's phone). isRetry is true when a
@@ -42,8 +42,8 @@ var pollInterval = 2 * time.Second
 //
 // State machine (8 states, polled every 2s): wait → scaned → confirmed;
 // need_verifycode asks the user for the pairing code shown on the phone;
-// verify_code_blocked and expired request a fresh QR (≤ maxQRRefreshCount
-// refreshes); scaned_but_redirect switches the poll host (IDC redirect);
+// verify_code_blocked and expired abort the login (single QR, no refresh);
+// scaned_but_redirect switches the poll host (IDC redirect);
 // binded_redirect reuses the local credentials for an already-bound bot.
 func Login(ctx context.Context, client *protocol.Client, opts LoginOptions) (*protocol.Credentials, error) {
 	baseURL := opts.BaseURL
@@ -59,124 +59,109 @@ func Login(ctx context.Context, client *protocol.Client, opts LoginOptions) (*pr
 		localTokens = []string{opts.LocalCreds.Token}
 	}
 
-	qrRefreshCount := 0
+	qr, err := client.GetQRCode(ctx, baseURL, localTokens)
+	if err != nil {
+		return nil, fmt.Errorf("get qr code: %w", err)
+	}
+	if opts.OnQRURL != nil {
+		opts.OnQRURL(qr.QRCodeImgURL)
+	} else {
+		fmt.Printf("Scan this URL in WeChat: %s\n", qr.QRCodeImgURL)
+	}
+
+	lastStatus := ""
+	currentPollBaseURL := baseURL
+	pendingVerifyCode := ""
+
+	// Poll loop. Each poll is a long request (~35s); a network error is
+	// treated as "still waiting" and retried.
 	for {
-		qrRefreshCount++
-		if qrRefreshCount > maxQRRefreshCount {
-			return nil, fmt.Errorf("qr code expired %d times — login aborted", maxQRRefreshCount)
-		}
-
-		qr, err := client.GetQRCode(ctx, baseURL, localTokens)
+		status, err := client.PollQRStatus(ctx, currentPollBaseURL, qr.QRCode, pendingVerifyCode)
 		if err != nil {
-			return nil, fmt.Errorf("get qr code: %w", err)
-		}
-		if opts.OnQRURL != nil {
-			opts.OnQRURL(qr.QRCodeImgURL)
-		} else {
-			fmt.Printf("Scan this URL in WeChat: %s\n", qr.QRCodeImgURL)
-		}
-
-		lastStatus := ""
-		currentPollBaseURL := baseURL
-		pendingVerifyCode := ""
-
-		// Inner poll loop for one QR. Each poll is a long request (~35s);
-		// a network error is treated as "still waiting" and retried.
-		for {
-			status, err := client.PollQRStatus(ctx, currentPollBaseURL, qr.QRCode, pendingVerifyCode)
-			if err != nil {
-				if ctx.Err() != nil {
-					return nil, ctx.Err()
-				}
-				time.Sleep(pollInterval) // transient — keep waiting
-				continue
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
 			}
+			time.Sleep(pollInterval) // transient — keep waiting
+			continue
+		}
 
-			if status.Status != lastStatus {
-				lastStatus = status.Status
-				switch status.Status {
-				case "scaned":
-					// A pending pairing code that leads back to scaned was
-					// accepted — clear it so subsequent polls are clean.
-					pendingVerifyCode = ""
-					if opts.OnScanned != nil {
-						opts.OnScanned()
-					}
-				case "confirmed":
-					// no callback; handled below
-				case "expired":
-					if opts.OnExpired != nil {
-						opts.OnExpired()
-					}
-				}
-			}
-
+		if status.Status != lastStatus {
+			lastStatus = status.Status
 			switch status.Status {
-			case "confirmed":
-				if status.BotToken == "" || status.BotID == "" || status.UserID == "" {
-					return nil, fmt.Errorf("login confirmed but credentials missing (bot_token=%q bot_id=%q user_id=%q)",
-						status.BotToken, status.BotID, status.UserID)
-				}
-				resolvedBase := baseURL
-				if status.BaseURL != "" {
-					resolvedBase = status.BaseURL
-				}
-				return &protocol.Credentials{
-					Token:     status.BotToken,
-					BaseURL:   resolvedBase,
-					AccountID: status.BotID,
-					UserID:    status.UserID,
-				}, nil
-
-			case "need_verifycode":
-				// The phone shows a pairing code; ask the user and
-				// re-poll immediately with it attached.
-				isRetry := pendingVerifyCode != ""
-				prompt := opts.OnVerifyCode
-				if prompt == nil {
-					prompt = readVerifyCode
-				}
-				code, err := prompt(ctx, isRetry)
-				if err != nil {
-					return nil, fmt.Errorf("read pairing code: %w", err)
-				}
-				pendingVerifyCode = code
-				continue
-
-			case "verify_code_blocked":
-				// Too many wrong pairing codes — the QR is dead; get a
-				// fresh one (counts toward the refresh limit).
+			case "scaned":
+				// A pending pairing code that leads back to scaned was
+				// accepted — clear it so subsequent polls are clean.
 				pendingVerifyCode = ""
-				lastStatus = ""
-				goto newQR
-
-			case "binded_redirect":
-				// The bot is already bound to this client: the existing
-				// session is still valid — reuse the stored credentials
-				// instead of issuing a duplicate.
-				if opts.LocalCreds != nil && opts.LocalCreds.Token != "" {
-					return opts.LocalCreds, nil
+				if opts.OnScanned != nil {
+					opts.OnScanned()
 				}
-				return nil, fmt.Errorf("server reports bot already bound (binded_redirect) but no local credentials were found")
-
-			case "scaned_but_redirect":
-				// IDC redirect: continue polling on the new host.
-				if status.RedirectHost != "" {
-					currentPollBaseURL = "https://" + status.RedirectHost
-				}
-				time.Sleep(pollInterval)
-				continue
-
+			case "confirmed":
+				// no callback; handled below
 			case "expired":
-				lastStatus = ""
-				goto newQR
+				if opts.OnExpired != nil {
+					opts.OnExpired()
+				}
 			}
-
-			time.Sleep(pollInterval)
 		}
 
-	newQR:
-		// Outer loop requests a fresh QR.
+		switch status.Status {
+		case "confirmed":
+			if status.BotToken == "" || status.BotID == "" || status.UserID == "" {
+				return nil, fmt.Errorf("login confirmed but credentials missing (bot_token=%q bot_id=%q user_id=%q)",
+					status.BotToken, status.BotID, status.UserID)
+			}
+			resolvedBase := baseURL
+			if status.BaseURL != "" {
+				resolvedBase = status.BaseURL
+			}
+			return &protocol.Credentials{
+				Token:     status.BotToken,
+				BaseURL:   resolvedBase,
+				AccountID: status.BotID,
+				UserID:    status.UserID,
+			}, nil
+
+		case "need_verifycode":
+			// The phone shows a pairing code; ask the user and
+			// re-poll immediately with it attached.
+			isRetry := pendingVerifyCode != ""
+			prompt := opts.OnVerifyCode
+			if prompt == nil {
+				prompt = readVerifyCode
+			}
+			code, err := prompt(ctx, isRetry)
+			if err != nil {
+				return nil, fmt.Errorf("read pairing code: %w", err)
+			}
+			pendingVerifyCode = code
+			continue
+
+		case "verify_code_blocked":
+			// Too many wrong pairing codes — the QR is dead; abort.
+			return nil, fmt.Errorf("wechat: pairing code blocked — too many wrong attempts")
+
+		case "binded_redirect":
+			// The bot is already bound to this client: the existing
+			// session is still valid — reuse the stored credentials
+			// instead of issuing a duplicate.
+			if opts.LocalCreds != nil && opts.LocalCreds.Token != "" {
+				return opts.LocalCreds, nil
+			}
+			return nil, fmt.Errorf("server reports bot already bound (binded_redirect) but no local credentials were found")
+
+		case "scaned_but_redirect":
+			// IDC redirect: continue polling on the new host.
+			if status.RedirectHost != "" {
+				currentPollBaseURL = "https://" + status.RedirectHost
+			}
+			time.Sleep(pollInterval)
+			continue
+
+		case "expired":
+			return nil, fmt.Errorf("wechat: qr code expired — login aborted")
+		}
+
+		time.Sleep(pollInterval)
 	}
 }
 
@@ -195,8 +180,3 @@ func readVerifyCode(ctx context.Context, isRetry bool) (string, error) {
 	}
 	return code, nil
 }
-
-// maxQRRefreshCount bounds QR refreshes before login aborts. Each QR
-// expires after ~120s server-side (measured empirically); 5 × 120 = 600s
-// matches qrCacheTTL so the frontend countdown and abort align.
-const maxQRRefreshCount = 5

--- a/channel/wechat/login_test.go
+++ b/channel/wechat/login_test.go
@@ -166,72 +166,45 @@ func TestLoginVerifyCodeFlow(t *testing.T) {
 	}
 }
 
-func TestLoginExpiredRefreshes(t *testing.T) {
+func TestLoginExpiredAborts(t *testing.T) {
 	old := pollInterval
 	pollInterval = time.Millisecond
 	defer func() { pollInterval = old }()
 
-	// First QR expires, second QR confirms. Two get_bot_qrcode calls.
-	f := newFakeILink("expired", "confirmed")
-	srv := httptest.NewServer(f.handler())
+	// QR expires — login aborts immediately (no refresh).
+	srv := httptest.NewServer(newFakeILink("expired").handler())
 	defer srv.Close()
 
 	expired := 0
-	creds, err := Login(context.Background(), protocol.NewClient(), LoginOptions{
+	_, err := Login(context.Background(), protocol.NewClient(), LoginOptions{
 		BaseURL:   srv.URL,
 		OnQRURL:   func(string) {},
 		OnExpired: func() { expired++ },
 	})
-	if err != nil {
-		t.Fatal(err)
+	if err == nil {
+		t.Fatal("expected abort on expired")
 	}
 	if expired != 1 {
-		t.Fatalf("OnExpired fired %d times", expired)
-	}
-	if creds.Token != "tok-1" {
-		t.Fatalf("creds = %+v", creds)
+		t.Fatalf("OnExpired fired %d times, want 1", expired)
 	}
 }
 
-func TestLoginTooManyRefreshes(t *testing.T) {
+func TestLoginVerifyCodeBlockedAborts(t *testing.T) {
 	old := pollInterval
 	pollInterval = time.Millisecond
 	defer func() { pollInterval = old }()
 
-	// Every QR expires: maxQRRefreshCount (3) refreshes then abort.
-	statuses := make([]string, 0, maxQRRefreshCount)
-	for i := 0; i < maxQRRefreshCount; i++ {
-		statuses = append(statuses, "expired")
-	}
-	srv := httptest.NewServer(newFakeILink(statuses...).handler())
+	// Too many wrong pairing codes — login aborts (no refresh).
+	srv := httptest.NewServer(newFakeILink("verify_code_blocked").handler())
 	defer srv.Close()
 
-	_, err := Login(context.Background(), protocol.NewClient(), LoginOptions{BaseURL: srv.URL, OnQRURL: func(string) {}})
-	if err == nil {
-		t.Fatal("expected abort after max refreshes")
-	}
-}
-
-func TestLoginVerifyCodeBlockedRefreshes(t *testing.T) {
-	old := pollInterval
-	pollInterval = time.Millisecond
-	defer func() { pollInterval = old }()
-
-	// First QR blocked after repeated mismatches; second QR confirms.
-	f := newFakeILink("verify_code_blocked", "confirmed")
-	srv := httptest.NewServer(f.handler())
-	defer srv.Close()
-
-	creds, err := Login(context.Background(), protocol.NewClient(), LoginOptions{
+	_, err := Login(context.Background(), protocol.NewClient(), LoginOptions{
 		BaseURL:      srv.URL,
 		OnQRURL:      func(string) {},
 		OnVerifyCode: func(context.Context, bool) (string, error) { return "999", nil },
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if creds.Token != "tok-1" {
-		t.Fatalf("creds = %+v", creds)
+	if err == nil {
+		t.Fatal("expected abort on verify_code_blocked")
 	}
 }
 

--- a/cmd/cli/server/wechat_manager.go
+++ b/cmd/cli/server/wechat_manager.go
@@ -134,8 +134,17 @@ func (m *WechatManager) ConnectAsync(onQR func(url string, expireIn int), onScan
 	phase := m.status.Phase
 	m.mu.Unlock()
 	switch phase {
-	case clirest.WechatRegistering, clirest.WechatConnecting, clirest.WechatConnected:
-		return false, nil // login/connection already in flight (idempotent)
+	case clirest.WechatConnecting, clirest.WechatConnected:
+		return false, nil // connection already in flight (idempotent)
+	case clirest.WechatRegistering:
+		// If the QR cache is still valid, the registration is live — idempotent.
+		_, _, expiresAt := loadWechatQR()
+		if expiresAt > 0 && time.Now().Unix() < expiresAt {
+			return false, nil
+		}
+		// QR cache expired — the old registration is stale (the server
+		// hasn't returned "expired" yet). Cancel it and start fresh.
+		m.Disconnect()
 	}
 
 	// Retry-windowed for the same reason as feishu: a disconnect that

--- a/cmd/cli/server/wechat_setup.go
+++ b/cmd/cli/server/wechat_setup.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -49,6 +50,7 @@ func ResolveWechatCredentials(ctx context.Context, localCreds *protocol.Credenti
 	if localCreds != nil {
 		baseURL = localCreds.BaseURL
 	}
+	qrIssuedAt := time.Now()
 	creds, err := wechat.Login(ctx, client, wechat.LoginOptions{
 		BaseURL:    baseURL,
 		LocalCreds: localCreds,
@@ -60,6 +62,7 @@ func ResolveWechatCredentials(ctx context.Context, localCreds *protocol.Credenti
 			if err := saveWechatQR(url, qrCacheTTL); err != nil {
 				fmt.Fprintf(os.Stderr, "wechat: failed to cache QR: %v\n", err)
 			}
+			slog.Debug("wechat: QR code issued", "ttl", qrCacheTTL, "url", url)
 			if onQR != nil {
 				onQR(url, qrCacheTTL)
 				return
@@ -72,6 +75,8 @@ func ResolveWechatCredentials(ctx context.Context, localCreds *protocol.Credenti
 		},
 		OnScanned: onScanned,
 		OnExpired: func() {
+			alive := time.Since(qrIssuedAt).Round(time.Second)
+			slog.Debug("wechat: QR code expired", "alive", alive.String(), "ttl", qrCacheTTL)
 			clearWechatQR()
 		},
 		OnVerifyCode: onVerifyCode,
@@ -95,11 +100,11 @@ func ResolveWechatCredentials(ctx context.Context, localCreds *protocol.Credenti
 	return wc, nil
 }
 
-// qrCacheTTL is the QR cache lifetime used for the expires_in field. The
-// ilinkai protocol does not return an expiry; the cache is only valid
-// while a registration is in flight anyway (phase-guarded), so the TTL
-// is a frontend countdown cap, not a protocol deadline.
-const qrCacheTTL = 600
+// qrCacheTTL is the QR cache lifetime used for the expires_in field. Each
+// QR expires after ~120s server-side (measured empirically); the TTL
+// matches so the frontend countdown aligns with the real deadline. The
+// cache is phase-guarded regardless.
+const qrCacheTTL = 120
 
 // ── QR cache ──
 


### PR DESCRIPTION
The QR refresh loop (max 5 retries) caused the frontend countdown to jump back on each refresh. Remove the outer loop entirely: one QR, 120s validity (matching the server-side expiry), abort on expired or verify_code_blocked. qrCacheTTL aligned 600→120 so the frontend countdown matches the real deadline.