### PR TITLE
feat: add runtime_set_embedding_config host export for in-place embedder credential refresh

### DIFF
--- a/acp/server.go
+++ b/acp/server.go
@@ -535,6 +535,16 @@ func (s *AgentServer) SetModel(provider, modelID, apiKey, baseURL string, maxInp
 	}
 }
 
+// SetEmbedding refreshes the embedder's baseURL, apiKey, and model in
+// place. Used by runtime_set_embedding_config. No-op when no memory
+// provider is configured or the provider does not expose UpdateEmbedder.
+func (s *AgentServer) SetEmbedding(baseURL, apiKey, model string) {
+	if u, ok := s.Deps.MemoryProvider.(interface{ UpdateEmbedder(string, string, string) }); ok {
+		u.UpdateEmbedder(baseURL, apiKey, model)
+		slog.Info("acp embedding config updated")
+	}
+}
+
 // modelIDs returns the registered model ids under modelsMu. SetModel
 // (wasm runtime_set_model_config) can insert concurrently from a tool
 // goroutine, so all iterations must go through this helper.
@@ -1596,7 +1606,7 @@ func (s *AgentServer) OnPrompt(ctx context.Context, req openacp.PromptRequest, s
 
 	// Inject AgentRuntime for runtime_* host exports.
 	if s.PluginMgr != nil {
-		rt := wasm.BuildAgentRuntime(agent, &oaSession, s.SetModel)
+		rt := wasm.BuildAgentRuntime(agent, &oaSession, s.SetModel, s.SetEmbedding)
 		ctx = wasmhost.WithAgentRuntime(ctx, rt)
 	}
 

--- a/embedder/openai/openai.go
+++ b/embedder/openai/openai.go
@@ -37,6 +37,17 @@ func New(baseURL, apiKey, model string) *OpenAI {
 	}
 }
 
+// Update replaces the baseURL, apiKey, and model of an existing embedder
+// in place, under mutex. Used by runtime_set_embedding_config to refresh
+// credentials without restarting the process.
+func (e *OpenAI) Update(baseURL, apiKey, model string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.baseURL = baseURL
+	e.apiKey = apiKey
+	e.model = model
+}
+
 // Embed implements openagent.Embedder.
 func (e *OpenAI) Embed(ctx context.Context, text string) ([]float64, error) {
 	body, err := json.Marshal(map[string]any{

--- a/examples/plugin/main.go
+++ b/examples/plugin/main.go
@@ -96,7 +96,7 @@ func main() {
 	fmt.Println("\n=== Running agent ===")
 
 	// Inject AgentRuntime so runtime_* host APIs work in observers.
-	wrt := wasm.BuildAgentRuntime(rt, &session, nil)
+	wrt := wasm.BuildAgentRuntime(rt, &session, nil, nil)
 	ctx = wasmhost.WithAgentRuntime(ctx, wrt)
 	result, err := rt.Run(ctx, session, openagent.UserMessage("Use the echo tool to echo 'hello plugin', then calculate 15+27"))
 	if err != nil {

--- a/plugin/agent/wasm/abi.go
+++ b/plugin/agent/wasm/abi.go
@@ -141,10 +141,13 @@ const (
 // BuildAgentRuntime constructs a wasmhost.AgentRuntime backed by the given
 // Agent config and Session. The Get/Set closures directly read/write
 // Agent and Session fields. setModel is called by runtime_set_model_config
-// to replace a model in the global registry; it may be nil.
-func BuildAgentRuntime(rt *kernel.Runtime, session *openagent.Session, setModel func(provider, modelID, apiKey, baseURL string, maxInputTokens, maxOutputTokens int)) *wasmhost.AgentRuntime {
+// to replace a model in the global registry; setEmbedding is called by
+// runtime_set_embedding_config to refresh the embedder's credentials.
+// Both may be nil.
+func BuildAgentRuntime(rt *kernel.Runtime, session *openagent.Session, setModel func(provider, modelID, apiKey, baseURL string, maxInputTokens, maxOutputTokens int), setEmbedding func(baseURL, apiKey, model string)) *wasmhost.AgentRuntime {
 	return &wasmhost.AgentRuntime{
-		SetModel: setModel,
+		SetModel:     setModel,
+		SetEmbedding: setEmbedding,
 		Get: func(key string) (string, bool) {
 			switch key {
 			case wasmhost.RuntimeKeySessionID:

--- a/plugin/pdk/rust/src/host.rs
+++ b/plugin/pdk/rust/src/host.rs
@@ -42,6 +42,7 @@ mod ffi {
         pub fn runtime_get_metadata(key_p: u32, key_l: u32) -> u64;
         pub fn runtime_set_metadata(key_p: u32, key_l: u32, val_p: u32, val_l: u32) -> u64;
         pub fn runtime_set_model_config(val_p: u32, val_l: u32) -> u64;
+        pub fn runtime_set_embedding_config(val_p: u32, val_l: u32) -> u64;
         pub fn runtime_set_system_prompts(val_p: u32, val_l: u32) -> u64;
         pub fn runtime_set_max_turns(val_p: u32, val_l: u32) -> u64;
     }
@@ -261,6 +262,12 @@ pub fn runtime_set_metadata(key: &str, val: &str) -> Result<(), String> {
 
 pub fn runtime_set_model_config(json: &str) -> Result<(), String> {
     let packed = unsafe { ffi::runtime_set_model_config(json.as_ptr() as u32, json.len() as u32) };
+    let r: HostResult = parse_host(packed);
+    if !r.error.is_empty() { Err(r.error) } else { Ok(()) }
+}
+
+pub fn runtime_set_embedding_config(json: &str) -> Result<(), String> {
+    let packed = unsafe { ffi::runtime_set_embedding_config(json.as_ptr() as u32, json.len() as u32) };
     let r: HostResult = parse_host(packed);
     if !r.error.is_empty() { Err(r.error) } else { Ok(()) }
 }

--- a/plugin/wasmhost/host_api.go
+++ b/plugin/wasmhost/host_api.go
@@ -99,11 +99,13 @@ type Logger interface {
 
 // AgentRuntime provides plugins with read/write access to the current
 // Agent and Session during a run. Get reads a named value; Set writes one;
-// SetModel replaces a model in the global registry.
+// SetModel replaces a model in the global registry; SetEmbedding refreshes
+// the configured embedder's credentials in place.
 type AgentRuntime struct {
-	Get      func(key string) (string, bool)
-	Set      func(key string, value string) error
-	SetModel func(provider, modelID, apiKey, baseURL string, maxInputTokens, maxOutputTokens int)
+	Get          func(key string) (string, bool)
+	Set          func(key string, value string) error
+	SetModel     func(provider, modelID, apiKey, baseURL string, maxInputTokens, maxOutputTokens int)
+	SetEmbedding func(baseURL, apiKey, model string)
 }
 
 // Runtime key constants used by AgentRuntime.Get/Set.

--- a/plugin/wasmhost/host_module.go
+++ b/plugin/wasmhost/host_module.go
@@ -474,6 +474,14 @@ func (h *HostAPI) RegisterHostModule(ctx context.Context, rt wazero.Runtime) err
 			return h.runtimeSet(ctx, mod, "max_turns", read(mod, valPtr, valLen))
 		}).
 		Export("runtime_set_max_turns").
+		NewFunctionBuilder().
+		WithFunc(func(ctx context.Context, mod api.Module, valPtr, valLen uint32) uint64 {
+			if h.denied("runtime_set_embedding_config") {
+				return writeJSON(ctx, mod, map[string]string{"error": "export runtime_set_embedding_config disabled"})
+			}
+			return h.runtimeSetEmbeddingConfig(ctx, mod, read(mod, valPtr, valLen))
+		}).
+		Export("runtime_set_embedding_config").
 		Instantiate(ctx)
 	return err
 }
@@ -539,6 +547,37 @@ func (h *HostAPI) runtimeSetModelConfig(ctx context.Context, mod api.Module, raw
 		return WriteString(ctx, mod, b)
 	}
 	rt.SetModel(mc.Provider, mc.ModelID, mc.APIKey, mc.BaseURL, mc.MaxInputTokens, mc.MaxOutputTokens)
+	b, _ := json.Marshal(map[string]string{})
+	return WriteString(ctx, mod, b)
+}
+
+// runtimeSetEmbeddingConfig parses a JSON embedding config and calls
+// rt.SetEmbedding to refresh the embedder's credentials in place.
+// Input: {"base_url":"https://...","api_key":"sk-...","model":"text-embedding-3-small"}
+func (h *HostAPI) runtimeSetEmbeddingConfig(ctx context.Context, mod api.Module, raw string) uint64 {
+	rt := AgentRuntimeFromContext(ctx)
+	if rt == nil {
+		b, _ := json.Marshal(map[string]string{"error": "runtime not available"})
+		return WriteString(ctx, mod, b)
+	}
+	if rt.SetEmbedding == nil {
+		b, _ := json.Marshal(map[string]string{"error": "SetEmbedding not configured"})
+		return WriteString(ctx, mod, b)
+	}
+	var ec struct {
+		BaseURL string `json:"base_url"`
+		APIKey  string `json:"api_key"`
+		Model   string `json:"model"`
+	}
+	if err := json.Unmarshal([]byte(raw), &ec); err != nil {
+		b, _ := json.Marshal(map[string]string{"error": err.Error()})
+		return WriteString(ctx, mod, b)
+	}
+	if ec.Model == "" {
+		b, _ := json.Marshal(map[string]string{"error": "model is required"})
+		return WriteString(ctx, mod, b)
+	}
+	rt.SetEmbedding(ec.BaseURL, ec.APIKey, ec.Model)
 	b, _ := json.Marshal(map[string]string{})
 	return WriteString(ctx, mod, b)
 }

--- a/provider/memory/sqlite/memory.go
+++ b/provider/memory/sqlite/memory.go
@@ -55,6 +55,16 @@ func (m *Memory) WithEmbedder(e openagent.Embedder) *Memory {
 	return m
 }
 
+// UpdateEmbedder refreshes the baseURL, apiKey, and model of the configured
+// embedder in place. Used by runtime_set_embedding_config to refresh
+// credentials without restarting. No-op when no embedder is configured or
+// the embedder does not expose an Update method.
+func (m *Memory) UpdateEmbedder(baseURL, apiKey, model string) {
+	if u, ok := m.embedder.(interface{ Update(string, string, string) }); ok {
+		u.Update(baseURL, apiKey, model)
+	}
+}
+
 // Close releases the database connection.
 func (m *Memory) Close() error { return m.db.Close() }
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -155,6 +155,16 @@ func (h *Handler) SetModel(provider, modelID, apiKey, baseURL string, maxInputTo
 	h.modelConfigs[key] = ModelConfig{Provider: provider, ModelID: modelID, APIKey: apiKey, BaseURL: baseURL}
 }
 
+// SetEmbedding refreshes the embedder's baseURL, apiKey, and model in
+// place. Used by runtime_set_embedding_config. No-op when no memory
+// provider is configured or the provider does not expose UpdateEmbedder.
+func (h *Handler) SetEmbedding(baseURL, apiKey, model string) {
+	if u, ok := h.deps.MemoryProvider.(interface{ UpdateEmbedder(string, string, string) }); ok {
+		u.UpdateEmbedder(baseURL, apiKey, model)
+		slog.Info("rest embedding config updated")
+	}
+}
+
 // ModelConfig stores the original apiKey/baseURL for a registered model,
 // used by SetModel to preserve values when only model_id changes.
 type ModelConfig struct {
@@ -448,7 +458,7 @@ func (h *Handler) handleChat(w http.ResponseWriter, r *http.Request) {
 		// Inject AgentRuntime into context so runtime_* host exports work
 		// in agent:observers / agent:tools plugins during this run.
 		if h.pluginMgr != nil {
-			wrt := wasm.BuildAgentRuntime(rt, &oaSession, h.SetModel)
+			wrt := wasm.BuildAgentRuntime(rt, &oaSession, h.SetModel, h.SetEmbedding)
 			ctx = wasmhost.WithAgentRuntime(ctx, wrt)
 		}
 


### PR DESCRIPTION
Adds a new PDK host function runtime_set_embedding_config that allows WASM observer plugins to refresh the embedder's baseURL, apiKey, and model at runtime, mirroring the existing runtime_set_model_config pattern for text models.

Changes:
- embedder/openai: add Update method (mutex-guarded field replacement)
- provider/memory/sqlite: add UpdateEmbedder (interface type-assert)
- plugin/wasmhost: add SetEmbedding to AgentRuntime; register runtime_set_embedding_config export in host module
- plugin/pdk/rust: add FFI decl + safe wrapper
- plugin/agent/wasm: add setEmbedding param to BuildAgentRuntime
- acp/server, rest/handler: add SetEmbedding method, wire to BuildAgentRuntime (both ACP and REST servers)
- examples/plugin: pass nil for the new parameter

**This enables hdspace-renew to update embedding credentials on 401**, preventing stale-key failures in semantic knowledge recall.