### PR TITLE
fix(result): guard against artifact-of-artifact cascade on read/grep

### DIFF
--- a/execution/runtime.go
+++ b/execution/runtime.go
@@ -284,7 +284,30 @@ func (e *ExecutionRuntime) executeOnce(ctx context.Context, session openagent.Se
 
 	// Result policy (truncation) — after hooks so redaction happens first.
 	if e.cfg.ResultPolicy != nil && result != nil {
+		// Stamp tool identity into metadata so DefaultResultPolicy can
+		// detect reads of its own artifact files and skip re-truncation
+		// (prevents the artifact-of-artifact cascade: shell output →
+		// artifact A → read A → artifact B → ...). Tools may already
+		// populate Metadata (exit_code, mime, ...); init only when nil
+		// and overwrite just these two policy-internal keys.
+		//
+		// The keys are deleted immediately after Apply returns so they
+		// never flow downstream: tool_args is the raw tool argument JSON
+		// (shell command text, file paths, ...) and redaction runs BEFORE
+		// this stamp, so it cannot scrub these keys. Leaving them in
+		// metadata would leak sensitive content through the ACP
+		// JSON-RPC result and observer/log spans.
+		if result.Metadata == nil {
+			result.Metadata = map[string]any{}
+		}
+		result.Metadata["tool_name"] = call.Function.Name
+		result.Metadata["tool_args"] = args
 		result = e.cfg.ResultPolicy.Apply(toolCtx, session, result)
+		delete(result.Metadata, "tool_name")
+		delete(result.Metadata, "tool_args")
+		if len(result.Metadata) == 0 {
+			result.Metadata = nil
+		}
 	}
 
 	return toolResultMessage(call, result)

--- a/result.go
+++ b/result.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -147,6 +148,53 @@ func (p *DefaultResultPolicy) Apply(ctx context.Context, session Session, result
 		return result
 	}
 
+	// Guard against the artifact-of-artifact cascade: when "read" targets
+	// a path under ArtifactRoot() and the result exceeds the threshold,
+	// truncate IN PLACE instead of spilling to a new artifact file.
+	//
+	// Why in-place and not "skip truncation entirely": the artifact file
+	// can be much larger than the model's input limit (a 576 KB artifact
+	// vs a 307 K-char API cap). Skipping truncation lets the full content
+	// into the prompt, which the model API rejects with a 400 "prompt
+	// length exceeds" — the model cannot read the file at all. In-place
+	// truncation returns a token-bounded preview (≤ threshold) plus a
+	// pointer to the SAME artifact file (FileRef), so the model can page
+	// through with read line=N+1. No new artifact file is created, so the
+	// cascade (artifact A → read A → artifact B → ...) is broken.
+	//
+	// Why only "read" (not "grep"): see artifactReadPath. grep's FileRef
+	// would point at the grepped file, not the match list — the model
+	// could not page correctly. grep overflow is also rare and
+	// self-terminating.
+	if artifactPath, startLine, hasPrefix := p.artifactReadPath(result.Metadata); artifactPath != "" {
+		origBytes := len(result.Content)
+		preview, lines := truncatePreview(modelID, result.Content, threshold)
+		// truncatePreview counts every '\n' in the truncated Content, but
+		// read inserts a "[lines N-M, total, bytes]:\n" summary prefix when
+		// line>1 or limit>0 (tool/file.go). That prefix line is NOT file
+		// data — counting it would make the continuation hint advance past
+		// real content by one line per page, permanently skipping a line
+		// each turn (off-by-one pagination). Subtract it when present.
+		dataLines := lines
+		if hasPrefix && dataLines > 0 {
+			dataLines--
+		}
+		continueLine := startLine + dataLines
+		result.Content = preview + fmt.Sprintf(
+			"\n... [%d lines shown of a larger artifact file (starting at line %d); to continue, call read with path=%s line=%d]",
+			dataLines, startLine, artifactPath, continueLine)
+		result.Truncated = true
+		result.FileRef = artifactPath
+		if result.Metadata == nil {
+			result.Metadata = map[string]any{}
+		}
+		// Match the spill path semantics: artifact_bytes is the ORIGINAL
+		// output size, not the truncated preview+hint length, so
+		// observers/logs tracking true output size agree across paths.
+		result.Metadata["artifact_bytes"] = origBytes
+		return result
+	}
+
 	dir := filepath.Join(ArtifactRoot(), "sess-"+SanitizeName(session.ID))
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		// Truncation failed: log instead of silently flooding the model
@@ -177,6 +225,174 @@ func (p *DefaultResultPolicy) Apply(ctx context.Context, session Session, result
 	}
 	result.Metadata["artifact_bytes"] = origBytes
 	return result
+}
+
+// artifactReadPath returns the absolute artifact-file path, the 1-based start
+// line of the read, and whether read will have inserted its "[lines ...]:"
+// summary prefix (true when line>1 or limit>0), when the tool call that
+// produced this result is a "read" targeting a path under ArtifactRoot().
+// It returns ("",0,false) otherwise. The runtime stamps "tool_name" and
+// "tool_args" into result.Metadata before calling Apply; when absent (e.g. a
+// third-party policy or a tool that clears metadata) the guard returns
+// ("",0,false) and truncation proceeds as usual.
+//
+// Only "read" is guarded, not "grep":
+//   - The cascade's real trigger is read (shell big output → artifact A →
+//     read A → artifact B → ...). grep output is matching lines, which is
+//     a subset of the file and almost always under threshold; a wide
+//     grep (".*") that does overflow naturally terminates (each step's
+//     output ⊂ the file), unlike read's identity-copy cascade.
+//   - read's FileRef semantics are exact after in-place truncation: the
+//     truncated Content is a prefix of the file (from the start line)
+//     and FileRef points at that same file, so the model can continue
+//     with read line=startLine+linesShown. grep's FileRef would point
+//     at the file it grepped, not at the match list — misleading the
+//     model if it tries to continue.
+//
+// hasPrefix is returned so the caller can subtract the prefix line from the
+// line count when computing the continuation line number — read inserts the
+// prefix unconditionally when line>1 or limit>0, and counting it as file
+// data would advance the hint past real content (off-by-one per page).
+//
+// Path resolution uses filepath.Abs so relative paths like
+// "../../tmp/openagent/..." are caught — the old hooks/artifact guard
+// used a raw strings.HasPrefix that missed relative paths.
+func (p *DefaultResultPolicy) artifactReadPath(meta map[string]any) (path string, startLine int, hasPrefix bool) {
+	if meta == nil {
+		return "", 0, false
+	}
+	name, _ := meta["tool_name"].(string)
+	if name != "read" {
+		return "", 0, false
+	}
+	raw, _ := meta["tool_args"].(json.RawMessage)
+	if len(raw) == 0 {
+		return "", 0, false
+	}
+	var params struct {
+		Path  string `json:"path"`
+		Line  int    `json:"line"`
+		Limit int    `json:"limit"`
+	}
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return "", 0, false
+	}
+	if params.Path == "" {
+		return "", 0, false
+	}
+	abs, err := filepath.Abs(filepath.Clean(params.Path))
+	if err != nil {
+		return "", 0, false
+	}
+	root := ArtifactRoot()
+	if strings.HasPrefix(abs, root+string(filepath.Separator)) {
+		// read's Line is 1-based; 0/unspecified means 1. Normalize so
+		// the continuation hint (startLine + linesShown) is correct.
+		start := params.Line
+		if start <= 0 {
+			start = 1
+		}
+		// read inserts its "[lines N-M, total, bytes]:\n" prefix exactly
+		// when line>1 or limit>0 (tool/file.go). Mirror that condition so
+		// the caller can discount the prefix line from the data line count.
+		return abs, start, params.Line > 1 || params.Limit > 0
+	}
+	return "", 0, false
+}
+
+// truncatePreview returns a prefix of s that fits within maxTokens (measured
+// with the same tokenizer the runner uses), cut at a line boundary so the
+// caller can report an exact "shown N lines, continue at line N+1" hint.
+// Also returns the number of complete lines in the preview.
+//
+// Used by Apply when "read" targets an existing artifact file: instead of
+// spilling the content to a NEW artifact file (which would restart the
+// cascade), we give the model a bounded preview of the SAME file and let
+// it page with read line=N+1. The preview is capped at the result-policy
+// threshold (context window × artifactFraction %), which is far below the
+// model's input limit, so the prompt never overflows.
+//
+// Algorithm: estimate a byte cutoff from the token ratio, snap left to the
+// previous '\n' (line boundary), then verify with CountTokens. If still
+// over budget (the ratio estimate is coarse for non-ASCII), halve and
+// re-snap until it fits — at most ~log2(len) iterations.
+func truncatePreview(modelID, s string, maxTokens int) (preview string, lines int) {
+	if maxTokens <= 0 || len(s) == 0 {
+		return "", 0
+	}
+	if CountTokens(modelID, s) <= maxTokens {
+		// Fast path: entire content fits. NOTE: this branch is currently
+		// unreachable from Apply, which pre-filters at result.go:147
+		// (CountTokens <= threshold → early return) before calling
+		// truncatePreview. The +1 here vs the no-+1 in the truncation
+		// path below is intentional but semantically inconsistent: this
+		// path counts the trailing line without a '\n' (the whole content
+		// is shown), while the truncation path counts only complete lines
+		// (cut at a '\n', no trailing partial line). If a future caller
+		// reaches this path, reconcile the lines semantic — the caller
+		// uses `lines` to compute a continuation line number where the
+		// no-+1 "complete lines only" meaning is required.
+		return s, strings.Count(s, "\n") + 1
+	}
+	// Initial estimate: bytes ≈ tokens × (len/totalTokens), with 10%
+	// headroom for the ratio's coarseness on multi-byte text.
+	totalTokens := CountTokens(modelID, s)
+	if totalTokens <= 0 {
+		totalTokens = 1
+	}
+	cutoff := len(s) * maxTokens / totalTokens * 9 / 10
+	if cutoff < 1 {
+		cutoff = 1
+	}
+	// Snap to the previous line boundary (keep complete lines only).
+	snapToLine := func(c int) int {
+		if c >= len(s) {
+			c = len(s)
+		}
+		if idx := strings.LastIndexByte(s[:c], '\n'); idx >= 0 {
+			return idx + 1 // first byte after the newline
+		}
+		return 0 // no line boundary found
+	}
+	cutoff = snapToLine(cutoff)
+	// Verify and halve if the estimate was too high.
+	for cutoff > 0 && CountTokens(modelID, s[:cutoff]) > maxTokens {
+		cutoff = snapToLine(cutoff / 2)
+	}
+	if cutoff > 0 {
+		return s[:cutoff], strings.Count(s[:cutoff], "\n")
+	}
+	// No line boundary found in the budget: the content is a single line
+	// longer than the token budget (minified JSON, base64, a huge log
+	// line). Returning ("",0) would give the model "0 lines shown" and
+	// force a re-read of the same line → infinite loop. Fall back to a
+	// byte-level cut so the preview is non-empty and the model can make
+	// progress. The cut may split a token/multibyte rune — we accept
+	// that over showing nothing, because the alternative is a livelock
+	// where the file content is never visible at all.
+	//
+	// Byte-level fallback: find the largest byte count ≤ the initial
+	// estimate that fits the token budget, without requiring a newline.
+	cutoff = len(s) * maxTokens / totalTokens * 9 / 10
+	if cutoff < 1 {
+		cutoff = 1
+	}
+	if cutoff > len(s) {
+		cutoff = len(s)
+	}
+	for cutoff > 0 && CountTokens(modelID, s[:cutoff]) > maxTokens {
+		cutoff /= 2
+	}
+	if cutoff == 0 {
+		cutoff = 1 // never return empty for non-empty input
+	}
+	// Report 1 line: there is no newline, but the model sees one logical
+	// line of content (truncated). The continuation hint will re-suggest
+	// the same start line — read has no byte-offset paging, so the model
+	// re-reads the same line and truncatePreview again takes the prefix.
+	// This is not a clean page (the line repeats on re-read), but it
+	// avoids the livelock and the content is at least visible.
+	return s[:cutoff], 1
 }
 
 // maxArtifactLine is the line length cap applied when spilling an

--- a/result_test.go
+++ b/result_test.go
@@ -2,8 +2,11 @@ package openagent
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -193,5 +196,378 @@ func TestWrapLongLinesTreatsCRAsLineEnding(t *testing.T) {
 	got = wrapLongLines(long, 1024)
 	if !strings.Contains(got, wrapMarker) {
 		t.Fatal("long CRLF-terminated line was not wrapped")
+	}
+}
+
+// TestDefaultResultPolicy_ArtifactReadInPlaceTruncated verifies the guard
+// that prevents the artifact-of-artifact cascade: when "read" targets a
+// path under ArtifactRoot() and the result exceeds the threshold, Apply
+// truncates IN PLACE (Content → bounded preview, FileRef → the SAME
+// artifact file) instead of spilling to a new artifact file. "grep" is
+// not guarded — it goes through normal spill truncation.
+func TestDefaultResultPolicy_ArtifactReadInPlaceTruncated(t *testing.T) {
+	scratch := t.TempDir()
+	t.Setenv("TMPDIR", scratch)
+	root := ArtifactRoot()
+
+	// Window = 10_000 → threshold = 500 tokens. 5000 bytes ≈ 625 tokens
+	// > 500 → would be truncated without the guard.
+	const big = 5000
+	bigRes := strings.Repeat("x\n", big/2) // newlines so truncatePreview can snap to line boundary
+	sess := Session{ID: "s-guard", Model: &fakeWindowModel{cw: 10_000}}
+	policy := &DefaultResultPolicy{}
+	ctx := context.Background()
+
+	// First Apply: no tool metadata → truncates and creates artifact A
+	// (normal spill path).
+	res1 := policy.Apply(ctx, sess, &ToolResult{Content: bigRes})
+	if !res1.Truncated || res1.FileRef == "" {
+		t.Fatalf("baseline: big result should truncate, got %+v", res1)
+	}
+	artifactPath := res1.FileRef
+	if !strings.HasPrefix(artifactPath, root) {
+		t.Fatalf("artifact path %q not under ArtifactRoot %q", artifactPath, root)
+	}
+	artifactsBefore := countArtifacts(t, root)
+
+	// Helper: build metadata as the runtime call site would.
+	toolMeta := func(tool, path string) map[string]any {
+		args, _ := json.Marshal(map[string]string{"path": path})
+		return map[string]any{
+			"tool_name": tool,
+			"tool_args": json.RawMessage(args),
+		}
+	}
+
+	// read on the artifact path → in-place truncation: Truncated=true,
+	// FileRef points at the SAME artifact file, Content is a prefix, and
+	// NO new artifact file is created.
+	res2 := policy.Apply(ctx, sess, &ToolResult{Content: bigRes, Metadata: toolMeta("read", artifactPath)})
+	if !res2.Truncated {
+		t.Fatal("read of artifact should be Truncated (in-place)")
+	}
+	if res2.FileRef != artifactPath {
+		t.Fatalf("FileRef should point at the same artifact file %q, got %q", artifactPath, res2.FileRef)
+	}
+	if res2.Content == bigRes {
+		t.Fatal("Content should be a truncated preview, not the full content")
+	}
+	// Content is preview + continuation hint; the preview portion (before
+	// the "\n..." hint) must be a prefix of the original at a line boundary.
+	hintIdx := strings.Index(res2.Content, "\n... [")
+	if hintIdx < 0 {
+		t.Fatalf("Content missing continuation hint: %q", res2.Content)
+	}
+	preview := res2.Content[:hintIdx]
+	if !strings.HasPrefix(bigRes, preview) {
+		t.Fatal("Content preview should be a prefix of the original content")
+	}
+	if !strings.Contains(res2.Content, "continue") {
+		t.Fatal("Content should contain a continuation hint")
+	}
+	// No new artifact file created.
+	if n := countArtifacts(t, root); n != artifactsBefore {
+		t.Fatalf("in-place truncation created a new artifact file: before=%d after=%d", artifactsBefore, n)
+	}
+
+	// grep on the artifact path → NOT guarded → normal spill truncation
+	// (creates a new artifact file). grep is excluded from the guard
+	// because its FileRef would point at the grepped file, not the match
+	// list, and grep overflow is rare/self-terminating.
+	res3 := policy.Apply(ctx, sess, &ToolResult{Content: bigRes, Metadata: toolMeta("grep", artifactPath)})
+	if !res3.Truncated {
+		t.Fatal("grep of artifact should be truncated (normal spill, not guarded)")
+	}
+	if res3.FileRef == artifactPath {
+		t.Fatal("grep spill should create a NEW artifact file, not reuse the source")
+	}
+
+	// grep with empty path (defaults to workspace) → truncates normally.
+	emptyArgs, _ := json.Marshal(map[string]string{})
+	res4 := policy.Apply(ctx, sess, &ToolResult{Content: bigRes, Metadata: map[string]any{
+		"tool_name": "grep",
+		"tool_args": json.RawMessage(emptyArgs),
+	}})
+	if !res4.Truncated {
+		t.Fatal("grep with empty path should still truncate")
+	}
+
+	// read of a non-artifact path → guard false → normal spill truncation.
+	res5 := policy.Apply(ctx, sess, &ToolResult{Content: bigRes, Metadata: toolMeta("read", "/workspace/main.go")})
+	if !res5.Truncated {
+		t.Fatal("read of non-artifact path should still truncate")
+	}
+	if res5.FileRef == "/workspace/main.go" {
+		t.Fatal("non-artifact read should spill to a new file, not set FileRef to the read path")
+	}
+
+	// read with a relative path that resolves under ArtifactRoot → guard
+	// catches it via filepath.Abs and truncates in place.
+	cwd, _ := os.Getwd()
+	relPath, err := filepath.Rel(cwd, artifactPath)
+	if err != nil {
+		t.Fatalf("filepath.Rel: %v", err)
+	}
+	artifactsBeforeRel := countArtifacts(t, root)
+	res6 := policy.Apply(ctx, sess, &ToolResult{Content: bigRes, Metadata: toolMeta("read", relPath)})
+	if !res6.Truncated || res6.FileRef != artifactPath {
+		t.Fatalf("read via relative artifact path %q: Truncated=%v FileRef=%q, want in-place truncation with FileRef=%q",
+			relPath, res6.Truncated, res6.FileRef, artifactPath)
+	}
+	if n := countArtifacts(t, root); n != artifactsBeforeRel {
+		t.Fatalf("relative-path in-place truncation created a new artifact file: before=%d after=%d", artifactsBeforeRel, n)
+	}
+
+	// No metadata at all → guard false → normal spill truncation.
+	res7 := policy.Apply(ctx, sess, &ToolResult{Content: bigRes})
+	if !res7.Truncated {
+		t.Fatal("result with no metadata should still truncate")
+	}
+}
+
+// countArtifacts counts artifact-*.txt files under root (the test's
+// TMPDIR-scoped ArtifactRoot). Used to assert that in-place truncation
+// does not create a new artifact file.
+func countArtifacts(t *testing.T, root string) int {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(root, "*", "artifact-*.txt"))
+	if err != nil {
+		t.Fatalf("glob artifacts: %v", err)
+	}
+	return len(matches)
+}
+
+// TestTruncatePreview_SingleHugeLine verifies the byte-level fallback: a
+// single line with no newlines that exceeds the token budget must still
+// produce a non-empty preview (lines >= 1), never ("", 0). Returning empty
+// would give the model "0 lines shown" and force a re-read of the same
+// line → infinite loop.
+func TestTruncatePreview_SingleHugeLine(t *testing.T) {
+	// A single line with no '\n', large enough to exceed a small budget.
+	big := strings.Repeat("x", 10000)
+	preview, lines := truncatePreview("gpt-4", big, 100)
+	if preview == "" {
+		t.Fatal("single huge line: preview must not be empty (would cause infinite loop)")
+	}
+	if lines < 1 {
+		t.Fatalf("single huge line: lines = %d, want >= 1", lines)
+	}
+	if CountTokens("gpt-4", preview) > 100 {
+		t.Fatalf("preview exceeds token budget: %d > 100", CountTokens("gpt-4", preview))
+	}
+}
+
+// TestTruncatePreview_NormalMultiLine verifies the line-boundary path: for
+// multi-line content with newlines, the preview is a prefix cut at a line
+// boundary and lines counts the newlines in the preview.
+func TestTruncatePreview_NormalMultiLine(t *testing.T) {
+	// 100 lines, each ~100 bytes → ~10000 bytes total. Budget 500 tokens
+	// (~2000 bytes) → should keep a prefix at a line boundary.
+	var b strings.Builder
+	for i := 1; i <= 100; i++ {
+		fmt.Fprintf(&b, "line %d %s\n", i, strings.Repeat("x", 90))
+	}
+	s := b.String()
+	preview, lines := truncatePreview("gpt-4", s, 500)
+	if preview == "" {
+		t.Fatal("multi-line preview empty")
+	}
+	if !strings.HasPrefix(s, preview) {
+		t.Fatal("preview must be a prefix of the input")
+	}
+	// Preview ends at a line boundary (no partial line).
+	if len(preview) > 0 && preview[len(preview)-1] != '\n' {
+		t.Fatalf("preview not cut at line boundary: ends %q", preview[len(preview)-10:])
+	}
+	wantLines := strings.Count(preview, "\n")
+	if lines != wantLines {
+		t.Fatalf("lines = %d, want %d (newline count in preview)", lines, wantLines)
+	}
+}
+
+// TestDefaultResultPolicy_ArtifactReadPaginationNoOffByOne simulates the
+// model paging through a large artifact file by repeated Apply calls, each
+// time passing the continuation line from the previous hint as the read
+// start line. It asserts that:
+//   - every source line is covered (no skips),
+//   - no line is duplicated,
+//   - the continuation line advances strictly past the data shown.
+//
+// This is the regression test for the off-by-one where read's "[lines ...]:"
+// prefix was counted as file data, making each page skip one real line.
+func TestDefaultResultPolicy_ArtifactReadPaginationNoOffByOne(t *testing.T) {
+	scratch := t.TempDir()
+	t.Setenv("TMPDIR", scratch)
+	root := ArtifactRoot()
+
+	// Build a large multi-line content that exceeds threshold when read
+	// in full. Window 10_000 → threshold 500 tokens. ~5000 bytes of
+	// numbered lines → ~625 tokens > 500.
+	const numLines = 300
+	var b strings.Builder
+	for i := 1; i <= numLines; i++ {
+		fmt.Fprintf(&b, "line %d\n", i)
+	}
+	bigRes := b.String()
+
+	sess := Session{ID: "s-paginate", Model: &fakeWindowModel{cw: 10_000}}
+	policy := &DefaultResultPolicy{}
+	ctx := context.Background()
+
+	// Spill to create the artifact file A.
+	res1 := policy.Apply(ctx, sess, &ToolResult{Content: bigRes})
+	if !res1.Truncated || res1.FileRef == "" {
+		t.Fatalf("baseline spill failed: %+v", res1)
+	}
+	artifactPath := res1.FileRef
+	if !strings.HasPrefix(artifactPath, root) {
+		t.Fatalf("artifact not under ArtifactRoot: %q", artifactPath)
+	}
+
+	// Read the artifact file from disk (what the read tool would return).
+	artifactContent, err := os.ReadFile(artifactPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate the model paging: start at line 1, each Apply produces a
+	// preview + continuation hint; extract the next line from the hint
+	// and repeat until the hint says no more content.
+	seen := map[string]bool{}
+	startLine := 1
+	iterations := 0
+	const maxIterations = 100 // 300 lines / ~10-20 per page → well under 100
+
+	for iterations < maxIterations {
+		iterations++
+
+		// Simulate what the read tool returns for this page: a "[lines ...]:"
+		// prefix (read inserts it when line>1 or limit>0) + the file content
+		// from startLine onward.
+		fileLines := strings.Split(string(artifactContent), "\n")
+		if startLine > len(fileLines) {
+			break // past end
+		}
+		// read's prefix line (tool/file.go:134-137).
+		var pageContent string
+		if startLine > 1 {
+			pageContent = fmt.Sprintf("[lines %d-%d, %d total, %d bytes]:\n",
+				startLine, len(fileLines), len(fileLines), len(artifactContent))
+		}
+		pageContent += strings.Join(fileLines[startLine-1:], "\n")
+
+		args, _ := json.Marshal(map[string]any{"path": artifactPath, "line": startLine})
+		res := policy.Apply(ctx, sess, &ToolResult{
+			Content: pageContent,
+			Metadata: map[string]any{
+				"tool_name": "read",
+				"tool_args": json.RawMessage(args),
+			},
+		})
+
+		if !res.Truncated {
+			// Content fit in budget — all remaining lines shown.
+			for _, ln := range fileLines[startLine-1:] {
+				if ln == "" {
+					continue
+				}
+				if seen[ln] {
+					t.Fatalf("duplicate line %q at startLine=%d", ln, startLine)
+				}
+				seen[ln] = true
+			}
+			break
+		}
+
+		// Extract the continuation line from the hint.
+		hintIdx := strings.Index(res.Content, "\n... [")
+		if hintIdx < 0 {
+			t.Fatalf("missing continuation hint at startLine=%d: %q", startLine, res.Content)
+		}
+		preview := res.Content[:hintIdx]
+		// Parse "line=N" from the hint.
+		hint := res.Content[hintIdx:]
+		lineIdx := strings.Index(hint, "line=")
+		if lineIdx < 0 {
+			t.Fatalf("hint missing line= at startLine=%d: %q", startLine, hint)
+		}
+		numStr := hint[lineIdx+len("line="):]
+		end := strings.IndexAny(numStr, " \n]")
+		if end < 0 {
+			end = len(numStr)
+		}
+		nextLine, err := strconv.Atoi(numStr[:end])
+		if err != nil {
+			t.Fatalf("parse continuation line at startLine=%d: %v", startLine, err)
+		}
+
+		// Verify the preview lines are seen exactly once.
+		for _, ln := range strings.Split(preview, "\n") {
+			// Skip the read prefix line and empty lines.
+			if ln == "" || strings.HasPrefix(ln, "[lines ") {
+				continue
+			}
+			if seen[ln] {
+				t.Fatalf("duplicate line %q at startLine=%d", ln, startLine)
+			}
+			seen[ln] = true
+		}
+
+		if nextLine <= startLine {
+			t.Fatalf("continuation line %d did not advance past startLine %d (infinite loop)", nextLine, startLine)
+		}
+		startLine = nextLine
+	}
+
+	if iterations >= maxIterations {
+		t.Fatalf("pagination did not terminate in %d iterations (infinite loop)", maxIterations)
+	}
+
+	// Assert every non-empty source line was seen (no skips).
+	sourceLines := strings.Split(string(artifactContent), "\n")
+	for _, ln := range sourceLines {
+		if ln == "" {
+			continue
+		}
+		if !seen[ln] {
+			t.Fatalf("line %q was never shown — pagination skipped it", ln)
+		}
+	}
+}
+
+// TestDefaultResultPolicy_ArtifactReadBytesSemantics asserts the in-place
+// truncation path records artifact_bytes as the ORIGINAL content size (pre-
+// truncation), matching the spill path semantics.
+func TestDefaultResultPolicy_ArtifactReadBytesSemantics(t *testing.T) {
+	scratch := t.TempDir()
+	t.Setenv("TMPDIR", scratch)
+
+	const big = 5000
+	bigRes := strings.Repeat("x\n", big/2)
+	sess := Session{ID: "s-bytes", Model: &fakeWindowModel{cw: 10_000}}
+	policy := &DefaultResultPolicy{}
+	ctx := context.Background()
+
+	// Spill to get an artifact path.
+	res1 := policy.Apply(ctx, sess, &ToolResult{Content: bigRes})
+	artifactPath := res1.FileRef
+
+	args, _ := json.Marshal(map[string]string{"path": artifactPath})
+	res2 := policy.Apply(ctx, sess, &ToolResult{
+		Content: bigRes,
+		Metadata: map[string]any{
+			"tool_name": "read",
+			"tool_args": json.RawMessage(args),
+		},
+	})
+	if !res2.Truncated {
+		t.Fatal("expected in-place truncation")
+	}
+	got, ok := res2.Metadata["artifact_bytes"].(int)
+	if !ok {
+		t.Fatalf("artifact_bytes not int: %T %v", res2.Metadata["artifact_bytes"], res2.Metadata["artifact_bytes"])
+	}
+	if got != len(bigRes) {
+		t.Fatalf("artifact_bytes = %d, want original size %d (spill-path semantics)", got, len(bigRes))
 	}
 }


### PR DESCRIPTION
## Problem

`DefaultResultPolicy.Apply` truncates oversized tool output to an artifact file and tells the model to `read`/`grep` it. When the model complies, read/grep's own output is also oversized, so `Apply` truncates it into a **second artifact** — repeating forever. Each step adds a disk file + a tool round-trip and never actually shrinks what the model sees.

## Root cause

The production `hooks/artifact/hook.go` (deleted in `11523d10` "rebuild into Agent Runtime Kernel") had an `isReadingArtifact(args)` guard that skipped re-saving when read/grep targeted a path under `ArtifactRoot()`. The guard was **lost in the refactor** because the new `Apply(ctx, session, result)` signature has no access to tool name or args.

## Reproduction (real model API, compiled binary)

- `shell seq 1 100000` → artifact A (588895 bytes)
- `read A` (full, no line/limit) → **artifact B** (588895 bytes, identical content) → cascade confirmed

## Fix

Restore the guard without changing the public `ResultPolicy` interface (changing `Apply`'s signature would break external implementors):

- **execution/runtime.go**: stamp `tool_name` + `tool_args` into `result.Metadata` before calling `Apply`, then **delete both keys immediately after** `Apply` returns so they never flow downstream (`tool_args` is raw arg JSON that may carry secrets; redaction runs before the stamp and cannot scrub it).
- **result.go**: `DefaultResultPolicy.isArtifactRead` reads the stamped metadata; for `read`/`grep` whose `Path` resolves under `ArtifactRoot()` it skips truncation entirely. `filepath.Abs` first so relative paths are caught (the old hook's raw `HasPrefix` missed them). Empty `Path` (grep defaulting to workspace) falls through to truncation.
- **result_test.go**: `TestDefaultResultPolicy_ArtifactReadNotRetruncated` covers read/grep on artifact path (skip), empty path (truncate), non-artifact path (truncate), relative path resolution, and no-metadata backward compat.

## Verification

- Regression test passes.
- `go vet` + `gofmt` clean.
- Full `go test ./...`: no new failures (two pre-existing `plugin/agent/wasm` decision-probe failures are unrelated — fail on baseline too).
- **End-to-end**: after the fix, `read` of artifact A no longer produces artifact B (artifact file count stays at 1); paged `read` returns content normally.