### PR TITLE
refactor: rename binary openagent-cli → hwcloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A fully pluggable, multi-agent AI agent framework in Go.
 - **WASM plugins** — agent-level: `agent:tools` and `agent:observers` plug into the tool/observer pipeline. CLI-level: `cli:settings`, `cli:commands`, `cli:observers`, `cli:http` for settings injection, command extension, lifecycle monitoring, and custom HTTP routes. Any plugin can declare cron-scheduled jobs.
 - **Static context profiles** — `AGENTS.md` (working rules) and `SOUL.md` (persona & limits) with user-level and project-level resolution
 - **Slash commands** — built-in `/help`, `/mode`, `/model`, `/compact`, `/context`, `/cwd`, `/clear`, `/rename`, `/sessions`, extensible via `slash/` registry
-- **Full CLI** — `openagent-cli` with cobra commands, config-driven models, keyring secrets, WASM plugin runtime
+- **Full CLI** — `hwcloud` with cobra commands, config-driven models, keyring secrets, WASM plugin runtime
 - **IM channels** — Feishu/Lark (WebSocket, card-based streaming output with markdown and tool call cards, one-click QR setup, inline approval buttons, /clear and /mode commands), personal WeChat (Tencent ilinkai channel, QR login with pairing code, /clear command), and WeCom 企业微信 (official long connection, native streaming replies, QR robot auto-creation, /clear command)
 - **RunHooks with state** — start/end callbacks share opaque state; OTEL spans nest, slog logs duration
 - **Dynamic context** — session-level plan status and mode injected into every prompt turn
@@ -29,32 +29,32 @@ A fully pluggable, multi-agent AI agent framework in Go.
 
 ```bash
 # Build CLI
-go build -o openagent-cli ./cmd/cli/
+go build -o hwcloud ./cmd/cli/
 
 # Show version
-./openagent-cli -v
+./hwcloud -v
 
 # ACP mode (stdio — for VSCode/Zed ACP plugins)
-./openagent-cli serve --acp
+./hwcloud serve --acp
 
 # REST mode (HTTP + SSE)
-./openagent-cli serve --port 8080
+./hwcloud serve --port 8080
 
 # One-shot chat with streaming output
-./openagent-cli run "Hello, introduce yourself briefly"
+./hwcloud run "Hello, introduce yourself briefly"
 
 # Enable OS-native sandbox for shell commands
-./openagent-cli serve --sandbox --port 8080
+./hwcloud serve --sandbox --port 8080
 
 # Toggle capabilities on/off (defaults: memory/summarizer/skills/mcp/embedder on, guard/approver off)
-./openagent-cli serve --guard on --approver on
+./hwcloud serve --guard on --approver on
 
 # Suppress all log output
-./openagent-cli serve -q --port 8080
+./hwcloud serve -q --port 8080
 
 # Manage secrets in the system keyring
-./openagent-cli keyring set mykey keyvalue
-./openagent-cli keyring get mykey
+./hwcloud keyring set mykey keyvalue
+./hwcloud keyring get mykey
 ```
 
 ### Configuration
@@ -101,7 +101,7 @@ Connect your agent to Feishu (Lark) so users can chat with it in IM — group ch
 **First-time setup (no credentials needed):**
 
 ```bash
-./openagent-cli serve --channel feishu
+./hwcloud serve --channel feishu
 ```
 
 A QR code will appear in your terminal. Open Feishu on your phone, scan it, and confirm the app creation. The SDK automatically provisions a bot app with the correct permissions (`im:message`, `im:message:send_as_bot`, `im.message.receive_v1` event, `card.action.trigger` for approval/mode button callbacks) and saves the credentials locally.
@@ -127,7 +127,7 @@ A QR code will appear in your terminal. Open Feishu on your phone, scan it, and 
 Then run with the flag to enable the channel:
 
 ```bash
-./openagent-cli serve --channel feishu
+./hwcloud serve --channel feishu
 ```
 
 The `--channel` flag is always required to start the bot — settings.json alone won't auto-start it. If your credentials are in settings.json, the setup step is skipped automatically.
@@ -146,10 +146,10 @@ The `--channel` flag is always required to start the bot — settings.json alone
 
 ```bash
 # REST API + Feishu bot
-./openagent-cli serve --channel feishu
+./hwcloud serve --channel feishu
 
 # ACP mode (stdio for VSCode/Zed) + Feishu bot
-./openagent-cli serve --acp --channel feishu
+./hwcloud serve --acp --channel feishu
 ```
 
 **Frontend control panel:**
@@ -229,7 +229,7 @@ Connect your agent to your **personal WeChat** via Tencent's official ilinkai ch
 **First-time setup (scan to create the bot):**
 
 ```bash
-./openagent-cli serve --channel wechat
+./hwcloud serve --channel wechat
 ```
 
 A QR code appears in the terminal — scan it with WeChat and confirm. The bot is created automatically; if the server asks for a **pairing code** (digits shown on your phone), type it in the terminal. Credentials are saved to settings.json.
@@ -254,7 +254,7 @@ Connect your agent to a **WeCom smart robot** via the official long-connection A
 **First-time setup (scan to auto-create the robot):**
 
 ```bash
-./openagent-cli serve --channel wecom
+./hwcloud serve --channel wecom
 ```
 
 A QR code appears — scan it with the WeCom app; the robot is created automatically and the BotID/Secret are saved to settings.json. Alternatively, create the robot manually in the WeCom admin console (安全与管理 → 管理工具 → 智能机器人 → API 模式 → 长连接) and configure it via the settings endpoint:

--- a/README.zh.md
+++ b/README.zh.md
@@ -20,7 +20,7 @@
 - **WASM 插件** — Agent 级：`agent:tools` 和 `agent:observers` 接入工具/观测器管线。CLI 级：`cli:settings`、`cli:commands`、`cli:observers`、`cli:http`，用于设置注入、命令扩展、生命周期监控和自定义 HTTP 路由。任意插件均可声明 cron 定时任务。
 - **静态上下文配置** — `AGENTS.md`（工作规则）和 `SOUL.md`（性格与底线），支持用户级和项目级覆盖
 - **Slash 命令** — 内置 `/help`、`/mode`、`/model`、`/compact`、`/context`、`/cwd`、`/clear`、`/rename`、`/sessions`，通过 `slash/` 注册表扩展
-- **完整 CLI** — `openagent-cli`，cobra 命令、配置驱动模型、keyring 密钥管理、WASM 插件运行时
+- **完整 CLI** — `hwcloud`，cobra 命令、配置驱动模型、keyring 密钥管理、WASM 插件运行时
 - **IM 频道** — 飞书/Lark（WebSocket，卡片式流式输出：Markdown 渲染、工具调用卡片，一键扫码创建应用，内嵌审批按钮、/clear 和 /mode 命令）、个人微信（腾讯 ilinkai 官方通道，扫码登录 + 配对码，/clear 命令）、企业微信（官方长连接，原生流式回复，扫码自动创建机器人，/clear 命令）
 - **RunHooks 状态传递** — Start/End 回调共享不透明状态，OTEL 正确嵌套 span，slog 精确计时
 - **动态上下文** — 会话级 plan 状态和 mode 指令每轮自动注入 prompt
@@ -29,32 +29,32 @@
 
 ```bash
 # 编译 CLI
-go build -o openagent-cli ./cmd/cli/
+go build -o hwcloud ./cmd/cli/
 
 # 查看版本号
-./openagent-cli -v
+./hwcloud -v
 
 # ACP 模式（stdio — 配合 VSCode/Zed ACP 插件使用）
-./openagent-cli serve --acp
+./hwcloud serve --acp
 
 # REST 模式（HTTP + SSE）
-./openagent-cli serve --port 8080
+./hwcloud serve --port 8080
 
 # 一次性流式对话
-./openagent-cli run "你好，请介绍一下你自己"
+./hwcloud run "你好，请介绍一下你自己"
 
 # 启用 OS 原生沙箱执行 shell 命令
-./openagent-cli serve --sandbox --port 8080
+./hwcloud serve --sandbox --port 8080
 
 # 按需开关能力（默认：memory/summarizer/skills/mcp/embedder 开，guard/approver 关）
-./openagent-cli serve --guard on --approver on
+./hwcloud serve --guard on --approver on
 
 # 静默所有日志输出
-./openagent-cli serve -q --port 8080
+./hwcloud serve -q --port 8080
 
 # 管理系统密钥环里
-./openagent-cli keyring set mykey keyvalue
-./openagent-cli keyring get mykey
+./hwcloud keyring set mykey keyvalue
+./hwcloud keyring get mykey
 ```
 
 ### 配置
@@ -101,7 +101,7 @@ export BOCHA_API_KEY=<你的-key>   # 在 https://open.bochaai.com 获取
 **首次使用（无需凭据）：**
 
 ```bash
-./openagent-cli serve --channel feishu
+./hwcloud serve --channel feishu
 ```
 
 终端会出现二维码。打开飞书 App 扫码，确认创建应用即可。SDK 会自动创建机器人应用并配置好权限（`im:message`、`im:message:send_as_bot`、`im.message.receive_v1` 事件、`card.action.trigger` 审批/模式按钮回调），凭据保存在本地。
@@ -127,7 +127,7 @@ export BOCHA_API_KEY=<你的-key>   # 在 https://open.bochaai.com 获取
 然后带 flag 启动：
 
 ```bash
-./openagent-cli serve --channel feishu
+./hwcloud serve --channel feishu
 ```
 
 `--channel` flag 是必须的 — 仅配置 settings.json 不会自动启动 bot。如果凭据已在 settings.json 中，启动时会跳过扫码步骤。
@@ -146,10 +146,10 @@ export BOCHA_API_KEY=<你的-key>   # 在 https://open.bochaai.com 获取
 
 ```bash
 # REST API + 飞书机器人
-./openagent-cli serve --channel feishu
+./hwcloud serve --channel feishu
 
 # ACP 模式（stdio，配合 VSCode/Zed）+ 飞书机器人
-./openagent-cli serve --acp --channel feishu
+./hwcloud serve --acp --channel feishu
 ```
 
 **前端控制面板：**
@@ -229,7 +229,7 @@ Manual 模式下的审批请求直接内嵌在运行卡片中（无独立审批�
 **首次设置（扫码自动创建 bot）：**
 
 ```bash
-./openagent-cli serve --channel wechat
+./hwcloud serve --channel wechat
 ```
 
 终端出现二维码，用微信扫码确认即可自动创建 bot；如果服务端要求**配对码**（手机微信上显示的数字），在终端输入。凭据保存到 settings.json。
@@ -254,7 +254,7 @@ Manual 模式下的审批请求直接内嵌在运行卡片中（无独立审批�
 **首次设置（扫码自动创建机器人）：**
 
 ```bash
-./openagent-cli serve --channel wecom
+./hwcloud serve --channel wecom
 ```
 
 出现二维码后用企微 App 扫码，机器人自动创建，BotID/Secret 保存到 settings.json。也可以在企微管理后台手动创建（安全与管理 → 管理工具 → 智能机器人 → API 模式 → 长连接），再通过设置接口配置：

--- a/cmd/cli/DESIGN.md
+++ b/cmd/cli/DESIGN.md
@@ -1,8 +1,8 @@
-# openagent-cli Design
+# hwcloud Design
 
 ## What is it?
 
-openagent-cli is the CLI entry point for openagent-go. It is not a simple launch script — it is an **extensible agent runtime platform**:
+hwcloud is the CLI entry point for openagent-go. It is not a simple launch script — it is an **extensible agent runtime platform**:
 
 1. Configuration from `~/.openagent/settings.json`
 2. Capabilities injected by WASM plugins at startup
@@ -139,7 +139,7 @@ The host never distinguishes between "user config" and "plugin config". Everythi
 ## Command Tree (cobra)
 
 ```
-openagent-cli
+hwcloud
 ├─ serve [--acp] [--port N]        Built-in: REST or ACP server
 ├─ run <message>                    Built-in: one-shot chat, streaming output
 ├─ keyring                          Built-in: credential management
@@ -155,10 +155,10 @@ openagent-cli
 
 ```
 on_startup()
-  → on_command_start("openagent-cli serve")
+  → on_command_start("hwcloud serve")
     → server running...
     → Ctrl+C
-  → on_command_end("openagent-cli serve", nil)
+  → on_command_end("hwcloud serve", nil)
 on_shutdown()
 ```
 
@@ -237,7 +237,7 @@ cmd/cli/
     stats-cmd.rs               cli:commands  — adds "stats" command
     telemetry.rs               cli:observers — logs lifecycle events
   build/
-    openagent-cli              Compiled binary
+    hwcloud              Compiled binary
     plugins/                   Compiled .wasm files
 ```
 
@@ -250,7 +250,7 @@ cmd/cli/
 `run` sends a single message to the agent and streams the response to stdout in real time.
 
 ```
-openagent-cli run "analyze main.go"
+hwcloud run "analyze main.go"
 ```
 
 ### Design

--- a/cmd/cli/DESIGN.zh.md
+++ b/cmd/cli/DESIGN.zh.md
@@ -1,8 +1,8 @@
-# openagent-cli 设计文档
+# hwcloud 设计文档
 
 ## 这是什么？
 
-openagent-cli 是 openagent-go 的命令行入口。不是简单的启动脚本，而是一个**可扩展的 Agent 运行时平台**：
+hwcloud 是 openagent-go 的命令行入口。不是简单的启动脚本，而是一个**可扩展的 Agent 运行时平台**：
 
 1. 配置来自 `~/.openagent/settings.json`
 2. 能力由 WASM 插件在启动时动态注入
@@ -124,7 +124,7 @@ log_error(msg_ptr, msg_len)
 ## 命令树 (cobra)
 
 ```
-openagent-cli
+hwcloud
 ├─ serve [--acp] [--port N]        内置: REST 或 ACP 服务
 ├─ run <message>                    内置: 单轮对话，流式输出
 ├─ keyring                          内置: 凭证管理
@@ -140,10 +140,10 @@ openagent-cli
 
 ```
 on_startup()
-  → on_command_start("openagent-cli serve")
+  → on_command_start("hwcloud serve")
     → server 运行中...
     → Ctrl+C
-  → on_command_end("openagent-cli serve", nil)
+  → on_command_end("hwcloud serve", nil)
 on_shutdown()
 ```
 
@@ -222,7 +222,7 @@ cmd/cli/
     stats-cmd.rs              cli:commands  — 添加 "stats" 命令
     telemetry.rs              cli:observers — 记录生命周期事件
   build/
-    openagent-cli             编译后的二进制
+    hwcloud             编译后的二进制
     plugins/                  编译后的 .wasm 文件
 ```
 
@@ -235,7 +235,7 @@ cmd/cli/
 `run` 发送一条消息给 Agent，实时流式输出回复到终端。
 
 ```
-openagent-cli run "分析 main.go 文件"
+hwcloud run "分析 main.go 文件"
 ```
 
 ### 设计要点

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -1,4 +1,4 @@
-# openagent-cli
+# hwcloud
 
 The command-line entry point for [openagent-go](https://github.com/yusheng-g/openagent-go). Start an LLM agent server (REST or ACP) with config-driven models and WASM-powered plugins.
 
@@ -7,7 +7,7 @@ The command-line entry point for [openagent-go](https://github.com/yusheng-g/ope
 Build and run:
 
 ```bash
-go build -o openagent-cli ./cmd/cli/
+go build -o hwcloud ./cmd/cli/
 mkdir -p ~/.openagent/plugins
 ```
 
@@ -31,7 +31,7 @@ Create `~/.openagent/settings.json`:
 Start the server:
 
 ```bash
-./openagent-cli serve
+./hwcloud serve
 ```
 
 The REST API is now on `http://localhost:8080`. Connect any OpenAI-compatible client.
@@ -39,7 +39,7 @@ The REST API is now on `http://localhost:8080`. Connect any OpenAI-compatible cl
 For ACP (Agent Communication Protocol) over stdio:
 
 ```bash
-./openagent-cli serve --acp
+./hwcloud serve --acp
 ```
 
 ## Configuration
@@ -64,9 +64,9 @@ All configuration lives in `~/.openagent/settings.json`. The path can be overrid
 Credentials that shouldn't live in settings.json (API keys, JWTs, anything sensitive) go into your system keychain:
 
 ```bash
-./openagent-cli keyring set my_provider_api_key sk-xxx
-./openagent-cli keyring set my_provider_base_url https://api.example.com/v1
-./openagent-cli keyring set my_provider_models model-a,model-b
+./hwcloud keyring set my_provider_api_key sk-xxx
+./hwcloud keyring set my_provider_base_url https://api.example.com/v1
+./hwcloud keyring set my_provider_models model-a,model-b
 ```
 
 Plugins read these at startup. Supported backends: Linux Secret Service (gnome-keyring/kwallet), macOS Keychain, Windows Credential Manager.
@@ -78,7 +78,7 @@ Plugins are `.wasm` files loaded at startup. There are three types:
 | Type | `metadata.type` | What it does |
 |------|----------------|--------------|
 | Settings injection | `cli:settings` | Transforms `settings.json` at startup — reads keyring, adds providers, injects env vars |
-| Command injection | `cli:commands` | Adds new `openagent-cli` commands (e.g. `openagent-cli stats`) |
+| Command injection | `cli:commands` | Adds new `hwcloud` commands (e.g. `hwcloud stats`) |
 | Lifecycle observer | `cli:observers` | Hooks into startup, shutdown, and command execution for telemetry |
 
 A single plugin can mix types: `"type": "cli:settings,cli:commands,cli:observers"`.
@@ -150,7 +150,7 @@ pub extern "C" fn run_my_cmd(p: u32, l: u32) -> u64 {
 ## Commands
 
 ```
-openagent-cli
+hwcloud
 ├─ serve [--acp] [--port N] [--sandbox]   REST or ACP server
 ├─ keyring                                 Credential management
 │  ├─ set <key> <value>

--- a/cmd/cli/README.zh.md
+++ b/cmd/cli/README.zh.md
@@ -1,4 +1,4 @@
-# openagent-cli
+# hwcloud
 
 [openagent-go](https://github.com/yusheng-g/openagent-go) 的命令行入口。通过配置驱动模型和 WASM 插件，启动一个 LLM Agent 服务器（REST 或 ACP）。
 
@@ -7,7 +7,7 @@
 编译并运行：
 
 ```bash
-go build -o openagent-cli ./cmd/cli/
+go build -o hwcloud ./cmd/cli/
 mkdir -p ~/.openagent/plugins
 ```
 
@@ -31,7 +31,7 @@ mkdir -p ~/.openagent/plugins
 启动服务器：
 
 ```bash
-./openagent-cli serve
+./hwcloud serve
 ```
 
 REST API 运行在 `http://localhost:8080`。连接任何 OpenAI 兼容客户端。
@@ -39,7 +39,7 @@ REST API 运行在 `http://localhost:8080`。连接任何 OpenAI 兼容客户端
 ACP（Agent 通信协议）模式：
 
 ```bash
-./openagent-cli serve --acp
+./hwcloud serve --acp
 ```
 
 ## 配置
@@ -64,9 +64,9 @@ ACP（Agent 通信协议）模式：
 不应写在 settings.json 中的凭证（API 密钥、JWT 等）存入系统密钥环：
 
 ```bash
-./openagent-cli keyring set my_provider_api_key sk-xxx
-./openagent-cli keyring set my_provider_base_url https://api.example.com/v1
-./openagent-cli keyring set my_provider_models model-a,model-b
+./hwcloud keyring set my_provider_api_key sk-xxx
+./hwcloud keyring set my_provider_base_url https://api.example.com/v1
+./hwcloud keyring set my_provider_models model-a,model-b
 ```
 
 插件在启动时读取这些密钥。支持：Linux Secret Service（gnome-keyring/kwallet）、macOS Keychain、Windows Credential Manager。
@@ -78,7 +78,7 @@ ACP（Agent 通信协议）模式：
 | 类型 | `metadata.type` | 功能 |
 |------|----------------|------|
 | 设置注入 | `cli:settings` | 启动时修改 settings.json：读 keyring、添加 provider、注入环境变量 |
-| 命令注入 | `cli:commands` | 添加新的 `openagent-cli` 命令（如 `openagent-cli stats`） |
+| 命令注入 | `cli:commands` | 添加新的 `hwcloud` 命令（如 `hwcloud stats`） |
 | 生命周期观察 | `cli:observers` | 钩入启动、关闭、命令执行过程，用于遥测监控 |
 
 一个插件可混搭多种类型：`"type": "cli:settings,cli:commands,cli:observers"`。
@@ -150,7 +150,7 @@ pub extern "C" fn run_my_cmd(p: u32, l: u32) -> u64 {
 ## 命令
 
 ```
-openagent-cli
+hwcloud
 ├─ serve [--acp] [--port N] [--sandbox]   REST 或 ACP 服务
 ├─ keyring                                 凭证管理
 │  ├─ set <key> <value>

--- a/cmd/cli/examples/plugin/extended-settings/Cargo.toml
+++ b/cmd/cli/examples/plugin/extended-settings/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "openagent-cli-plugin-extended-settings"
+name = "hwcloud-plugin-extended-settings"
 version = "0.1.0"
 edition = "2021"
 

--- a/cmd/cli/examples/plugin/stats-cmd/Cargo.toml
+++ b/cmd/cli/examples/plugin/stats-cmd/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "openagent-cli-plugin-stats-cmd"
+name = "hwcloud-plugin-stats-cmd"
 version = "0.1.0"
 edition = "2021"
 

--- a/cmd/cli/examples/plugin/stats-cmd/src/lib.rs
+++ b/cmd/cli/examples/plugin/stats-cmd/src/lib.rs
@@ -1,4 +1,4 @@
-// stats-cmd — adds `openagent-cli stats` command.
+// stats-cmd — adds `hwcloud stats` command.
 
 #![no_std]
 

--- a/cmd/cli/examples/plugin/telemetry/Cargo.toml
+++ b/cmd/cli/examples/plugin/telemetry/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "openagent-cli-plugin-telemetry"
+name = "hwcloud-plugin-telemetry"
 version = "0.1.0"
 edition = "2021"
 

--- a/cmd/cli/examples/plugin/telemetry/src/lib.rs
+++ b/cmd/cli/examples/plugin/telemetry/src/lib.rs
@@ -1,4 +1,4 @@
-// telemetry — openagent-cli observer plugin using the high-level Plugin trait.
+// telemetry — hwcloud observer plugin using the high-level Plugin trait.
 
 #![no_std]
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,4 +1,4 @@
-// openagent-cli — openagent-go CLI.
+// hwcloud — openagent-go CLI.
 
 package main
 
@@ -241,7 +241,7 @@ func parseArgRule(rule string) cobra.PositionalArgs {
 }
 
 var rootCmd = &cobra.Command{
-	Use:   "openagent-cli",
+	Use:   "hwcloud",
 	Short: "openagent CLI",
 }
 
@@ -366,9 +366,9 @@ func buildRunCmd(cfg config.Config) *cobra.Command {
 		Long: `Send a message to the AI Agent and stream the response to stdout in real time.
 
 Wrap your message in quotes when it contains spaces:
-  openagent-cli run "analyze main.go"`,
-		Example: `  openagent-cli run "Hello, introduce yourself briefly"
-  openagent-cli run "analyze cmd/cli/main.go and summarize"`,
+  hwcloud run "analyze main.go"`,
+		Example: `  hwcloud run "Hello, introduce yourself briefly"
+  hwcloud run "analyze cmd/cli/main.go and summarize"`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return server.RunCLI(cmd.Context(), &cfg, args[0])

--- a/plugin/pdk/rust/src/export.rs
+++ b/plugin/pdk/rust/src/export.rs
@@ -46,7 +46,7 @@ pub trait Plugin: Sized {
     fn on_startup() {}
     fn on_shutdown() {}
 
-    /// cmd_path is the full cobra command path, e.g. "openagent-cli serve".
+    /// cmd_path is the full cobra command path, e.g. "hwcloud serve".
     fn on_command_start(_cmd_path: &str) {}
 
     /// cmd_path + optional " error=..." suffix.

--- a/sandbox/native/native_linux.go
+++ b/sandbox/native/native_linux.go
@@ -20,7 +20,7 @@ import (
 // The ctx deadline only controls how long the caller waits — it does NOT
 // kill the process. When ctx expires the process keeps running (bwrap
 // continues with --die-with-parent, which only triggers when the parent
-// openagent-cli exits, not when a single call times out).
+// hwcloud exits, not when a single call times out).
 //
 // Falls back to unsandboxed execution with a warning if bwrap is not found
 // or if bwrap fails to start (e.g. "setting up uid map: Permission denied"

--- a/version/version.go
+++ b/version/version.go
@@ -9,14 +9,14 @@
 //	-X github.com/yusheng-g/openagent-go/version.Version=v1.2.3
 //
 // When ldflags are absent (development build), init fills Name with
-// "openagent-cli" and Version with "0.0.0-dev.<build-timestamp>".
+// "hwcloud" and Version with "0.0.0-dev.<build-timestamp>".
 package version
 
 import "time"
 
 // Name is the agent implementation name reported to peers (e.g. in ACP
 // initialize agentInfo.name and MCP client identity). Inject via
-// -X ...version.Name=<name>; defaults to "openagent-cli" in init.
+// -X ...version.Name=<name>; defaults to "hwcloud" in init.
 var Name = ""
 
 // Version is the build version reported to peers and via `--version`.
@@ -26,7 +26,7 @@ var Version = ""
 
 func init() {
 	if Name == "" {
-		Name = "openagent-cli"
+		Name = "hwcloud"
 	}
 	if Version == "" {
 		Version = "0.0.0-dev." + time.Now().Format("20060102150405")

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -33,8 +33,8 @@ func TestPopulated(t *testing.T) {
 func TestDefaultName(t *testing.T) {
 	// We can't distinguish ldflags-injected Name from the default here,
 	// so only assert it's non-empty (covered by TestPopulated). If it's
-	// the default, it must be exactly "openagent-cli".
-	const defaultName = "openagent-cli"
+	// the default, it must be exactly "hwcloud".
+	const defaultName = "hwcloud"
 	if Name == defaultName {
 		return // expected default
 	}


### PR DESCRIPTION
Rename the product binary from `openagent-cli` to `hwcloud` across source, docs, and plugin examples.

## Changes

- **version**: default `Name` now `hwcloud` (reported as ACP/MCP peer identity via `version.Name` in `acp.go` / `mcp.go`)
- **cmd/cli**: cobra `rootCmd.Use`, `run` subcommand `Long`/`Example`
- **plugin examples**: crate names `openagent-cli-plugin-*` → `hwcloud-plugin-*`, `lib.rs` comments, PDK `export.rs` doc example
- **docs**: README/DESIGN (en + zh) command examples and ASCII command trees
- **sandbox**: `native_linux.go` comment

## Out of scope (intentionally unchanged)

- `openagent` standalone token (e.g. `~/.openagent/`, `openagent-pdk` crate) — only the hyphenated `openagent-cli` literal is renamed
- `OPENAGENT_CLI_CONFIG` / `OPENAGENT_CLI_NAME` env vars — public config keys, renaming would break existing users
- `Short: "openagent CLI"` in `main.go` — `openagent` + space + `CLI`, not the hyphenated literal

## Verification

- `go build ./...` ✅
- `go test ./...` — all pass except `embedder/bge` (missing `libonnxruntime.so` in CI env, unrelated to this change)
- 3 example plugins build as wasm: `hwcloud-plugin-stats-cmd`, `hwcloud-plugin-extended-settings`, `hwcloud-plugin-telemetry` ✅