### PR TITLE
fix(iac-server): transport mutex, empty-output retry, terraform path validation, longer poll cap

### DIFF
--- a/cmd/mcp/iac-server/agent/job.go
+++ b/cmd/mcp/iac-server/agent/job.go
@@ -10,12 +10,14 @@
 // actual work in a background goroutine.
 //
 // Jobs persist to <workDir>/jobs/job-<id>.json so a server restart does
-// not lose them. Same-deployment jobs supersede: a new submission for a
-// deployment cancels any running job for that deployment (the cancelled
-// job's fn may still be mid-execution — it checks ctx.Err() and returns an
-// interrupted error, but saveDag/saveCost are ctx-unaware so they complete
-// their atomic write before the goroutine exits). Different deployments run
-// in parallel, bounded by a global semaphore.
+// not lose them. Same-deployment jobs from the same MCP session supersede:
+// a new submission from that session cancels any running job for that
+// deployment (the cancelled job's fn may still be mid-execution — it checks
+// ctx.Err() and returns an interrupted error, but saveDag/saveCost are
+// ctx-unaware so they complete their atomic write before the goroutine
+// exits). Cross-session requests for the same deployment are rejected so
+// the second client gets an error instead of silently cancelling the first.
+// Different deployments run in parallel, bounded by a global semaphore.
 package agent
 
 import (
@@ -77,8 +79,9 @@ type Job struct {
 // runningJob tracks a job that has been submitted, with its cancel handle
 // so a newer submission for the same deployment can supersede it.
 type runningJob struct {
-	job    *Job
-	cancel context.CancelFunc
+	job       *Job
+	cancel    context.CancelFunc
+	sessionID string
 }
 
 // JobManager owns job lifecycle: submission, progress, persistence, and
@@ -166,14 +169,23 @@ func (m *JobManager) cleanupStale() {
 // callback (writing to the job file) and a 15-minute deadline; panics are
 // recovered into a failed job.
 //
-// When deploymentID is non-empty, a new submission supersedes any running
-// job for that deployment: the prior job's context is cancelled (so its fn
-// observes ctx.Err() and returns an interrupted error) and is marked
-// cancelled. The new job then acquires the global semaphore and runs. The
-// prior job's goroutine may still be mid-saveDag/saveCost when cancelled —
-// those writes are atomic (tmp+rename) and ctx-unaware, so they complete
-// before the goroutine exits, preventing half-written dag.json/cost.json.
-func (m *JobManager) Submit(ctx context.Context, deploymentID, tool string, fn func(ctx context.Context) (string, error)) (string, error) {
+// When deploymentID is non-empty, the submission is checked against any
+// running job for that deployment:
+//   - Same session (same sessionID): the prior job is superseded — its context
+//     is cancelled so the client's retry acts on the latest request instead of
+//     queueing behind a stale run.
+//   - Different session: the submission is rejected with an error, so the
+//     second client learns the deployment is busy instead of silently
+//     cancelling the first client's work.
+//
+// The sessionID is the MCP session ID (empty for stdio, unique per HTTP
+// connection). An empty deploymentID (propose_architecture, query_cloud) is
+// stateless and bypasses this check entirely.
+//
+// The superseded job's goroutine may still be mid-saveDag/saveCost when
+// cancelled — those writes are atomic (tmp+rename) and ctx-unaware, so they
+// complete before the goroutine exits, preventing half-written files.
+func (m *JobManager) Submit(ctx context.Context, deploymentID, sessionID, tool string, fn func(ctx context.Context) (string, error)) (string, error) {
 	job := &Job{
 		ID:           fmt.Sprintf("job-%d", time.Now().UnixNano()),
 		Tool:         tool,
@@ -189,18 +201,30 @@ func (m *JobManager) Submit(ctx context.Context, deploymentID, tool string, fn f
 	// The submit request's ctx is cancelled when the tool call returns
 	// (which is immediate for async jobs) — the job runs on its own
 	// context, bounded only by JobTimeout, and can be superseded by a
-	// newer submission for the same deployment.
+	// newer same-session submission for the same deployment.
 	runCtx, cancel := context.WithTimeout(context.Background(), JobTimeout)
 
-	// Supersede any prior job for the same deployment: cancel it so the
-	// client's retry/submit always acts on the latest request instead of
-	// queueing behind a stale run. The superseded job reports cancelled.
+	// Register in the running map so done()/fail() can reclaim the cancel
+	// handle (releasing the WithTimeout timer). For non-empty deploymentID,
+	// this also enforces supersede/reject semantics. For empty deploymentID
+	// (propose_architecture, query_cloud), the entry is purely for timer
+	// cleanup — there is no deployment state to conflict over.
 	m.mu.Lock()
-	if prev, ok := m.running[deploymentID]; ok {
-		prev.cancel()
-		m.cancelLocked(prev.job)
+	if deploymentID != "" {
+		if prev, ok := m.running[deploymentID]; ok {
+			if prev.sessionID == sessionID {
+				// Same client retrying: supersede the prior job.
+				prev.cancel()
+				m.cancelLocked(prev.job)
+			} else {
+				// Different client: reject to avoid silent cancellation.
+				m.mu.Unlock()
+				cancel()
+				return "", fmt.Errorf("deployment %q is busy — another session is operating on it; wait for that operation to finish or use a different deployment", deploymentID)
+			}
+		}
 	}
-	m.running[deploymentID] = &runningJob{job: job, cancel: cancel}
+	m.running[deploymentID] = &runningJob{job: job, cancel: cancel, sessionID: sessionID}
 	m.mu.Unlock()
 
 	go func() {

--- a/cmd/mcp/iac-server/agent/job_test.go
+++ b/cmd/mcp/iac-server/agent/job_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestJobManager_BasicDone(t *testing.T) {
 	m := NewJobManager(t.TempDir())
-	id, err := m.Submit(context.Background(), "", "test", func(ctx context.Context) (string, error) {
+	id, err := m.Submit(context.Background(), "", "", "test", func(ctx context.Context) (string, error) {
 		return `{"ok":true}`, nil
 	})
 	if err != nil {
@@ -36,7 +36,7 @@ func TestJobManager_BasicDone(t *testing.T) {
 
 func TestJobManager_Failure(t *testing.T) {
 	m := NewJobManager(t.TempDir())
-	id, _ := m.Submit(context.Background(), "", "test", func(ctx context.Context) (string, error) {
+	id, _ := m.Submit(context.Background(), "", "", "test", func(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("boom")
 	})
 	job, _ := m.Get(context.Background(), id, 5*time.Second)
@@ -50,7 +50,7 @@ func TestJobManager_Failure(t *testing.T) {
 
 func TestJobManager_PanicRecovery(t *testing.T) {
 	m := NewJobManager(t.TempDir())
-	id, _ := m.Submit(context.Background(), "", "test", func(ctx context.Context) (string, error) {
+	id, _ := m.Submit(context.Background(), "", "", "test", func(ctx context.Context) (string, error) {
 		panic("kaboom")
 	})
 	job, _ := m.Get(context.Background(), id, 5*time.Second)
@@ -68,13 +68,13 @@ func TestJobManager_Supersession(t *testing.T) {
 
 	// job1: blocks until we release the barrier
 	barrier := make(chan struct{})
-	id1, _ := m.Submit(context.Background(), dep, "test", func(ctx context.Context) (string, error) {
+	id1, _ := m.Submit(context.Background(), dep, "", "test", func(ctx context.Context) (string, error) {
 		<-barrier
 		return `{"job":1}`, nil
 	})
 
 	// job2 for same dep: should supersede job1
-	id2, _ := m.Submit(context.Background(), dep, "test", func(ctx context.Context) (string, error) {
+	id2, _ := m.Submit(context.Background(), dep, "", "test", func(ctx context.Context) (string, error) {
 		return `{"job":2}`, nil
 	})
 
@@ -105,6 +105,57 @@ func TestJobManager_Supersession(t *testing.T) {
 	}
 }
 
+// TestJobManager_CrossSessionReject verifies that a second session operating
+// on the same deployment is rejected rather than silently superseding the
+// first session's job. Same-session retry still supersedes (tested above).
+func TestJobManager_CrossSessionReject(t *testing.T) {
+	m := NewJobManager(t.TempDir())
+	dep := "d-cross-session"
+
+	// Session A starts a long-running job.
+	barrier := make(chan struct{})
+	idA, err := m.Submit(context.Background(), dep, "session-A", "test", func(ctx context.Context) (string, error) {
+		<-barrier
+		return `{"session":"A"}`, nil
+	})
+	if err != nil {
+		t.Fatalf("session A submit: %v", err)
+	}
+
+	// Session B tries the same deployment — must be rejected.
+	_, err = m.Submit(context.Background(), dep, "session-B", "test", func(ctx context.Context) (string, error) {
+		return `{"session":"B"}`, nil
+	})
+	if err == nil {
+		t.Fatal("session B should be rejected, got nil error")
+	}
+	if !strings.Contains(err.Error(), "busy") {
+		t.Fatalf("error should mention busy, got: %s", err)
+	}
+
+	// Session A retrying (same session ID) should supersede its own prior job.
+	idA2, err := m.Submit(context.Background(), dep, "session-A", "test", func(ctx context.Context) (string, error) {
+		return `{"session":"A-retry"}`, nil
+	})
+	if err != nil {
+		t.Fatalf("session A retry submit: %v", err)
+	}
+
+	// Original job A should be cancelled (superseded by A retry).
+	jobA, _ := m.Get(context.Background(), idA, 2*time.Second)
+	if jobA.Status != JobCancelled {
+		t.Fatalf("job A should be cancelled by same-session retry, got %s", jobA.Status)
+	}
+
+	close(barrier)
+
+	// A retry should complete.
+	jobA2, _ := m.Get(context.Background(), idA2, 5*time.Second)
+	if jobA2.Status != JobDone {
+		t.Fatalf("job A retry should be done, got %s", jobA2.Status)
+	}
+}
+
 // TestJobManager_SupersessionDoneOverwritesCancelled_Bug is an adversarial
 // reproduction of the done()-overwrites-cancelled bug. It deterministically
 // forces the superseded job's fn to return nil error AFTER cancelLocked has
@@ -116,13 +167,13 @@ func TestJobManager_SupersessionDoneOverwritesCancelled_Bug(t *testing.T) {
 	// job1's fn blocks on a channel we control, then returns nil error
 	// (the done path — the one without a JobCancelled guard).
 	release := make(chan struct{})
-	id1, _ := m.Submit(context.Background(), dep, "test", func(ctx context.Context) (string, error) {
+	id1, _ := m.Submit(context.Background(), dep, "", "test", func(ctx context.Context) (string, error) {
 		<-release
 		return `{"job":1}`, nil
 	})
 
 	// job2 supersedes job1 — cancelLocked writes Status=cancelled to disk.
-	id2, _ := m.Submit(context.Background(), dep, "test", func(ctx context.Context) (string, error) {
+	id2, _ := m.Submit(context.Background(), dep, "", "test", func(ctx context.Context) (string, error) {
 		return `{"job":2}`, nil
 	})
 	if id1 == id2 {
@@ -162,7 +213,7 @@ func TestJobManager_ConcurrencyLimit(t *testing.T) {
 	// Submit maxConcurrentJobs+1 jobs with distinct deployments (no supersession).
 	for i := 0; i < maxConcurrentJobs+1; i++ {
 		dep := "d-" + string(rune('a'+i))
-		_, _ = m.Submit(context.Background(), dep, "test", func(ctx context.Context) (string, error) {
+		_, _ = m.Submit(context.Background(), dep, "", "test", func(ctx context.Context) (string, error) {
 			cur := atomic.AddInt32(&active, 1)
 			for {
 				old := atomic.LoadInt32(&maxActive)
@@ -209,7 +260,7 @@ func TestJobManager_ConcurrencyLimit(t *testing.T) {
 func TestJobManager_PersistenceAcrossRestart(t *testing.T) {
 	dir := t.TempDir()
 	m1 := NewJobManager(dir)
-	id, _ := m1.Submit(context.Background(), "", "test", func(ctx context.Context) (string, error) {
+	id, _ := m1.Submit(context.Background(), "", "", "test", func(ctx context.Context) (string, error) {
 		return `{"persist":true}`, nil
 	})
 	job, _ := m1.Get(context.Background(), id, 5*time.Second)
@@ -233,7 +284,7 @@ func TestJobManager_PersistenceAcrossRestart(t *testing.T) {
 
 func TestJobManager_LongPoll(t *testing.T) {
 	m := NewJobManager(t.TempDir())
-	id, _ := m.Submit(context.Background(), "", "test", func(ctx context.Context) (string, error) {
+	id, _ := m.Submit(context.Background(), "", "", "test", func(ctx context.Context) (string, error) {
 		time.Sleep(200 * time.Millisecond)
 		return `{"done":true}`, nil
 	})
@@ -246,7 +297,7 @@ func TestJobManager_LongPoll(t *testing.T) {
 
 func TestJobManager_OutputTruncation(t *testing.T) {
 	m := NewJobManager(t.TempDir())
-	id, _ := m.Submit(context.Background(), "", "test", func(ctx context.Context) (string, error) {
+	id, _ := m.Submit(context.Background(), "", "", "test", func(ctx context.Context) (string, error) {
 		sink := JobOutputsFromContext(ctx)
 		if sink == nil {
 			t.Fatal("output sink should be in ctx")
@@ -329,7 +380,7 @@ func TestJobManager_OrphanedRunningJobAfterCrash(t *testing.T) {
 func TestJobManager_AppliedJobNotResumedOnRestart(t *testing.T) {
 	dir := t.TempDir()
 	m1 := NewJobManager(dir)
-	id, _ := m1.Submit(context.Background(), "", "test", func(ctx context.Context) (string, error) {
+	id, _ := m1.Submit(context.Background(), "", "", "test", func(ctx context.Context) (string, error) {
 		return `{"ok":true}`, nil
 	})
 	j1, _ := m1.Get(context.Background(), id, 5*time.Second)
@@ -433,7 +484,7 @@ func TestJobManager_HighConcurrentDistinctDeployments(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			dep := fmt.Sprintf("d-%03d", i)
-			id, err := m.Submit(context.Background(), dep, "test", func(ctx context.Context) (string, error) {
+			id, err := m.Submit(context.Background(), dep, "", "test", func(ctx context.Context) (string, error) {
 				time.Sleep(10 * time.Millisecond) // simulate work
 				return `{}`, nil
 			})
@@ -467,7 +518,7 @@ func TestCancelLocked_DoesNotOverwriteDone(t *testing.T) {
 	dep := "d-done-then-supersede"
 
 	// job1 completes successfully (done).
-	id1, _ := m.Submit(context.Background(), dep, "test", func(ctx context.Context) (string, error) {
+	id1, _ := m.Submit(context.Background(), dep, "", "test", func(ctx context.Context) (string, error) {
 		return `{"result":"ok"}`, nil
 	})
 	job1, _ := m.Get(context.Background(), id1, 5*time.Second)
@@ -477,7 +528,7 @@ func TestCancelLocked_DoesNotOverwriteDone(t *testing.T) {
 
 	// job2 supersedes job1 — but job1 is already done. cancelLocked must
 	// NOT overwrite job1's status to cancelled.
-	id2, _ := m.Submit(context.Background(), dep, "test", func(ctx context.Context) (string, error) {
+	id2, _ := m.Submit(context.Background(), dep, "", "test", func(ctx context.Context) (string, error) {
 		return `{}`, nil
 	})
 	if id1 == id2 {
@@ -503,7 +554,7 @@ func TestCancelLocked_DoesNotOverwriteFailed(t *testing.T) {
 	m := NewJobManager(t.TempDir())
 	dep := "d-failed-then-supersede"
 
-	id1, _ := m.Submit(context.Background(), dep, "test", func(ctx context.Context) (string, error) {
+	id1, _ := m.Submit(context.Background(), dep, "", "test", func(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("terraform plan failed: provider not found")
 	})
 	job1, _ := m.Get(context.Background(), id1, 5*time.Second)
@@ -512,7 +563,7 @@ func TestCancelLocked_DoesNotOverwriteFailed(t *testing.T) {
 	}
 	wantErr := job1.Error
 
-	id2, _ := m.Submit(context.Background(), dep, "test", func(ctx context.Context) (string, error) {
+	id2, _ := m.Submit(context.Background(), dep, "", "test", func(ctx context.Context) (string, error) {
 		return `{}`, nil
 	})
 	_, _ = m.Get(context.Background(), id2, 5*time.Second)
@@ -537,14 +588,14 @@ func TestRunningMap_ReclaimedAfterDone(t *testing.T) {
 	dep := "d-reclaim"
 
 	// job1 completes.
-	id1, _ := m.Submit(context.Background(), dep, "test", func(ctx context.Context) (string, error) {
+	id1, _ := m.Submit(context.Background(), dep, "", "test", func(ctx context.Context) (string, error) {
 		return `{}`, nil
 	})
 	_, _ = m.Get(context.Background(), id1, 5*time.Second)
 
 	// job2 for the same dep: since job1's entry was reclaimed, there is no
 	// prev to cancel. job1 should still be done (not clobbered).
-	id2, _ := m.Submit(context.Background(), dep, "test", func(ctx context.Context) (string, error) {
+	id2, _ := m.Submit(context.Background(), dep, "", "test", func(ctx context.Context) (string, error) {
 		return `{}`, nil
 	})
 	_, _ = m.Get(context.Background(), id2, 5*time.Second)
@@ -566,7 +617,7 @@ func TestRunningMap_NoUnboundedGrowth(t *testing.T) {
 	var done int32
 	for i := 0; i < N; i++ {
 		dep := fmt.Sprintf("d-%03d", i)
-		_, _ = m.Submit(context.Background(), dep, "test", func(ctx context.Context) (string, error) {
+		_, _ = m.Submit(context.Background(), dep, "", "test", func(ctx context.Context) (string, error) {
 			return `{}`, nil
 		})
 	}
@@ -639,7 +690,7 @@ func BenchmarkJobManager_ConcurrentSubmit(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		dep := fmt.Sprintf("d-%d", i%100) // 100 distinct deployments
 		atomic.AddInt32(&pending, 1)
-		_, err := m.Submit(context.Background(), dep, "bench", func(ctx context.Context) (string, error) {
+		_, err := m.Submit(context.Background(), dep, "", "bench", func(ctx context.Context) (string, error) {
 			defer atomic.AddInt32(&pending, -1)
 			return `{}`, nil
 		})
@@ -669,7 +720,7 @@ func BenchmarkJobManager_SupersededSubmit(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		atomic.AddInt32(&pending, 1)
-		_, err := m.Submit(context.Background(), "d-same", "bench", func(ctx context.Context) (string, error) {
+		_, err := m.Submit(context.Background(), "d-same", "", "bench", func(ctx context.Context) (string, error) {
 			defer atomic.AddInt32(&pending, -1)
 			select {
 			case <-release:
@@ -703,7 +754,7 @@ func BenchmarkJobManager_ParallelSubmit(b *testing.B) {
 		for pb.Next() {
 			atomic.AddInt32(&pending, 1)
 			dep := fmt.Sprintf("d-%d", i%50)
-			_, err := m.Submit(context.Background(), dep, "bench", func(ctx context.Context) (string, error) {
+			_, err := m.Submit(context.Background(), dep, "", "bench", func(ctx context.Context) (string, error) {
 				defer atomic.AddInt32(&pending, -1)
 				return `{}`, nil
 			})

--- a/cmd/mcp/iac-server/agent/planner.go
+++ b/cmd/mcp/iac-server/agent/planner.go
@@ -26,6 +26,7 @@ import (
 	"github.com/yusheng-g/openagent-go/agent"
 	"github.com/yusheng-g/openagent-go/cmd/mcp/iac-server/provider"
 	ctxpkg "github.com/yusheng-g/openagent-go/context"
+	"github.com/yusheng-g/openagent-go/mcp"
 	sloghooks "github.com/yusheng-g/openagent-go/hooks/slog"
 	"github.com/yusheng-g/openagent-go/iac"
 	"github.com/yusheng-g/openagent-go/kernel"
@@ -94,11 +95,12 @@ func ctxProgress(ctx context.Context) openagent.ProgressFunc {
 }
 
 // SubmitJob runs fn as an async job and returns the job id immediately.
-// Same-deployment jobs serialize; fn's ctx has the 15-min deadline and a
-// progress callback that writes to the job file. The mcp layer wraps the
-// long-running Planner methods with this.
+// Same-deployment jobs from the same session supersede (client retry);
+// cross-session requests for the same deployment are rejected. fn's ctx has
+// the 15-min deadline and a progress callback that writes to the job file.
+// The mcp layer wraps the long-running Planner methods with this.
 func (p *Planner) SubmitJob(ctx context.Context, deploymentID, tool string, fn func(ctx context.Context) (string, error)) (string, error) {
-	return p.jobs.Submit(ctx, deploymentID, tool, fn)
+	return p.jobs.Submit(ctx, deploymentID, mcp.SessionIDFromContext(ctx), tool, fn)
 }
 
 // GetJob returns the current state of an async job (nil if unknown).
@@ -209,7 +211,20 @@ Return JSON:
 
 	progress("Analyzing deployment request...", 1, 2)
 	session := openagent.Session{ID: sessionID(depID)}
-	result, err := rt.Run(ctx, session, openagent.UserMessage(request))
+	msg := openagent.UserMessage(request)
+	var result *openagent.RunResult
+	for attempt := 0; attempt < 3; attempt++ {
+		result, err = rt.Run(ctx, session, msg)
+		if err != nil {
+			_ = os.RemoveAll(dir)
+			return "", fmt.Errorf("propose_architecture: LLM run (attempt %d): %w", attempt+1, err)
+		}
+		if hasJSONObject(result.FinalOutput) {
+			break
+		}
+		// Empty or non-JSON output — retry with a nudge.
+		msg = nudgeMessage("Your previous response was empty or not valid JSON. Output the JSON result as specified in the system prompt.")
+	}
 	if err != nil {
 		_ = os.RemoveAll(dir)
 		return "", fmt.Errorf("propose_architecture: LLM run: %w", err)
@@ -218,7 +233,7 @@ Return JSON:
 	raw := extractJSON(result.FinalOutput)
 	if raw == "" {
 		_ = os.RemoveAll(dir)
-		return "", fmt.Errorf("propose_architecture: LLM returned empty output (FinalOutput=%q)", result.FinalOutput)
+		return "", fmt.Errorf("propose_architecture: LLM returned empty output after 3 attempts (last FinalOutput=%q)", result.FinalOutput)
 	}
 
 	var arch struct {
@@ -363,14 +378,26 @@ or, when you need more input:
 		userMsg += "\n\nUser adjustments: " + adjustments
 	}
 
-	result, err := rt.Run(ctx, session, openagent.UserMessage(userMsg))
+	msg := openagent.UserMessage(userMsg)
+	var result *openagent.RunResult
+	for attempt := 0; attempt < 3; attempt++ {
+		result, err = rt.Run(ctx, session, msg)
+		if err != nil {
+			return "", fmt.Errorf("specify_resources: LLM run (attempt %d): %w", attempt+1, err)
+		}
+		if hasJSONObject(result.FinalOutput) {
+			break
+		}
+		// Empty or non-JSON output — retry with a nudge.
+		msg = nudgeMessage("Your previous response was empty or not valid JSON. Output the JSON result as specified in the system prompt.")
+	}
 	if err != nil {
 		return "", fmt.Errorf("specify_resources: LLM run: %w", err)
 	}
 
 	raw := extractJSON(result.FinalOutput)
 	if raw == "" {
-		return "", fmt.Errorf("specify_resources: LLM returned empty output (FinalOutput=%q)", result.FinalOutput)
+		return "", fmt.Errorf("specify_resources: LLM returned empty output after 3 attempts (last FinalOutput=%q)", result.FinalOutput)
 	}
 
 	var spec struct {
@@ -549,8 +576,10 @@ Return JSON:
 			Reasoning string            `json:"reasoning"`
 		}
 		raw := extractJSON(result.FinalOutput)
-		if raw == "" {
-			return "", fmt.Errorf("generate_terraform_plan: LLM returned empty output (attempt %d, FinalOutput=%q)", attempt+1, result.FinalOutput)
+		if raw == "" || !strings.HasPrefix(raw, "{") {
+			// Empty or non-JSON output — retry with a nudge instead of failing.
+			msg = nudgeMessage("Your previous response was empty or not valid JSON. Output the JSON result with .tf files as specified in the system prompt.")
+			continue
 		}
 		if err := json.Unmarshal([]byte(raw), &llmOutput); err != nil {
 			return "", fmt.Errorf("generate_terraform_plan: parse (attempt %d): %w (raw=%q)", attempt+1, err, raw)
@@ -1067,6 +1096,25 @@ func extractJSON(s string) string {
 		return s
 	}
 	return s[start : end+1]
+}
+
+// hasJSONObject reports whether s contains an extractable JSON object.
+// Used to decide whether an LLM response is usable or should be retried:
+// extractJSON returns the raw string when no braces are found, so a plain-text
+// refusal ("I cannot help") would otherwise pass the non-empty check.
+func hasJSONObject(s string) bool {
+	extracted := extractJSON(s)
+	return strings.HasPrefix(extracted, "{") && strings.HasSuffix(extracted, "}")
+}
+
+// nudgeMessage returns a transient user message that prompts the LLM to retry
+// after an empty or non-JSON response. Transient=true prevents the nudge from
+// being persisted to the shared session store, so downstream steps (specify,
+// generate, estimate) do not read retry artifacts into their prompts.
+func nudgeMessage(text string) openagent.Message {
+	m := openagent.UserMessage(text)
+	m.Transient = true
+	return m
 }
 
 // marshalResult marshals a planResult to JSON string.

--- a/cmd/mcp/iac-server/main.go
+++ b/cmd/mcp/iac-server/main.go
@@ -1,21 +1,24 @@
 // iac-server is a cloud IaC MCP server. It exposes the deployment tools over
-// MCP stdio so any MCP client (Claude Code, opencode, Cursor, openagent) can
+// MCP so any MCP client (Claude Code, opencode, Cursor, openagent) can
 // plan, update, estimate cost, apply, troubleshoot, and destroy cloud
-// infrastructure, and query existing cloud resources/bills. When --port (or
-// IAC_PORT) is given, it additionally serves MCP over HTTP on
-// 127.0.0.1:<port> for external tool access.
+// infrastructure, and query existing cloud resources/bills.
+//
+// Transport is mutually exclusive:
+//   - default: stdio (for IDE/agent runtime as parent process)
+//   - --port / IAC_PORT: HTTP-only on 127.0.0.1:<port> (for sandbox/container/
+//     systemd where stdin is not connected)
 //
 // Configuration is via environment variables:
 //
-//	CLOUD          cloud provider: "huaweicloud" (default), "aliyun"
-//	IAC_API_KEY    server-side LLM API key
-//	IAC_BASE_URL   server-side LLM base URL (OpenAI-compatible)
-//	IAC_MODEL      server-side LLM model ID
-//	IAC_HOME       iac-server home (default: ~/.openagent/mcp/iac-server)
-//	              skills + deployments live under $IAC_HOME/<cloud>/
-//	IAC_DRY_RUN    "true" = simulate, don't call terraform binary
-//	IAC_PORT        HTTP listen port — setting this enables HTTP alongside stdio
-//	TF_BINARY_MIRRORS   comma-separated terraform binary download mirror URLs
+//	CLOUD              cloud provider: "huaweicloud" (default), "aliyun"
+//	IAC_API_KEY        server-side LLM API key
+//	IAC_BASE_URL       server-side LLM base URL (OpenAI-compatible)
+//	IAC_MODEL          server-side LLM model ID
+//	IAC_HOME           iac-server home (default: ~/.openagent/mcp/iac-server)
+//	                   skills + deployments live under $IAC_HOME/<cloud>/
+//	IAC_DRY_RUN        "true" = simulate, don't call terraform binary
+//	IAC_PORT           HTTP listen port — switches to HTTP-only transport
+//	TF_BINARY_MIRRORS  comma-separated terraform binary download mirror URLs
 //	TF_PROVIDER_MIRRORS comma-separated provider mirror URLs or local paths
 //
 // Cloud credentials are read from the environment by the selected provider
@@ -31,6 +34,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -64,21 +68,39 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	// ── HTTP port (optional, for external tool access) ──
-	// --port or IAC_PORT enables HTTP on 127.0.0.1:<port> alongside stdio.
+	// ── HTTP port (optional, switches to HTTP-only transport) ──
+	// --port or IAC_PORT switches from stdio to HTTP-only on 127.0.0.1:<port>.
 	// Neither given = pure stdio (backward compatible).
 	fs := flag.NewFlagSet("iac-server", flag.ContinueOnError)
-	portFlag := fs.Int("port", 0, "HTTP listen port (enables HTTP alongside stdio for external tool access)")
+	portFlag := fs.Int("port", 0, "HTTP listen port (switches to HTTP-only transport; stdio is not started)")
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		fatal(err)
 	}
-	httpPort := 0
-	if *portFlag > 0 {
-		httpPort = *portFlag
-	} else if envPort := os.Getenv("IAC_PORT"); envPort != "" {
-		if p, err := strconv.Atoi(envPort); err == nil && p > 0 {
-			httpPort = p
+	// portFlagSet is true only if --port was explicitly passed on the
+	// command line. fs.Visit visits exactly the flags that were set, so it
+	// distinguishes "not given" (→ stdio) from "given as 0" (→ invalid).
+	portFlagSet := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "port" {
+			portFlagSet = true
 		}
+	})
+	httpPort := 0
+	if portFlagSet {
+		if *portFlag <= 0 {
+			fatal(fmt.Errorf("--port=%d is not a valid HTTP listen port (omit --port for stdio)", *portFlag))
+		}
+		httpPort = *portFlag
+	}
+	if envPort := os.Getenv("IAC_PORT"); envPort != "" && httpPort == 0 {
+		p, err := strconv.Atoi(envPort)
+		if err != nil {
+			fatal(fmt.Errorf("IAC_PORT %q is not a valid port number", envPort))
+		}
+		if p <= 0 {
+			fatal(fmt.Errorf("IAC_PORT %q is not a valid HTTP listen port (unset IAC_PORT for stdio)", envPort))
+		}
+		httpPort = p
 	}
 
 	// ── Logging ──
@@ -248,15 +270,10 @@ func main() {
 		fatal(err)
 	}
 
-	// ── HTTP transport (optional, for external tool access) ──
-	// Listen before starting the goroutine so a bind failure is fatal
-	// immediately rather than silently leaving HTTP unavailable while
-	// stdio continues. stdio remains the primary transport — the process
-	// lifetime follows stdin (Run blocks the main goroutine).
-	//
-	// DNS rebinding protection is disabled because external tools may
-	// forward requests with a non-loopback Host header; authentication
-	// is the external tool's responsibility.
+	// ── Transport: HTTP and stdio are mutually exclusive ──
+	// --port > 0: HTTP-only (for sandbox/container/systemd where stdin is
+	// not connected and stdio would immediately EOF, killing the process).
+	// --port = 0: stdio-only (for IDE/agent runtime as parent process).
 	if httpPort > 0 {
 		addr := fmt.Sprintf("127.0.0.1:%d", httpPort)
 		handler := mcpsdk.NewStreamableHTTPHandler(
@@ -270,17 +287,23 @@ func main() {
 			fatal(fmt.Errorf("http listen %s: %w", addr, err))
 		}
 		slog.Info("starting HTTP transport", "addr", addr)
+		srv := &http.Server{Handler: handler}
 		go func() {
-			if err := http.Serve(ln, handler); err != nil {
+			if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
 				fatal(fmt.Errorf("http serve: %w", err))
 			}
 		}()
-	}
-
-	// ── stdio transport (always; process lifetime follows stdin) ──
-	slog.Info("starting iac-server on stdio")
-	if err := server.Run(ctx, &mcpsdk.StdioTransport{}); err != nil {
-		fatal(err)
+		<-ctx.Done()
+		shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancelShutdown()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			fatal(fmt.Errorf("http shutdown: %w", err))
+		}
+	} else {
+		slog.Info("starting iac-server on stdio")
+		if err := server.Run(ctx, &mcpsdk.StdioTransport{}); err != nil {
+			fatal(err)
+		}
 	}
 }
 

--- a/cmd/mcp/iac-server/mcp/tools.go
+++ b/cmd/mcp/iac-server/mcp/tools.go
@@ -58,7 +58,7 @@ func NewTools(cfg Config) []openagent.Tool {
 // jobStarted renders the immediate response of an async tool call: the
 // client polls get_job_result with the returned job_id.
 func jobStarted(jobID, tool string) *openagent.ToolResult {
-	content := fmt.Sprintf(`{"job_id": %q, "status": "started", "tool": %q, "hint": "call get_job_result with job_id to poll for completion (wait_seconds up to 60 to block)"}`, jobID, tool)
+	content := fmt.Sprintf(`{"job_id": %q, "status": "started", "tool": %q, "hint": "call get_job_result with job_id to poll for completion (wait_seconds up to 120 to block)"}`, jobID, tool)
 	return &openagent.ToolResult{Content: content}
 }
 
@@ -551,7 +551,7 @@ func (t *getJobResultTool) Definition() openagent.FunctionDefinition {
 			"update_deployment, estimate_cost, troubleshoot_deployment, or query_cloud. " +
 			"Those tools return immediately with a job_id; call this with that job_id to retrieve the outcome. " +
 			"Returns {status: \"running\"|\"done\"|\"failed\", progress_msg, progress_cur, progress_tot, outputs, result, error}. " +
-			"wait_seconds (0-60) blocks up to that long and returns as soon as the job finishes — " +
+			"wait_seconds (0-120) blocks up to that long and returns as soon as the job finishes — " +
 			"pass a value comfortably below your client's tool-call timeout to poll efficiently. " +
 			"IMPORTANT: when status is \"running\" and progress_msg is non-empty, you MUST tell the user the current progress " +
 			"(progress_msg, progress_cur/progress_tot) before calling get_job_result again. Do not poll silently — the user " +
@@ -572,8 +572,8 @@ func (t *getJobResultTool) Execute(ctx context.Context, args json.RawMessage) *o
 		}
 	}
 	wait := time.Duration(params.WaitSeconds) * time.Second
-	if wait < 0 || wait > 60*time.Second {
-		return openagent.ErrorResult(fmt.Errorf("get_job_result: wait_seconds must be 0-60"), false, "")
+	if wait < 0 || wait > 120*time.Second {
+		return openagent.ErrorResult(fmt.Errorf("get_job_result: wait_seconds must be 0-120"), false, "")
 	}
 	job, err := t.cfg.Planner.GetJob(ctx, params.JobID, wait)
 	if err != nil {
@@ -705,7 +705,7 @@ type GetDeploymentStatusParams struct {
 // GetJobResultParams are the arguments to get_job_result.
 type GetJobResultParams struct {
 	JobID       string `json:"job_id" jsonschema:"description=Job ID returned by an async tool call"`
-	WaitSeconds int    `json:"wait_seconds,omitempty" jsonschema:"description=Block up to this many seconds (0-60) and return as soon as the job finishes; 0 returns immediately"`
+	WaitSeconds int    `json:"wait_seconds,omitempty" jsonschema:"description=Block up to this many seconds (0-120) and return as soon as the job finishes; 0 returns immediately"`
 }
 
 // parseJobResultParamsLenient parses get_job_result args, tolerating a string

--- a/cmd/mcp/iac-server/provider/huaweicloud/prompts.go
+++ b/cmd/mcp/iac-server/provider/huaweicloud/prompts.go
@@ -86,6 +86,7 @@ func (h *HuaweiCloud) agents() map[provider.PromptRole]provider.AgentConfig {
 			Prompt: `You are a HuaweiCloud cloud query expert.
 - Use load_skill to load the relevant skill for the cloud service being queried (e.g. load_skill("huaweicloud-ecs") for ECS instances/flavors, load_skill("huaweicloud-vpc") for VPCs/subnets/security groups, load_skill("huaweicloud-bss") for billing/pricing/orders)
 - Then use http_request to call the API with the correct endpoint and parameters
+- For OBS (object storage) queries: do NOT call OBS endpoints directly (obs.*.myhuaweicloud.com). In sandbox environments these resolve to internal addresses blocked by SSRF protection, and OBS uses a different signing scheme. Instead, use the Config (RMS) service to list OBS resources: load_skill("huaweicloud-config"), then call CollectAllResourcesSummary or ListResources with resource_type "obs.buckets" via http_request to rms.{region}.myhuaweicloud.com.
 - CRITICAL: Only call read-only APIs (List/Show/Get). NEVER call Create/Update/Delete APIs — this tool is for querying existing resources only, not for creating or modifying them`,
 		},
 	}

--- a/cmd/mcp/iac-server/provider/huaweicloud/skills/huaweicloud-obs/SKILL.md
+++ b/cmd/mcp/iac-server/provider/huaweicloud/skills/huaweicloud-obs/SKILL.md
@@ -46,5 +46,6 @@ description: HuaweiCloud OBS API guide. 94 APIs covering 多段操作, 对象操
 
 ## Usage
 
-Use `http_request` to call these APIs. SDK-HMAC-SHA256 signing is automatic — do NOT pass credentials.
-Use `read`/`grep`/`ls` to browse `references/` for detailed request/response schemas.
+NOTE: In sandbox/developer-space environments, OBS endpoints (obs.*.myhuaweicloud.com) resolve to internal addresses and use S3-compatible signing that http_request does not support. To query OBS resources (buckets, objects), use the Config (RMS) service instead: load_skill("huaweicloud-config") and call CollectAllResourcesSummary with resource_type "obs.buckets".
+
+The API definitions below are for reference only — direct http_request calls to OBS endpoints will fail.

--- a/iac/binary.go
+++ b/iac/binary.go
@@ -188,8 +188,8 @@ func installViaHCInstall(ctx context.Context, ver, destDir string) (string, erro
 func EnsureTerraform(ctx context.Context, cfg Config) (string, error) {
 	// 1. Explicit path.
 	if cfg.BinaryPath != "" {
-		if _, err := os.Stat(cfg.BinaryPath); err != nil {
-			return "", fmt.Errorf("binary not found at %s: %w", cfg.BinaryPath, err)
+		if err := validateBinaryPath(cfg.BinaryPath); err != nil {
+			return "", fmt.Errorf("binary at %s: %w", cfg.BinaryPath, err)
 		}
 		return cfg.BinaryPath, nil
 	}
@@ -216,7 +216,34 @@ func EnsureTerraform(ctx context.Context, cfg Config) (string, error) {
 		}
 		return "", err
 	}
+	if err := validateBinaryPath(installPath); err != nil {
+		return "", fmt.Errorf("terraform install at %s: %w", installPath, err)
+	}
 	return installPath, nil
+}
+
+// validateBinaryPath checks that path is a regular file and its parent is a
+// directory. This catches the "file where a directory was expected" (or vice
+// versa) mismatch that produces a bare OS "not a directory" error at exec
+// time, translating it into a clear message before the binary is handed to
+// fork/exec.
+func validateBinaryPath(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return fmt.Errorf("expected a binary file but found a directory — remove it and reinstall")
+	}
+	parent := filepath.Dir(path)
+	pInfo, err := os.Stat(parent)
+	if err != nil {
+		return fmt.Errorf("parent dir: %w", err)
+	}
+	if !pInfo.IsDir() {
+		return fmt.Errorf("parent %s is not a directory — path layout is corrupted, remove the install dir and retry", parent)
+	}
+	return nil
 }
 
 // binaryName returns the cached binary filename for a version.

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -64,8 +64,11 @@ func (s *Server) AddTool(tool openagent.Tool) error {
 	// If the client supplied a progressToken, a [ProgressFunc] is built from
 	// the server session and injected into the context so the tool can stream
 	// progress notifications back to the client during long-running calls.
+	// The session ID is also injected so tools can distinguish same-client
+	// retries from cross-client conflicts on shared resources.
 	handler := func(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
 		ctx = withProgress(ctx, req)
+		ctx = withSessionID(ctx, req)
 		output := tool.Execute(ctx, req.Params.Arguments)
 		if output.Error != nil {
 			return &mcpsdk.CallToolResult{
@@ -128,6 +131,7 @@ func (s *Server) AddToolWithSchema(tool openagent.Tool, inputSchema json.RawMess
 
 	handler := func(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
 		ctx = withProgress(ctx, req)
+		ctx = withSessionID(ctx, req)
 		output := tool.Execute(ctx, req.Params.Arguments)
 		if output.Error != nil {
 			return &mcpsdk.CallToolResult{
@@ -146,6 +150,34 @@ func (s *Server) AddToolWithSchema(tool openagent.Tool, inputSchema json.RawMess
 
 	s.inner.AddTool(mcpTool, handler)
 	return nil
+}
+
+// withSessionID injects the MCP server session ID into ctx so tools can
+// distinguish same-client retries from cross-client conflicts. The session
+// ID is empty for stdio (single client) and unique per HTTP connection.
+func withSessionID(ctx context.Context, req *mcpsdk.CallToolRequest) context.Context {
+	if req.Session != nil {
+		return WithSessionID(ctx, req.Session.ID())
+	}
+	return ctx
+}
+
+// sessionIDKey is the context key for the MCP session ID (Mcp-Session-Id
+// header). Empty for stdio (single client), unique per HTTP connection.
+// withSessionID injects it; SessionIDFromContext extracts it.
+type sessionIDKey struct{}
+
+// WithSessionID returns a context that carries the MCP session ID.
+// An empty sessionID is valid (stdio transport) and means "single client".
+func WithSessionID(ctx context.Context, sessionID string) context.Context {
+	return context.WithValue(ctx, sessionIDKey{}, sessionID)
+}
+
+// SessionIDFromContext extracts the MCP session ID from ctx, or "" if none
+// was set (e.g. stdio transport, or a call outside an MCP server).
+func SessionIDFromContext(ctx context.Context) string {
+	id, _ := ctx.Value(sessionIDKey{}).(string)
+	return id
 }
 
 // Run starts the MCP server on the given transport. It blocks until the


### PR DESCRIPTION
## Summary

Fixes several iac-server robustness issues found through sandbox deployment testing and adversarial code review.

## Changes

### 1. Transport is mutually exclusive (`main.go`)
`--port > 0` starts HTTP-only (process lifetime held by the HTTP listener); omitting `--port` starts stdio-only. Previously stdio+HTTP coexisted, so a sandbox EOF on stdin killed the entire process including the HTTP listener.

### 2. Strict port validation (`main.go`)
`--port=0`, `--port<0`, `IAC_PORT=0`, `IAC_PORT<0`, and non-numeric `IAC_PORT` now fatal instead of silently falling back to stdio. Uses `fs.Visit` to distinguish "flag not given" (stdio) from "flag given as 0" (error).

### 3. Cross-session same-deployment protection (`agent/job.go`, `mcp/server.go`)
A second MCP session operating on an already-running deployment is rejected with a "busy" error instead of silently superseding the first session's job. Same-session retry still supersedes (client retry). MCP session ID is injected into tool ctx so the JobManager can distinguish sessions — stdio is always `""` (single client), HTTP is unique per connection.

### 4. Retry empty/non-JSON LLM output (`agent/planner.go`)
`propose_architecture`, `specify_resources`, and `generate_terraform_plan` now retry 3x when the server LLM returns empty or non-JSON output, with a transient nudge message (`Transient: true` — not persisted to the shared session store, so downstream steps do not read retry artifacts into their prompts). `generate_terraform_plan` uses `continue` instead of `return error` on empty output, reusing its existing 3-attempt outer loop.

A `hasJSONObject` helper detects usable output — `extractJSON` returns the raw string for brace-less input, so plain-text refusals (e.g. "I cannot help") would otherwise bypass retry.

### 5. Validate terraform binary path (`iac/binary.go`)
`EnsureTerraform` now checks the returned path is a regular file and its parent is a directory. A stale install (file where a directory is expected — e.g. hc-install placing a binary under a path that was a file) now produces a clear error instead of a bare OS `not a directory` at `fork/exec` time.

### 6. Raise `get_job_result` `wait_seconds` cap 60 → 120 (`mcp/tools.go`)
Minute-scale `terraform init`/`apply` previously needed 10+ polls at the 60s cap, triggering client-side doom-loop detection. At 120s the same operations need 3-5 polls. 120s is conservative — it stays below typical client tool-call timeouts (120-180s) while cutting poll count significantly.

## Verification

```
go build -o /tmp/iac-server ./cmd/mcp/iac-server   # exit 0
go vet ./cmd/mcp/iac-server/... ./iac/...          # clean
go test -race ./cmd/mcp/iac-server/agent/... ./iac/...  # ok
```

E2E tested with opencode + codearts over HTTP transport (internal localhost + external tunnel).

## Files changed

```
cmd/mcp/iac-server/agent/planner.go | 58 +++++++++++++++++++++++++++++++++----
cmd/mcp/iac-server/mcp/tools.go     | 10 +++----
iac/binary.go                       | 31 ++++++++++++++++++--
cmd/mcp/iac-server/agent/job.go     | (cross-session sessionID field)
cmd/mcp/iac-server/main.go          | (transport mutex + port validation)
cmd/mcp/iac-server/mcp/server.go    | (inject session ID into ctx)
```