### PR TITLE
feat(openviking): use type-quota recall endpoint with configurable quotas

### DIFF
--- a/cmd/cli/config/config.go
+++ b/cmd/cli/config/config.go
@@ -50,8 +50,27 @@ type ContextProviderConfig struct {
 // OpenVikingConfig connects to an OpenViking server (direct HTTP API —
 // search/remember/read, no SDK).
 type OpenVikingConfig struct {
-	Endpoint string `json:"endpoint,omitempty"` // e.g. "http://127.0.0.1:1933"
-	APIKey   string `json:"api_key,omitempty"`   // Bearer token; empty = no auth
+	Endpoint string       `json:"endpoint,omitempty"` // e.g. "http://127.0.0.1:1933"
+	APIKey   string       `json:"api_key,omitempty"`   // Bearer token; empty = no auth
+	Recall   RecallConfig `json:"recall,omitempty"`
+}
+
+// RecallConfig controls OpenViking's type-quota memory recall endpoint
+// (POST /api/v1/search/recall). The endpoint searches memory subtrees
+// independently by type then renders a bounded context block — without
+// quotas the recall can return empty or irrelevant results.
+//
+// Quotas caps how many items each memory type contributes. A zero value
+// disables that type. Keys: "events", "entities", "preferences",
+// "experiences". Empty = server defaults (events=10, entities=10,
+// preferences=3, experiences=0).
+//
+// MaxChars bounds the rendered output size. MinScore filters low-relevance
+// hits. Both empty = server defaults (6500 / 0.1).
+type RecallConfig struct {
+	Quotas   map[string]int `json:"quotas,omitempty"`
+	MaxChars int            `json:"max_chars,omitempty"`
+	MinScore float64        `json:"min_score,omitempty"`
 }
 
 // EmbeddingConfig selects the semantic-embedding backend for knowledge

--- a/cmd/cli/server/context_providers_test.go
+++ b/cmd/cli/server/context_providers_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/yusheng-g/openagent-go/cmd/cli/config"
 	"github.com/yusheng-g/openagent-go/kernel"
+	openviking "github.com/yusheng-g/openagent-go/provider/openviking"
 )
 
 // TestApplyContextProviders_EndpointSwitchesAll: a configured OpenViking
@@ -26,6 +27,25 @@ func TestApplyContextProviders_EndpointSwitchesAll(t *testing.T) {
 	}
 	if deps.ResourceProvider == nil {
 		t.Error("resource provider not switched to openviking")
+	}
+	// A bare endpoint (no explicit recall config) still gets the
+	// provider defaults — the provider is the single source of truth.
+	if mem, ok := deps.MemoryProvider.(*openviking.Memory); ok {
+		rc := mem.RecallConfig()
+		if rc.MaxChars != 6500 {
+			t.Errorf("recall max_chars = %d, want 6500", rc.MaxChars)
+		}
+		if rc.MinScore != 0.1 {
+			t.Errorf("recall min_score = %v, want 0.1", rc.MinScore)
+		}
+		if rc.Quotas["events"] != 10 {
+			t.Errorf("recall events quota = %d, want 10", rc.Quotas["events"])
+		}
+		if rc.Quotas["preferences"] != 3 {
+			t.Errorf("recall preferences quota = %d, want 3", rc.Quotas["preferences"])
+		}
+	} else {
+		t.Errorf("memory provider is %T, want *openviking.Memory", deps.MemoryProvider)
 	}
 }
 
@@ -65,3 +85,40 @@ func TestApplyContextProviders_NoEndpoint(t *testing.T) {
 		t.Error("no endpoint must leave all providers nil (local)")
 	}
 }
+
+// TestApplyContextProviders_CustomRecallConfig: a user-configured recall
+// config overrides the defaults and propagates to the provider.
+func TestApplyContextProviders_CustomRecallConfig(t *testing.T) {
+	cfg := &config.Config{
+		OpenViking: config.OpenVikingConfig{
+			Endpoint: "http://127.0.0.1:1933",
+			Recall: config.RecallConfig{
+				Quotas:   map[string]int{"events": 5, "entities": 5, "preferences": 2, "experiences": 1},
+				MaxChars: 4000,
+				MinScore: 0.25,
+			},
+		},
+	}
+	var deps kernel.Deps
+	if err := applyContextProviders(cfg, &deps); err != nil {
+		t.Fatal(err)
+	}
+	mem, ok := deps.MemoryProvider.(*openviking.Memory)
+	if !ok {
+		t.Fatalf("memory provider is %T, want *openviking.Memory", deps.MemoryProvider)
+	}
+	rc := mem.RecallConfig()
+	if rc.MaxChars != 4000 {
+		t.Errorf("recall max_chars = %d, want 4000", rc.MaxChars)
+	}
+	if rc.MinScore != 0.25 {
+		t.Errorf("recall min_score = %v, want 0.25", rc.MinScore)
+	}
+	if rc.Quotas["events"] != 5 {
+		t.Errorf("recall events quota = %d, want 5", rc.Quotas["events"])
+	}
+	if rc.Quotas["experiences"] != 1 {
+		t.Errorf("recall experiences quota = %d, want 1", rc.Quotas["experiences"])
+	}
+}
+

--- a/cmd/cli/server/shared.go
+++ b/cmd/cli/server/shared.go
@@ -148,7 +148,11 @@ func applyContextProviders(cfg *config.Config, deps *kernel.Deps) error {
 		return fmt.Errorf("openviking: %w", err)
 	}
 	if cp.Memory != "builtin" {
-		deps.MemoryProvider = openviking.NewMemory(client)
+		deps.MemoryProvider = openviking.NewMemoryWithRecall(client, openviking.RecallConfig{
+			Quotas:   cfg.OpenViking.Recall.Quotas,
+			MaxChars: cfg.OpenViking.Recall.MaxChars,
+			MinScore: cfg.OpenViking.Recall.MinScore,
+		})
 	}
 	if cp.Skill != "builtin" {
 		deps.SkillProvider = openviking.NewSkill(client, nil)

--- a/provider/openviking/client.go
+++ b/provider/openviking/client.go
@@ -187,6 +187,59 @@ func (c *Client) Search(ctx context.Context, query string, limit int, contextTyp
 	return items, nil
 }
 
+// ── Recall ──
+
+// recallRequest mirrors the POST /api/v1/search/recall request body.
+type recallRequest struct {
+	Query    string         `json:"query"`
+	Quotas   map[string]int `json:"quotas,omitempty"`
+	MaxChars int            `json:"max_chars,omitempty"`
+	MinScore float64        `json:"min_score,omitempty"`
+	Render   bool           `json:"render"`
+}
+
+// recallEntry is one hit in the recall response.
+type recallEntry struct {
+	URI      string  `json:"uri,omitempty"`
+	Score    float64 `json:"score,omitempty"`
+	Type     string  `json:"type,omitempty"`     // events | entities | preferences | experiences
+	Mode     string  `json:"mode,omitempty"`     // full | summary | uri
+	Origin   string  `json:"origin,omitempty"`   // actor_peer | self | other_peer
+	Content  string  `json:"content,omitempty"`
+	Summary  string  `json:"summary,omitempty"`
+	Abstract string  `json:"abstract,omitempty"`
+	Rank     int     `json:"rank,omitempty"`
+}
+
+// recallResult mirrors the /api/v1/search/recall response result.
+type recallResult struct {
+	Entries  []recallEntry `json:"entries,omitempty"`
+	Rendered string        `json:"rendered,omitempty"`
+	Stats    map[string]any `json:"stats,omitempty"`
+}
+
+// Recall runs the server's type-quota memory recall endpoint
+// (POST /api/v1/search/recall). Unlike Search, which does a flat semantic
+// lookup, Recall searches memory subtrees independently by type
+// (events/entities/preferences/experiences), applies per-type quotas, and
+// returns a bounded context block. The caller is responsible for
+// supplying non-zero cfg values (the provider's RecallConfig defaults
+// handle this).
+func (c *Client) Recall(ctx context.Context, query string, cfg RecallConfig) (recallResult, error) {
+	req := recallRequest{
+		Query:    query,
+		Quotas:   cfg.Quotas,
+		MaxChars: cfg.MaxChars,
+		MinScore: cfg.MinScore,
+		Render:   false,
+	}
+	var res recallResult
+	if err := c.doJSON(ctx, http.MethodPost, "/api/v1/search/recall", nil, req, &res); err != nil {
+		return recallResult{}, fmt.Errorf("openviking recall: %w", err)
+	}
+	return res, nil
+}
+
 // ── ListSkills ──
 
 // SkillEntry is one skill in the GET /api/v1/skills catalog listing.

--- a/provider/openviking/memory.go
+++ b/provider/openviking/memory.go
@@ -6,30 +6,103 @@ import (
 	ctxpkg "github.com/yusheng-g/openagent-go/context"
 )
 
-// Memory implements context.MemoryProvider backed by OpenViking's memory
-// index: Recall runs the server's semantic search (find, memory type),
-// Store persists a message via remember.
+// Default recall quotas — match the OpenViking server's DEFAULT_QUOTAS
+// (openviking/retrieve/type_quota_recall.py). Without quotas the recall
+// endpoint can return empty results.
+var defaultRecallQuotas = map[string]int{
+	"events":      10,
+	"entities":    10,
+	"preferences": 3,
+	"experiences": 0,
+}
+
+const (
+	defaultRecallMaxChars = 6500
+	defaultRecallMinScore = 0.1
+)
+
+// RecallConfig is the per-provider recall tuning. Zero values fall back
+// to the defaults above. Mirrors cmd/cli/config.RecallConfig but lives
+// here so the provider is usable without the CLI config package.
+type RecallConfig struct {
+	Quotas   map[string]int
+	MaxChars int
+	MinScore float64
+}
+
+// Memory implements context.MemoryProvider backed by OpenViking's
+// type-quota recall endpoint (POST /api/v1/search/recall).
 type Memory struct {
-	client *Client
+	client    *Client
+	recallCfg RecallConfig
 }
 
-// NewMemory creates the memory provider.
+// NewMemory creates the memory provider with default recall quotas.
 func NewMemory(client *Client) *Memory {
-	return &Memory{client: client}
+	return &Memory{
+		client:    client,
+		recallCfg: RecallConfig{Quotas: cloneQuotas(defaultRecallQuotas), MaxChars: defaultRecallMaxChars, MinScore: defaultRecallMinScore},
+	}
 }
 
-// Recall implements context.MemoryProvider.
+// NewMemoryWithRecall creates the memory provider with a custom recall
+// config. Zero-value fields fall back to the defaults.
+func NewMemoryWithRecall(client *Client, cfg RecallConfig) *Memory {
+	m := NewMemory(client)
+	if cfg.MaxChars > 0 {
+		m.recallCfg.MaxChars = cfg.MaxChars
+	}
+	if cfg.MinScore > 0 {
+		m.recallCfg.MinScore = cfg.MinScore
+	}
+	if cfg.Quotas != nil {
+		m.recallCfg.Quotas = cloneQuotas(cfg.Quotas)
+	}
+	return m
+}
+
+// RecallConfig returns the provider's effective recall configuration.
+// The returned map is a copy so callers cannot mutate the live config.
+func (m *Memory) RecallConfig() RecallConfig {
+	return RecallConfig{
+		Quotas:   cloneQuotas(m.recallCfg.Quotas),
+		MaxChars: m.recallCfg.MaxChars,
+		MinScore: m.recallCfg.MinScore,
+	}
+}
+
+func cloneQuotas(q map[string]int) map[string]int {
+	out := make(map[string]int, len(q))
+	for k, v := range q {
+		out[k] = v
+	}
+	return out
+}
+
+// Recall implements context.MemoryProvider. The limit parameter is
+// ignored — quotas control per-type limits. Content falls back through
+// summary → abstract → uri so a truncated-mode hit still carries text.
 func (m *Memory) Recall(ctx context.Context, scope ctxpkg.ContextScope, query string, limit int) ([]ctxpkg.MemoryEntry, error) {
-	items, err := m.client.Search(ctx, query, limit, "memory")
+	res, err := m.client.Recall(ctx, query, m.recallCfg)
 	if err != nil {
 		return nil, err
 	}
-	entries := make([]ctxpkg.MemoryEntry, 0, len(items))
-	for _, it := range items {
+	entries := make([]ctxpkg.MemoryEntry, 0, len(res.Entries))
+	for _, e := range res.Entries {
+		content := e.Content
+		if content == "" {
+			content = e.Summary
+		}
+		if content == "" {
+			content = e.Abstract
+		}
+		if content == "" {
+			content = e.URI
+		}
 		entries = append(entries, ctxpkg.MemoryEntry{
-			Kind:    ctxpkg.MemoryKind(it.Kind),
-			Content: it.Content,
-			Score:   it.Score,
+			Kind:    ctxpkg.MemoryKind(e.Type),
+			Content: content,
+			Score:   e.Score,
 		})
 	}
 	return entries, nil

--- a/provider/openviking/memory_test.go
+++ b/provider/openviking/memory_test.go
@@ -1,0 +1,237 @@
+package openviking
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	ctxpkg "github.com/yusheng-g/openagent-go/context"
+)
+
+// TestRecall_EndpointAndParsing: the Memory provider calls
+// /api/v1/search/recall (not /search) with the configured quotas, and
+// parses entries into MemoryEntry. Content falls back to summary →
+// abstract → uri when the server returns mode="uri" (no full content).
+func TestRecall_EndpointAndParsing(t *testing.T) {
+	var gotPath string
+	var gotBody recallRequest
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/search/recall", func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		resp := map[string]any{
+			"status": "ok",
+			"result": map[string]any{
+				"entries": []map[string]any{
+					{
+						"uri":     "viking://user/default/memories/preferences/deploy.md",
+						"score":   0.92,
+						"type":    "preferences",
+						"mode":    "full",
+						"content": "I prefer terraform for infrastructure.",
+					},
+					{
+						"uri":     "viking://user/default/memories/events/chat-2024.md",
+						"score":   0.71,
+						"type":    "events",
+						"mode":    "summary",
+						"summary": "Discussed kubectl rollout restart.",
+						"abstract": "kubectl rollout event",
+					},
+					{
+						"uri":     "viking://user/default/memories/entities/port.md",
+						"score":   0.55,
+						"type":    "entities",
+						"mode":    "uri",
+						"abstract": "port 5432",
+					},
+				},
+				"rendered": "",
+				"stats":    map[string]any{},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client, err := NewClient(srv.URL, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mem := NewMemoryWithRecall(client, RecallConfig{
+		Quotas:   map[string]int{"events": 8, "entities": 8, "preferences": 2, "experiences": 0},
+		MaxChars: 3000,
+		MinScore: 0.2,
+	})
+
+	entries, err := mem.Recall(context.Background(), ctxpkg.ContextScope{}, "terraform deploy", 5)
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+
+	if gotPath != "/api/v1/search/recall" {
+		t.Errorf("requested %q, want /api/v1/search/recall", gotPath)
+	}
+	if gotBody.Query != "terraform deploy" {
+		t.Errorf("query = %q, want %q", gotBody.Query, "terraform deploy")
+	}
+	if gotBody.MaxChars != 3000 {
+		t.Errorf("max_chars = %d, want 3000", gotBody.MaxChars)
+	}
+	if gotBody.MinScore != 0.2 {
+		t.Errorf("min_score = %v, want 0.2", gotBody.MinScore)
+	}
+	if gotBody.Render != false {
+		t.Errorf("render = %v, want false (openagent renders itself)", gotBody.Render)
+	}
+	if gotBody.Quotas["preferences"] != 2 {
+		t.Errorf("preferences quota = %d, want 2", gotBody.Quotas["preferences"])
+	}
+	if gotBody.Quotas["events"] != 8 {
+		t.Errorf("events quota = %d, want 8", gotBody.Quotas["events"])
+	}
+
+	if len(entries) != 3 {
+		t.Fatalf("got %d entries, want 3", len(entries))
+	}
+
+	cases := []struct {
+		content string
+		score   float64
+		kind    string
+	}{
+		{"I prefer terraform for infrastructure.", 0.92, "preferences"},
+		{"Discussed kubectl rollout restart.", 0.71, "events"},
+		{"port 5432", 0.55, "entities"},
+	}
+	for i, c := range cases {
+		if entries[i].Content != c.content {
+			t.Errorf("entry[%d] content = %q, want %q", i, entries[i].Content, c.content)
+		}
+		if entries[i].Score != c.score {
+			t.Errorf("entry[%d] score = %v, want %v", i, entries[i].Score, c.score)
+		}
+		if string(entries[i].Kind) != c.kind {
+			t.Errorf("entry[%d] kind = %q, want %q", i, entries[i].Kind, c.kind)
+		}
+	}
+}
+
+// TestRecall_DefaultQuotas: NewMemory (no explicit config) uses the
+// server-default quotas so a bare endpoint produces non-empty results.
+func TestRecall_DefaultQuotas(t *testing.T) {
+	var gotBody recallRequest
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/search/recall", func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "ok",
+			"result": map[string]any{"entries": []any{}, "rendered": "", "stats": map[string]any{}},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client, err := NewClient(srv.URL, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mem := NewMemory(client)
+	_, _ = mem.Recall(context.Background(), ctxpkg.ContextScope{}, "test", 5)
+
+	if gotBody.Quotas["events"] != 10 {
+		t.Errorf("default events quota = %d, want 10", gotBody.Quotas["events"])
+	}
+	if gotBody.Quotas["entities"] != 10 {
+		t.Errorf("default entities quota = %d, want 10", gotBody.Quotas["entities"])
+	}
+	if gotBody.Quotas["preferences"] != 3 {
+		t.Errorf("default preferences quota = %d, want 3", gotBody.Quotas["preferences"])
+	}
+	if gotBody.Quotas["experiences"] != 0 {
+		t.Errorf("default experiences quota = %d, want 0", gotBody.Quotas["experiences"])
+	}
+	if gotBody.MaxChars != 6500 {
+		t.Errorf("default max_chars = %d, want 6500", gotBody.MaxChars)
+	}
+	if gotBody.MinScore != 0.1 {
+		t.Errorf("default min_score = %v, want 0.1", gotBody.MinScore)
+	}
+}
+
+// TestRecall_EmptyEntries: an empty recall result is not an error — the
+// caller (context runtime) treats nil entries as "no memories".
+func TestRecall_EmptyEntries(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/search/recall", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "ok",
+			"result": map[string]any{"entries": []any{}, "rendered": "", "stats": map[string]any{}},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client, err := NewClient(srv.URL, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mem := NewMemory(client)
+	entries, err := mem.Recall(context.Background(), ctxpkg.ContextScope{}, "nothing matches", 5)
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("got %d entries, want 0", len(entries))
+	}
+}
+
+// TestRecall_URIFallback: when the server returns mode="uri" with no
+// content/summary/abstract, the entry's content falls back to the URI so
+// the caller always gets useful text.
+func TestRecall_URIFallback(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/search/recall", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "ok",
+			"result": map[string]any{
+				"entries": []map[string]any{
+					{
+						"uri":  "viking://user/default/memories/entities/redis.md",
+						"score": 0.4,
+						"type": "entities",
+						"mode": "uri",
+					},
+				},
+				"rendered": "",
+				"stats":    map[string]any{},
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client, err := NewClient(srv.URL, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mem := NewMemory(client)
+	entries, err := mem.Recall(context.Background(), ctxpkg.ContextScope{}, "redis", 5)
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+	if entries[0].Content != "viking://user/default/memories/entities/redis.md" {
+		t.Errorf("content = %q, want URI fallback", entries[0].Content)
+	}
+}


### PR DESCRIPTION
Switch OpenViking memory provider from the flat /search endpoint to the dedicated /api/v1/search/recall endpoint, which searches memory subtrees independently by type (events/entities/preferences/experiences) and applies per-type quotas — without quotas the recall can return empty or irrelevant results.

- Add RecallConfig (quotas, max_chars, min_score) to OpenVikingConfig
- Add Client.Recall() calling POST /api/v1/search/recall
- Add NewMemoryWithRecall() constructor; provider owns default quotas (events=10, entities=10, preferences=3, experiences=0, max_chars=6500, min_score=0.1) matching the server defaults
- Entry content falls back content → summary → abstract → uri
- Wire config through applyContextProviders
- Add httptest-based tests for endpoint routing, quotas, fallbacks