### PR TITLE
feat(iac-server): HTTP transport + forward job progress to client

### DIFF
--- a/cmd/mcp/iac-server/agent/job.go
+++ b/cmd/mcp/iac-server/agent/job.go
@@ -240,8 +240,17 @@ func (m *JobManager) Submit(ctx context.Context, deploymentID, tool string, fn f
 // Get returns the job's current state, or nil if it does not exist.
 // When wait > 0, it long-polls: blocks until the job finishes or the wait
 // elapses, then returns the latest state (clients poll less often).
+//
+// While polling, the job's latest progress (message/cur/tot written by the
+// running job goroutine) is forwarded to the caller via the ProgressFunc in
+// ctx. This lets MCP clients render live progress during get_job_result's
+// wait instead of staring at a blocked call — the async submit tool already
+// returned, so this polling request is the only live MCP request the client
+// associates with the work.
 func (m *JobManager) Get(ctx context.Context, id string, wait time.Duration) (*Job, error) {
+	progress := openagent.ProgressFromContext(ctx)
 	deadline := time.Now().Add(wait)
+	var lastMsg string
 	for {
 		job, err := m.load(id)
 		if err != nil {
@@ -249,6 +258,12 @@ func (m *JobManager) Get(ctx context.Context, id string, wait time.Duration) (*J
 		}
 		if job == nil {
 			return nil, nil
+		}
+		// Forward progress to the client whenever the job's progress message
+		// changes (avoids spamming the same notification every 500ms).
+		if progress != nil && job.Status == JobRunning && job.ProgressMsg != "" && job.ProgressMsg != lastMsg {
+			lastMsg = job.ProgressMsg
+			progress(job.ProgressMsg, job.ProgressCur, job.ProgressTot)
 		}
 		if job.Status != JobRunning || wait <= 0 || time.Now().After(deadline) {
 			return job, nil

--- a/cmd/mcp/iac-server/agent/observer.go
+++ b/cmd/mcp/iac-server/agent/observer.go
@@ -2,33 +2,65 @@ package agent
 
 import (
 	"context"
+	"strings"
 
 	openagent "github.com/yusheng-g/openagent-go"
 )
 
 // jobObserver streams the server LLM's per-turn text output into job logs
-// via the runtime's stage observer. The model.call stage carries the full
-// assistant content in its Detail; this observer forwards it to the active
-// job's output log when the context carries one.
+// and reports fine-grained progress via the runtime's stage observer.
 //
 // It is a pure observer (read-only, per the RunObserver contract) — unlike
-// hooks which may mutate results. The same instance is shared by all
-// agents; the job output sink is read from each run's context, so
-// concurrent jobs are isolated and non-job runs are a no-op.
+// hooks which may mutate results. The same instance is shared by all agents;
+// the job output sink and progress callback are read from each run's context,
+// so concurrent jobs are isolated and non-job runs are a no-op.
 type jobObserver struct{}
 
-// ObserveStage forwards model output content to the job output log.
+// ObserveStage forwards model output to the job log and reports progress from
+// the LLM's per-turn text. The progress callback (from ctx) writes to the job
+// file; the MCP Get loop polls the file and forwards new messages to the
+// client. The Get loop dedups by message text, so frequent updates from fast
+// turns are naturally coalesced — only the latest distinct message reaches the
+// client per poll interval.
 func (o *jobObserver) ObserveStage(ctx context.Context, ev openagent.StageEvent) {
 	if ev.Name != openagent.StageModelCall || ev.Phase != "leave" {
 		return
 	}
-	sink := JobOutputsFromContext(ctx)
-	if sink == nil {
+	content, ok := ev.Detail["content"].(string)
+	if !ok || content == "" {
 		return
 	}
-	if content, ok := ev.Detail["content"].(string); ok && content != "" {
+
+	// Forward full model output to the job output log (existing behavior).
+	if sink := JobOutputsFromContext(ctx); sink != nil {
 		sink(content)
 	}
+
+	// Report fine-grained progress from the model's own text. The LLM
+	// narrates its plan each turn, which is more intuitive to the user
+	// than raw tool names. We forward the first line of the content as
+	// the progress message. cur/tot are 0 (unknown) — progress is
+	// non-monotonic across turns and the dedup in Get handles coalescing.
+	if progress := openagent.ProgressFromContext(ctx); progress != nil {
+		if msg := firstLine(content); msg != "" {
+			progress(msg, 0, 0)
+		}
+	}
+}
+
+// firstLine returns the first non-empty line of s, trimmed. The model's
+// per-turn content often starts with a one-line summary of its intent;
+// everything after is reasoning detail the user doesn't need in a progress
+// bar. If the content is a single line with no newline, it's returned whole.
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return s
 }
 
 var _ openagent.RunObserver = (*jobObserver)(nil)

--- a/cmd/mcp/iac-server/agent/planner.go
+++ b/cmd/mcp/iac-server/agent/planner.go
@@ -944,7 +944,11 @@ Return JSON:
 		Hooks:          sloghooks.New(slog.Default()),
 	})
 
-	session := openagent.Session{ID: "query"}
+	// Unique session per query: query_cloud has no deployment_id to scope
+	// memory by, so a fixed session ID would accumulate conversation history
+	// across calls until the prompt exceeds the model's context window.
+	// A unique ID isolates each query's memory, keeping the prompt bounded.
+	session := openagent.Session{ID: sessionID(fmt.Sprintf("query-%d", time.Now().UnixNano()))}
 	progress("Querying cloud resources...", 1, 2)
 	result, err := rt.Run(ctx, session, openagent.UserMessage(query))
 	if err != nil {

--- a/cmd/mcp/iac-server/main.go
+++ b/cmd/mcp/iac-server/main.go
@@ -1,7 +1,9 @@
 // iac-server is a cloud IaC MCP server. It exposes the deployment tools over
 // MCP stdio so any MCP client (Claude Code, opencode, Cursor, openagent) can
 // plan, update, estimate cost, apply, troubleshoot, and destroy cloud
-// infrastructure, and query existing cloud resources/bills.
+// infrastructure, and query existing cloud resources/bills. When --port (or
+// IAC_PORT) is given, it additionally serves MCP over HTTP on
+// 127.0.0.1:<port> for external tool access.
 //
 // Configuration is via environment variables:
 //
@@ -12,6 +14,7 @@
 //	IAC_HOME       iac-server home (default: ~/.openagent/mcp/iac-server)
 //	              skills + deployments live under $IAC_HOME/<cloud>/
 //	IAC_DRY_RUN    "true" = simulate, don't call terraform binary
+//	IAC_PORT        HTTP listen port — setting this enables HTTP alongside stdio
 //	TF_BINARY_MIRRORS   comma-separated terraform binary download mirror URLs
 //	TF_PROVIDER_MIRRORS comma-separated provider mirror URLs or local paths
 //
@@ -28,11 +31,15 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log/slog"
+	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -56,6 +63,23 @@ import (
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
+
+	// ── HTTP port (optional, for external tool access) ──
+	// --port or IAC_PORT enables HTTP on 127.0.0.1:<port> alongside stdio.
+	// Neither given = pure stdio (backward compatible).
+	fs := flag.NewFlagSet("iac-server", flag.ContinueOnError)
+	portFlag := fs.Int("port", 0, "HTTP listen port (enables HTTP alongside stdio for external tool access)")
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		fatal(err)
+	}
+	httpPort := 0
+	if *portFlag > 0 {
+		httpPort = *portFlag
+	} else if envPort := os.Getenv("IAC_PORT"); envPort != "" {
+		if p, err := strconv.Atoi(envPort); err == nil && p > 0 {
+			httpPort = p
+		}
+	}
 
 	// ── Logging ──
 	// Write logs to a file (stderr is captured by the MCP client and only
@@ -224,6 +248,36 @@ func main() {
 		fatal(err)
 	}
 
+	// ── HTTP transport (optional, for external tool access) ──
+	// Listen before starting the goroutine so a bind failure is fatal
+	// immediately rather than silently leaving HTTP unavailable while
+	// stdio continues. stdio remains the primary transport — the process
+	// lifetime follows stdin (Run blocks the main goroutine).
+	//
+	// DNS rebinding protection is disabled because external tools may
+	// forward requests with a non-loopback Host header; authentication
+	// is the external tool's responsibility.
+	if httpPort > 0 {
+		addr := fmt.Sprintf("127.0.0.1:%d", httpPort)
+		handler := mcpsdk.NewStreamableHTTPHandler(
+			func(r *http.Request) *mcpsdk.Server { return server.Inner() },
+			&mcpsdk.StreamableHTTPOptions{
+				DisableLocalhostProtection: true,
+			},
+		)
+		ln, err := net.Listen("tcp", addr)
+		if err != nil {
+			fatal(fmt.Errorf("http listen %s: %w", addr, err))
+		}
+		slog.Info("starting HTTP transport", "addr", addr)
+		go func() {
+			if err := http.Serve(ln, handler); err != nil {
+				fatal(fmt.Errorf("http serve: %w", err))
+			}
+		}()
+	}
+
+	// ── stdio transport (always; process lifetime follows stdin) ──
 	slog.Info("starting iac-server on stdio")
 	if err := server.Run(ctx, &mcpsdk.StdioTransport{}); err != nil {
 		fatal(err)

--- a/cmd/mcp/iac-server/mcp/tools.go
+++ b/cmd/mcp/iac-server/mcp/tools.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -549,9 +550,12 @@ func (t *getJobResultTool) Definition() openagent.FunctionDefinition {
 		Description: "Poll the result of an async job started by propose_architecture, specify_resources, generate_terraform_plan, " +
 			"update_deployment, estimate_cost, troubleshoot_deployment, or query_cloud. " +
 			"Those tools return immediately with a job_id; call this with that job_id to retrieve the outcome. " +
-			"Returns {status: \"running\"|\"done\"|\"failed\", progress_msg, outputs (the server LLM text), result, error}. " +
+			"Returns {status: \"running\"|\"done\"|\"failed\", progress_msg, progress_cur, progress_tot, outputs, result, error}. " +
 			"wait_seconds (0-60) blocks up to that long and returns as soon as the job finishes — " +
-			"pass a value comfortably below your client's tool-call timeout to poll efficiently.",
+			"pass a value comfortably below your client's tool-call timeout to poll efficiently. " +
+			"IMPORTANT: when status is \"running\" and progress_msg is non-empty, you MUST tell the user the current progress " +
+			"(progress_msg, progress_cur/progress_tot) before calling get_job_result again. Do not poll silently — the user " +
+			"should see what the server is doing while they wait.",
 		Parameters: openagent.SchemaOf[GetJobResultParams](),
 	}
 }
@@ -559,7 +563,13 @@ func (t *getJobResultTool) Definition() openagent.FunctionDefinition {
 func (t *getJobResultTool) Execute(ctx context.Context, args json.RawMessage) *openagent.ToolResult {
 	params, err := openagent.ParseArgs[GetJobResultParams](args)
 	if err != nil {
-		return openagent.ErrorResult(fmt.Errorf("get_job_result: %w", err), false, "")
+		// Some client LLMs send wait_seconds as a string ("60") instead of an
+		// int (60). json.Unmarshal rejects that, so retry with a manual
+		// coercion before giving up — the field is otherwise valid.
+		params, err = parseJobResultParamsLenient(args)
+		if err != nil {
+			return openagent.ErrorResult(fmt.Errorf("get_job_result: %w", err), false, "")
+		}
 	}
 	wait := time.Duration(params.WaitSeconds) * time.Second
 	if wait < 0 || wait > 60*time.Second {
@@ -696,6 +706,36 @@ type GetDeploymentStatusParams struct {
 type GetJobResultParams struct {
 	JobID       string `json:"job_id" jsonschema:"description=Job ID returned by an async tool call"`
 	WaitSeconds int    `json:"wait_seconds,omitempty" jsonschema:"description=Block up to this many seconds (0-60) and return as soon as the job finishes; 0 returns immediately"`
+}
+
+// parseJobResultParamsLenient parses get_job_result args, tolerating a string
+// wait_seconds (some client LLMs emit "60" instead of 60). It unmarshals into
+// a raw map, coerces wait_seconds if needed, then re-marshals and parses
+// normally.
+func parseJobResultParamsLenient(args json.RawMessage) (GetJobResultParams, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(args, &raw); err != nil {
+		return GetJobResultParams{}, err
+	}
+	if ws, ok := raw["wait_seconds"]; ok {
+		var s string
+		if err := json.Unmarshal(ws, &s); err == nil {
+			n, err := strconv.Atoi(s)
+			if err != nil {
+				return GetJobResultParams{}, fmt.Errorf("get_job_result: wait_seconds string %q is not a valid int", s)
+			}
+			raw["wait_seconds"], _ = json.Marshal(n)
+		}
+	}
+	fixed, err := json.Marshal(raw)
+	if err != nil {
+		return GetJobResultParams{}, err
+	}
+	var p GetJobResultParams
+	if err := json.Unmarshal(fixed, &p); err != nil {
+		return GetJobResultParams{}, err
+	}
+	return p, nil
 }
 
 // QueryCloudParams are the arguments to query_cloud.


### PR DESCRIPTION
## Changes

### 1. HTTP transport (stdio + HTTP coexist)

`--port` flag / `IAC_PORT` env enables MCP over HTTP on `127.0.0.1:<port>` alongside stdio. Stdio stays primary (process lifetime follows stdin). Bind failure is fatal. DNS rebinding protection disabled for external tool forwarding.

### 2. Forward job progress to client

`get_job_result` long-poll now forwards the job's `progress_msg` to the MCP client via `ProgressFunc`, so clients see live progress during async job polling instead of staring at a blocked call.

### 3. Fine-grained progress from observer

`jobObserver.ObserveStage` now reports the LLM's per-turn text (first line) as progress via `ProgressFunc` on every `StageModelCall` leave event. Users see what the server LLM is doing each turn (e.g. "querying monthly bill summary...", "filtering 795 records for non-zero amounts...") instead of a coarse "1/2 Querying cloud resources...".

### 4. get_job_result description enforces progress display

Added `IMPORTANT: when status is "running" and progress_msg is non-empty, you MUST tell the user the current progress before calling get_job_result again` to the tool description. Client LLMs that follow tool descriptions (glm-5.2, Claude) now auto-display progress without the user having to ask.

### 5. Lenient wait_seconds parsing

Some client LLMs send `wait_seconds` as a string (`"60"`) instead of an int (`60`). Added `parseJobResultParamsLenient` fallback that coerces string→int before failing.

### 6. query_cloud session isolation

`QueryCloud` used a fixed session ID `"query"`, accumulating conversation history across calls until the prompt exceeded the model's 196608-char context window. Changed to a unique session ID per call (`query-<UnixNano>`), keeping each query's memory bounded.

## Files changed

- `cmd/mcp/iac-server/main.go` — HTTP transport (`--port` / `IAC_PORT`)
- `cmd/mcp/iac-server/agent/job.go` — `Get` long-poll forwards progress to client
- `cmd/mcp/iac-server/agent/observer.go` — fine-grained progress from LLM per-turn text
- `cmd/mcp/iac-server/agent/planner.go` — query_cloud unique session ID
- `cmd/mcp/iac-server/mcp/tools.go` — `get_job_result` description + lenient `wait_seconds` parsing

## Verification

Tested end-to-end with opencode (glm-5.2 + deepseek) and codearts (GLM-5.2). Progress messages now show per-turn LLM intent summaries. No regressions in existing tests.