### PR TITLE
feat(iac): add check_drift MCP tool for terraform drift detection

### DIFF
--- a/cmd/mcp/iac-server/agent/dag.go
+++ b/cmd/mcp/iac-server/agent/dag.go
@@ -25,6 +25,9 @@ const DagVersion = 1
 // CostVersion is the current cost.json schema version.
 const CostVersion = 1
 
+// DriftVersion is the current drift.json schema version.
+const DriftVersion = 1
+
 // DagStatus tracks how far a deployment has progressed. Steps enforce a
 // minimum status (e.g. generate requires "specified") by checking the DAG
 // they load.
@@ -301,4 +304,76 @@ func invalidateCost(dir string) error {
 		return fmt.Errorf("invalidate cost.json: %w", err)
 	}
 	return nil
+}
+
+// ── Drift detection (check_drift) ──
+
+// DriftStatus is the outcome of a drift check.
+type DriftStatus string
+
+const (
+	DriftClean       DriftStatus = "clean"        // no drift — cloud matches desired state
+	DriftDetected    DriftStatus = "drifted"      // cloud differs from desired state
+	DriftCheckFailed DriftStatus = "check_failed" // terraform plan failed during refresh
+)
+
+// DriftChange describes a single resource diff found by check_drift.
+// Fields mirror iac.ResourceChange but are self-contained so dag.go stays
+// free of iac-package dependencies (same pattern as CostEstimate using []any).
+type DriftChange struct {
+	Address string          `json:"address"`
+	Type    string          `json:"type"`
+	Action  string          `json:"action"` // "create" | "update" | "delete"
+	Before  json.RawMessage `json:"before,omitempty"`
+	After   json.RawMessage `json:"after,omitempty"`
+}
+
+// DriftSummary counts drifted resources by action.
+type DriftSummary struct {
+	Create int `json:"create"`
+	Update int `json:"update"`
+	Delete int `json:"delete"`
+	Noop   int `json:"noop"`
+}
+
+// DriftResult is the persisted check_drift result, analogous to CostEstimate.
+// check_drift writes this to drift.json in the deployment directory; it does
+// NOT modify dag.json or cost.json — drift is a read-only side observation.
+type DriftResult struct {
+	Version      int           `json:"version"`
+	DeploymentID string        `json:"deployment_id"`
+	CheckedAt    string        `json:"checked_at"`
+	Status       DriftStatus   `json:"status"`
+	Summary      DriftSummary  `json:"summary"` // always emitted (omitempty has no effect on structs)
+	Changes      []DriftChange `json:"changes,omitempty"`
+	Error        string        `json:"error,omitempty"` // populated when status=check_failed
+}
+
+// driftPath returns the drift.json path inside a deployment directory.
+func driftPath(dir string) string {
+	return filepath.Join(dir, "drift.json")
+}
+
+// SaveDrift persists a drift check result atomically (tmp + rename).
+func SaveDrift(dir string, r *DriftResult) error {
+	data, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal drift.json: %w", err)
+	}
+	return atomicWrite(driftPath(dir), data)
+}
+
+// DriftStatusOf returns the persisted drift status, or "" if no drift
+// check has been run (drift.json missing or unreadable). list_deployments
+// uses this to report drift_status per deployment.
+func DriftStatusOf(dir string) DriftStatus {
+	data, err := os.ReadFile(driftPath(dir))
+	if err != nil {
+		return ""
+	}
+	var r DriftResult
+	if err := json.Unmarshal(data, &r); err != nil {
+		return ""
+	}
+	return r.Status
 }

--- a/cmd/mcp/iac-server/agent/dag_test.go
+++ b/cmd/mcp/iac-server/agent/dag_test.go
@@ -354,3 +354,49 @@ func BenchmarkLoadDag(b *testing.B) {
 		}
 	}
 }
+
+// ── Drift helpers ──
+
+func TestSaveDrift_DriftStatusOf(t *testing.T) {
+	dir := t.TempDir()
+
+	// No drift.json yet — DriftStatusOf returns "".
+	if s := DriftStatusOf(dir); s != "" {
+		t.Fatalf("expected empty status before any check, got %q", s)
+	}
+
+	// Save a clean result.
+	r := &DriftResult{
+		Version:      DriftVersion,
+		DeploymentID: "d-001",
+		CheckedAt:    "2026-09-01T00:00:00Z",
+		Status:       DriftClean,
+	}
+	if err := SaveDrift(dir, r); err != nil {
+		t.Fatal(err)
+	}
+	if s := DriftStatusOf(dir); s != DriftClean {
+		t.Fatalf("expected clean, got %q", s)
+	}
+
+	// Overwrite with drifted.
+	r.Status = DriftDetected
+	r.Changes = []DriftChange{{Address: "t.a", Type: "t", Action: "update"}}
+	if err := SaveDrift(dir, r); err != nil {
+		t.Fatal(err)
+	}
+	if s := DriftStatusOf(dir); s != DriftDetected {
+		t.Fatalf("expected drifted, got %q", s)
+	}
+}
+
+func TestDriftStatusOf_UnreadableReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	// Write invalid JSON — DriftStatusOf returns "" on parse error.
+	if err := os.WriteFile(filepath.Join(dir, "drift.json"), []byte("not json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if s := DriftStatusOf(dir); s != "" {
+		t.Fatalf("expected empty for unparseable drift.json, got %q", s)
+	}
+}

--- a/cmd/mcp/iac-server/mcp/tools.go
+++ b/cmd/mcp/iac-server/mcp/tools.go
@@ -37,7 +37,7 @@ type Config struct {
 	ProviderMirrors []string // provider download mirrors (URLs or local paths)
 }
 
-// NewTools builds the 12 tools exposed by iac-server.
+// NewTools builds the 13 tools exposed by iac-server.
 func NewTools(cfg Config) []openagent.Tool {
 	return []openagent.Tool{
 		&proposeArchitectureTool{cfg: cfg},
@@ -47,6 +47,7 @@ func NewTools(cfg Config) []openagent.Tool {
 		&troubleshootDeploymentTool{cfg: cfg},
 		&applyDeploymentTool{cfg: cfg},
 		&destroyDeploymentTool{cfg: cfg},
+		&checkDriftTool{cfg: cfg},
 		&getDeploymentStatusTool{cfg: cfg},
 		&listDeploymentsTool{cfg: cfg},
 		&queryCloudTool{cfg: cfg},
@@ -273,7 +274,7 @@ type applyDeploymentTool struct{ cfg Config }
 func (t *applyDeploymentTool) Definition() openagent.FunctionDefinition {
 	return openagent.FunctionDefinition{
 		Name:        "apply_deployment",
-		Description: "Step 5 of deployment: Apply a saved terraform plan. This creates/modifies real cloud resources. The deployment must have been planned (generate_terraform_plan succeeded) AND cost-estimated (estimate_cost succeeded) first — apply is rejected with an error if the deployment has no current cost estimate." + " ASYNC: returns immediately with a job_id — call get_job_result(job_id, wait_seconds=25) to poll for the result.",
+		Description: "Step 5 of deployment: Apply a saved terraform plan. This creates/modifies real cloud resources. The deployment must have been planned (generate_terraform_plan succeeded) AND cost-estimated (estimate_cost succeeded) first — apply is rejected with an error if the deployment has no current cost estimate. After apply succeeds, use check_drift to verify the cloud resources actually match the desired state." + " ASYNC: returns immediately with a job_id — call get_job_result(job_id, wait_seconds=25) to poll for the result.",
 		Parameters:  openagent.SchemaOf[ApplyDeploymentParams](),
 	}
 }
@@ -435,6 +436,153 @@ func (t *destroyDeploymentTool) Execute(ctx context.Context, args json.RawMessag
 	return jobStarted(jobID, "destroy_deployment")
 }
 
+// ── check_drift ──
+
+// planFunc is the signature of iac.Client.Plan, extracted so tests can
+// inject a stub and exercise the non-dry-run drifted/check_failed branches
+// without a real terraform binary.
+type planFunc func(ctx context.Context) (*iac.Plan, error)
+
+type checkDriftTool struct {
+	cfg    Config
+	planFn planFunc // nil → use real iac.Client.Plan (production)
+}
+
+func (t *checkDriftTool) Definition() openagent.FunctionDefinition {
+	return openagent.FunctionDefinition{
+		Name: "check_drift",
+		Description: "Detect drift between terraform desired state and real cloud resources by running terraform plan (refresh + diff). " +
+			"Use this when the user asks whether a deployment is healthy, whether resources were changed manually outside terraform, " +
+			"whether the cloud still matches the plan, or to verify convergence after apply_deployment. " +
+			"Requires apply_deployment to have succeeded. Read-only — does not modify cloud resources. " +
+			"Returns {status: \"clean\" | \"drifted\" | \"check_failed\", summary, changes, error}. " +
+			"If drift is detected, the saved tfplan is updated to the remediation plan — " +
+			"call apply_deployment directly to converge cloud state back to desired (cost estimate stays valid, no re-estimate needed)." +
+			" ASYNC: returns immediately with a job_id — call get_job_result(job_id, wait_seconds=25) to poll for the result.",
+		Parameters: openagent.SchemaOf[CheckDriftParams](),
+	}
+}
+
+func (t *checkDriftTool) Execute(ctx context.Context, args json.RawMessage) *openagent.ToolResult {
+	params, err := openagent.ParseArgs[CheckDriftParams](args)
+	if err != nil {
+		return openagent.ErrorResult(fmt.Errorf("check_drift: %w", err), false, "")
+	}
+	if !validDeploymentID(params.DeploymentID) {
+		return openagent.ErrorResult(fmt.Errorf("check_drift: invalid deployment_id %q", params.DeploymentID), false, "")
+	}
+
+	jobID, err := t.cfg.Planner.SubmitJob(ctx, params.DeploymentID, "check_drift", func(ctx context.Context) (string, error) {
+		dir := workDir(t.cfg.DeploymentsDir, params.DeploymentID)
+
+		// State gate: drift only makes sense after apply — before apply,
+		// plan is all-create with no real cloud resources to drift from.
+		status := agent.DagStatusOf(dir)
+		if status != agent.DagApplied {
+			return "", fmt.Errorf("check_drift: deployment %s has not been applied (dag.Status=%q) — call apply_deployment first", params.DeploymentID, status)
+		}
+
+		// Dry-run: no real cloud state to compare against — simulated plan
+		// is all-create with no drift semantics. Still persist drift.json so
+		// list_deployments can report drift_status.
+		if t.cfg.DryRun {
+			result := agent.DriftResult{
+				Version:      agent.DriftVersion,
+				DeploymentID: params.DeploymentID,
+				CheckedAt:    time.Now().UTC().Format(time.RFC3339),
+				Status:       agent.DriftClean,
+			}
+			if err := agent.SaveDrift(dir, &result); err != nil {
+				return "", fmt.Errorf("check_drift: save drift.json: %w", err)
+			}
+			data, err := json.Marshal(result)
+			if err != nil {
+				return "", fmt.Errorf("check_drift: marshal: %w", err)
+			}
+			return string(data), nil
+		}
+
+		// Run plan (refresh + diff). This overwrites tfplan — if drift is
+		// detected, tfplan becomes the remediation plan that apply_deployment
+		// can consume directly to fix the drift. planFn is injected by tests;
+		// in production it is nil and we use the real iac.Client.
+		var plan *iac.Plan
+		if t.planFn != nil {
+			plan, err = t.planFn(ctx)
+		} else {
+			client, clientErr := iac.NewClient(ctx, dir, iacConfig(t.cfg.Cloud, t.cfg.DryRun, t.cfg.BinaryMirrors, t.cfg.ProviderMirrors))
+			if clientErr != nil {
+				return "", fmt.Errorf("check_drift: %w", clientErr)
+			}
+			plan, err = client.Plan(ctx)
+		}
+		if err != nil {
+			// Refresh failed (deleted resources, perms, provider bugs, network).
+			// Persist check_failed so list_deployments surfaces it. A write
+			// failure here does not change the primary error (plan failed),
+			// but we surface it as context so the caller knows drift.json
+			// may not reflect the failure.
+			failResult := agent.DriftResult{
+				Version:      agent.DriftVersion,
+				DeploymentID: params.DeploymentID,
+				CheckedAt:    time.Now().UTC().Format(time.RFC3339),
+				Status:       agent.DriftCheckFailed,
+				Error:        err.Error(),
+			}
+			if saveErr := agent.SaveDrift(dir, &failResult); saveErr != nil {
+				err = fmt.Errorf("%w (also failed to persist drift.json: %v)", err, saveErr)
+			}
+			if ctx.Err() != nil {
+				return "", fmt.Errorf("check_drift: interrupted (ctx cancelled: %v) — terraform may have left a state lock; run troubleshoot_deployment before retrying: %w", ctx.Err(), err)
+			}
+			return "", fmt.Errorf("check_drift: terraform plan (refresh) failed: %w", err)
+		}
+
+		// planFromJSON skips NoOp changes, so non-empty Changes means drift.
+		driftStatus := agent.DriftClean
+		if len(plan.Changes) > 0 {
+			driftStatus = agent.DriftDetected
+		}
+
+		// Map iac.Plan fields to self-contained DriftResult types.
+		result := agent.DriftResult{
+			Version:      agent.DriftVersion,
+			DeploymentID: params.DeploymentID,
+			CheckedAt:    time.Now().UTC().Format(time.RFC3339),
+			Status:       driftStatus,
+			Summary: agent.DriftSummary{
+				Create: plan.Summary.Create,
+				Update: plan.Summary.Update,
+				Delete: plan.Summary.Delete,
+				Noop:   plan.Summary.Noop,
+			},
+		}
+		for _, c := range plan.Changes {
+			result.Changes = append(result.Changes, agent.DriftChange{
+				Address: c.Address,
+				Type:    c.Type,
+				Action:  string(c.Action),
+				Before:  c.Before,
+				After:   c.After,
+			})
+		}
+
+		if err := agent.SaveDrift(dir, &result); err != nil {
+			return "", fmt.Errorf("check_drift: save drift.json: %w", err)
+		}
+
+		data, err := json.Marshal(result)
+		if err != nil {
+			return "", fmt.Errorf("check_drift: marshal: %w", err)
+		}
+		return string(data), nil
+	})
+	if err != nil {
+		return openagent.ErrorResult(err, false, "")
+	}
+	return jobStarted(jobID, "check_drift")
+}
+
 // ── get_deployment_status ──
 
 type getDeploymentStatusTool struct{ cfg Config }
@@ -442,7 +590,7 @@ type getDeploymentStatusTool struct{ cfg Config }
 func (t *getDeploymentStatusTool) Definition() openagent.FunctionDefinition {
 	return openagent.FunctionDefinition{
 		Name:        "get_deployment_status",
-		Description: "Read the terraform state for a deployment and return a status summary. Does not call terraform binary — reads the state file directly.",
+		Description: "Read the LOCAL terraform state for a deployment and return a status summary. Does not call terraform binary — reads the state file directly, so the result may be stale if someone changed cloud resources manually. To verify the real cloud state matches the desired state, use check_drift instead.",
 		Parameters:  openagent.SchemaOf[GetDeploymentStatusParams](),
 	}
 }
@@ -548,7 +696,7 @@ func (t *getJobResultTool) Definition() openagent.FunctionDefinition {
 	return openagent.FunctionDefinition{
 		Name: "get_job_result",
 		Description: "Poll the result of an async job started by propose_architecture, specify_resources, generate_terraform_plan, " +
-			"update_deployment, estimate_cost, troubleshoot_deployment, or query_cloud. " +
+			"update_deployment, estimate_cost, troubleshoot_deployment, query_cloud, or check_drift. " +
 			"Those tools return immediately with a job_id; call this with that job_id to retrieve the outcome. " +
 			"Returns {status: \"running\"|\"done\"|\"failed\", progress_msg, progress_cur, progress_tot, outputs, result, error}. " +
 			"wait_seconds (0-120) blocks up to that long and returns as soon as the job finishes — " +
@@ -596,7 +744,7 @@ type listDeploymentsTool struct{ cfg Config }
 func (t *listDeploymentsTool) Definition() openagent.FunctionDefinition {
 	return openagent.FunctionDefinition{
 		Name:        "list_deployments",
-		Description: "List all deployments by scanning the deployments directory. Returns deployment IDs and whether each has a state file.",
+		Description: "List all deployments by scanning the deployments directory. Returns each deployment's ID, whether it has a state file, and its drift_status (\"clean\"/\"drifted\"/\"check_failed\"/\"\"=never checked). For any applied deployment whose drift_status is empty or stale, call check_drift to verify the real cloud state.",
 		Parameters:  openagent.SchemaOf[struct{}](),
 	}
 }
@@ -611,9 +759,10 @@ func (t *listDeploymentsTool) Execute(ctx context.Context, _ json.RawMessage) *o
 	}
 
 	type deployment struct {
-		ID       string `json:"id"`
-		HasState bool   `json:"has_state"`
-		HasPlan  bool   `json:"has_plan"`
+		ID          string            `json:"id"`
+		HasState    bool              `json:"has_state"`
+		HasPlan     bool              `json:"has_plan"`
+		DriftStatus agent.DriftStatus `json:"drift_status"` // "" = never checked
 	}
 
 	// Start as a non-nil slice so an empty deployments dir marshals to []
@@ -627,9 +776,10 @@ func (t *listDeploymentsTool) Execute(ctx context.Context, _ json.RawMessage) *o
 		_, stateErr := os.Stat(filepath.Join(dir, "terraform.tfstate"))
 		_, planErr := os.Stat(filepath.Join(dir, "tfplan"))
 		deployments = append(deployments, deployment{
-			ID:       entry.Name(),
-			HasState: stateErr == nil,
-			HasPlan:  planErr == nil,
+			ID:          entry.Name(),
+			HasState:    stateErr == nil,
+			HasPlan:     planErr == nil,
+			DriftStatus: agent.DriftStatusOf(dir),
 		})
 	}
 
@@ -695,6 +845,11 @@ type ApplyDeploymentParams struct {
 // DestroyDeploymentParams are the arguments to destroy_deployment.
 type DestroyDeploymentParams struct {
 	DeploymentID string `json:"deployment_id" jsonschema:"description=Deployment ID to destroy"`
+}
+
+// CheckDriftParams are the arguments to check_drift.
+type CheckDriftParams struct {
+	DeploymentID string `json:"deployment_id" jsonschema:"description=Deployment ID to check for drift (must have been applied)"`
 }
 
 // GetDeploymentStatusParams are the arguments to get_deployment_status.

--- a/cmd/mcp/iac-server/mcp/tools_test.go
+++ b/cmd/mcp/iac-server/mcp/tools_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/yusheng-g/openagent-go/cmd/mcp/iac-server/agent"
 	"github.com/yusheng-g/openagent-go/cmd/mcp/iac-server/provider"
+	"github.com/yusheng-g/openagent-go/iac"
 )
 
 // mockCloud is a CloudProvider that returns dummy credentials instead of
@@ -681,6 +683,412 @@ func TestDestroyDeployment_StateGateRejectsAlreadyDestroyed(t *testing.T) {
 	}
 	if !strings.Contains(job.Error, "already destroyed") {
 		t.Fatalf("error should mention 'already destroyed', got: %s", job.Error)
+	}
+}
+
+// ── check_drift ──
+
+// TestCheckDrift_InvalidID verifies the path-traversal guard runs synchronously
+// before the async job is submitted.
+func TestCheckDrift_InvalidID(t *testing.T) {
+	root := t.TempDir()
+	tool := &checkDriftTool{cfg: Config{DeploymentsDir: root, DryRun: true}}
+	for _, id := range []string{"", "..", "../etc", "a/b"} {
+		args, _ := json.Marshal(map[string]string{"deployment_id": id})
+		result := tool.Execute(context.Background(), args)
+		if result.Error == nil {
+			t.Errorf("invalid id %q should be rejected synchronously", id)
+		}
+	}
+}
+
+// TestCheckDrift_StateGateRejectsNonApplied verifies check_drift is rejected
+// when dag.Status is not "applied" — drift only makes sense after apply.
+func TestCheckDrift_StateGateRejectsNonApplied(t *testing.T) {
+	workDir := t.TempDir()
+	deploymentsDir := filepath.Join(workDir, "deployments")
+	mustMkdirAll(t, deploymentsDir)
+	depDir := filepath.Join(deploymentsDir, "d-001")
+	mustMkdirAll(t, depDir)
+	dagJSON := `{"version":1,"deployment_id":"d-001","status":"cost_estimated","nodes":[{"id":"a","type":"t","name":"a"}]}`
+	mustWriteFile(t, filepath.Join(depDir, "dag.json"), []byte(dagJSON))
+	planner := newTestPlanner(t, workDir)
+	tool := &checkDriftTool{cfg: Config{
+		Planner: planner, Cloud: mockCloud{},
+		DeploymentsDir: deploymentsDir, DryRun: true,
+	}}
+
+	args, _ := json.Marshal(map[string]string{"deployment_id": "d-001"})
+	result := tool.Execute(context.Background(), args)
+	if result.Error != nil {
+		t.Fatalf("Execute should return job_id, got error: %v", result.Error)
+	}
+	jobID := extractJobID(t, result.Content)
+
+	job := pollJob(t, planner, jobID)
+	if job.Status != agent.JobFailed {
+		t.Fatalf("check_drift on non-applied dag should fail, got status %s", job.Status)
+	}
+	if !strings.Contains(job.Error, "has not been applied") {
+		t.Fatalf("error should mention 'has not been applied', got: %s", job.Error)
+	}
+}
+
+// TestCheckDrift_StateGateRejectsDestroyed verifies check_drift is rejected
+// when the deployment was already destroyed.
+func TestCheckDrift_StateGateRejectsDestroyed(t *testing.T) {
+	workDir := t.TempDir()
+	deploymentsDir := filepath.Join(workDir, "deployments")
+	mustMkdirAll(t, deploymentsDir)
+	depDir := filepath.Join(deploymentsDir, "d-001")
+	mustMkdirAll(t, depDir)
+	dagJSON := `{"version":1,"deployment_id":"d-001","status":"destroyed","nodes":[{"id":"a","type":"t","name":"a"}]}`
+	mustWriteFile(t, filepath.Join(depDir, "dag.json"), []byte(dagJSON))
+	planner := newTestPlanner(t, workDir)
+	tool := &checkDriftTool{cfg: Config{
+		Planner: planner, Cloud: mockCloud{},
+		DeploymentsDir: deploymentsDir, DryRun: true,
+	}}
+
+	args, _ := json.Marshal(map[string]string{"deployment_id": "d-001"})
+	result := tool.Execute(context.Background(), args)
+	jobID := extractJobID(t, result.Content)
+
+	job := pollJob(t, planner, jobID)
+	if job.Status != agent.JobFailed {
+		t.Fatalf("check_drift on destroyed dag should fail, got status %s", job.Status)
+	}
+	if !strings.Contains(job.Error, "has not been applied") {
+		t.Fatalf("error should mention 'has not been applied', got: %s", job.Error)
+	}
+}
+
+// TestCheckDrift_StateGateRejectsMissingDag verifies check_drift is rejected
+// when dag.json is missing (empty status from DagStatusOf).
+func TestCheckDrift_StateGateRejectsMissingDag(t *testing.T) {
+	workDir := t.TempDir()
+	deploymentsDir := filepath.Join(workDir, "deployments")
+	mustMkdirAll(t, deploymentsDir)
+	depDir := filepath.Join(deploymentsDir, "d-001")
+	mustMkdirAll(t, depDir)
+	// No dag.json — DagStatusOf returns ""
+	planner := newTestPlanner(t, workDir)
+	tool := &checkDriftTool{cfg: Config{
+		Planner: planner, Cloud: mockCloud{},
+		DeploymentsDir: deploymentsDir, DryRun: true,
+	}}
+
+	args, _ := json.Marshal(map[string]string{"deployment_id": "d-001"})
+	result := tool.Execute(context.Background(), args)
+	jobID := extractJobID(t, result.Content)
+
+	job := pollJob(t, planner, jobID)
+	if job.Status != agent.JobFailed {
+		t.Fatalf("check_drift on missing dag should fail, got status %s", job.Status)
+	}
+	if !strings.Contains(job.Error, "has not been applied") {
+		t.Fatalf("error should mention 'has not been applied', got: %s", job.Error)
+	}
+}
+
+// TestCheckDrift_DryRunClean verifies check_drift in dry-run mode returns
+// status "clean" and persists drift.json to disk.
+func TestCheckDrift_DryRunClean(t *testing.T) {
+	workDir := t.TempDir()
+	deploymentsDir := filepath.Join(workDir, "deployments")
+	mustMkdirAll(t, deploymentsDir)
+	depDir := filepath.Join(deploymentsDir, "d-001")
+	mustMkdirAll(t, depDir)
+	dagJSON := `{"version":1,"deployment_id":"d-001","status":"applied","nodes":[{"id":"a","type":"t","name":"a"}]}`
+	mustWriteFile(t, filepath.Join(depDir, "dag.json"), []byte(dagJSON))
+	planner := newTestPlanner(t, workDir)
+	tool := &checkDriftTool{cfg: Config{
+		Planner: planner, Cloud: mockCloud{},
+		DeploymentsDir: deploymentsDir, DryRun: true,
+	}}
+
+	args, _ := json.Marshal(map[string]string{"deployment_id": "d-001"})
+	result := tool.Execute(context.Background(), args)
+	if result.Error != nil {
+		t.Fatalf("Execute should return job_id, got error: %v", result.Error)
+	}
+	jobID := extractJobID(t, result.Content)
+
+	job := pollJob(t, planner, jobID)
+	if job.Status != agent.JobDone {
+		t.Fatalf("check_drift on applied deployment in dry-run should succeed, got status %s (err=%s)", job.Status, job.Error)
+	}
+
+	// Verify the job result content.
+	var driftResult agent.DriftResult
+	if err := json.Unmarshal(job.Result, &driftResult); err != nil {
+		t.Fatalf("parse drift result: %v", err)
+	}
+	if driftResult.Status != agent.DriftClean {
+		t.Errorf("expected status=clean, got %q", driftResult.Status)
+	}
+	if driftResult.Version != agent.DriftVersion {
+		t.Errorf("expected version=%d, got %d", agent.DriftVersion, driftResult.Version)
+	}
+	if driftResult.DeploymentID != "d-001" {
+		t.Errorf("expected deployment_id=d-001, got %q", driftResult.DeploymentID)
+	}
+
+	// Verify drift.json was persisted to disk.
+	driftData, err := os.ReadFile(filepath.Join(depDir, "drift.json"))
+	if err != nil {
+		t.Fatalf("drift.json not written: %v", err)
+	}
+	var onDisk agent.DriftResult
+	if err := json.Unmarshal(driftData, &onDisk); err != nil {
+		t.Fatalf("parse drift.json: %v", err)
+	}
+	if onDisk.Status != agent.DriftClean {
+		t.Errorf("drift.json status = %q, want clean", onDisk.Status)
+	}
+}
+
+// TestCheckDrift_DoesNotInvalidateCost verifies check_drift does not delete
+// cost.json — drift detection does not change the desired state, so the cost
+// estimate remains valid.
+func TestCheckDrift_DoesNotInvalidateCost(t *testing.T) {
+	workDir := t.TempDir()
+	deploymentsDir := filepath.Join(workDir, "deployments")
+	mustMkdirAll(t, deploymentsDir)
+	depDir := filepath.Join(deploymentsDir, "d-001")
+	mustMkdirAll(t, depDir)
+	dagJSON := `{"version":1,"deployment_id":"d-001","status":"applied","nodes":[{"id":"a","type":"t","name":"a"}]}`
+	mustWriteFile(t, filepath.Join(depDir, "dag.json"), []byte(dagJSON))
+	mustWriteFile(t, filepath.Join(depDir, "cost.json"), []byte("{}"))
+	planner := newTestPlanner(t, workDir)
+	tool := &checkDriftTool{cfg: Config{
+		Planner: planner, Cloud: mockCloud{},
+		DeploymentsDir: deploymentsDir, DryRun: true,
+	}}
+
+	args, _ := json.Marshal(map[string]string{"deployment_id": "d-001"})
+	result := tool.Execute(context.Background(), args)
+	jobID := extractJobID(t, result.Content)
+	job := pollJob(t, planner, jobID)
+	if job.Status != agent.JobDone {
+		t.Fatalf("check_drift should succeed, got status %s (err=%s)", job.Status, job.Error)
+	}
+
+	// cost.json must still exist.
+	if !agent.HasCost(depDir) {
+		t.Fatal("check_drift must not invalidate cost.json — cost estimate stays valid")
+	}
+}
+
+// TestCheckDrift_DoesNotChangeDagStatus verifies check_drift does not modify
+// dag.Status — drift is a read-only side observation, not a lifecycle advance.
+func TestCheckDrift_DoesNotChangeDagStatus(t *testing.T) {
+	workDir := t.TempDir()
+	deploymentsDir := filepath.Join(workDir, "deployments")
+	mustMkdirAll(t, deploymentsDir)
+	depDir := filepath.Join(deploymentsDir, "d-001")
+	mustMkdirAll(t, depDir)
+	dagJSON := `{"version":1,"deployment_id":"d-001","status":"applied","nodes":[{"id":"a","type":"t","name":"a"}]}`
+	mustWriteFile(t, filepath.Join(depDir, "dag.json"), []byte(dagJSON))
+	planner := newTestPlanner(t, workDir)
+	tool := &checkDriftTool{cfg: Config{
+		Planner: planner, Cloud: mockCloud{},
+		DeploymentsDir: deploymentsDir, DryRun: true,
+	}}
+
+	args, _ := json.Marshal(map[string]string{"deployment_id": "d-001"})
+	result := tool.Execute(context.Background(), args)
+	jobID := extractJobID(t, result.Content)
+	job := pollJob(t, planner, jobID)
+	if job.Status != agent.JobDone {
+		t.Fatalf("check_drift should succeed, got status %s (err=%s)", job.Status, job.Error)
+	}
+
+	// dag.Status must still be "applied".
+	status := agent.DagStatusOf(depDir)
+	if status != agent.DagApplied {
+		t.Fatalf("dag.Status = %q, want applied — check_drift must not advance the state machine", status)
+	}
+}
+
+// TestListDeployments_DriftStatus verifies list_deployments reports the
+// drift_status field from drift.json.
+func TestListDeployments_DriftStatus(t *testing.T) {
+	root := t.TempDir()
+
+	// d-001: has drift.json with status=clean
+	mustMkdirAll(t, filepath.Join(root, "d-001"))
+	driftJSON := `{"version":1,"deployment_id":"d-001","status":"clean","checked_at":"2026-09-01T00:00:00Z"}`
+	mustWriteFile(t, filepath.Join(root, "d-001", "drift.json"), []byte(driftJSON))
+
+	// d-002: no drift.json — drift_status should be ""
+	mustMkdirAll(t, filepath.Join(root, "d-002"))
+
+	// d-003: has drift.json with status=drifted
+	mustMkdirAll(t, filepath.Join(root, "d-003"))
+	driftJSON2 := `{"version":1,"deployment_id":"d-003","status":"drifted","checked_at":"2026-09-01T00:00:00Z"}`
+	mustWriteFile(t, filepath.Join(root, "d-003", "drift.json"), []byte(driftJSON2))
+
+	tool := &listDeploymentsTool{cfg: Config{DeploymentsDir: root}}
+	result := tool.Execute(context.Background(), nil)
+	if result.Error != nil {
+		t.Fatalf("unexpected error: %v", result.Error)
+	}
+
+	var deployments []struct {
+		ID          string `json:"id"`
+		DriftStatus string `json:"drift_status"`
+	}
+	if err := json.Unmarshal([]byte(result.Content), &deployments); err != nil {
+		t.Fatal(err)
+	}
+	if len(deployments) != 3 {
+		t.Fatalf("expected 3 deployments, got %d", len(deployments))
+	}
+	want := []struct {
+		ID          string
+		DriftStatus string
+	}{
+		{"d-001", "clean"},
+		{"d-002", ""},
+		{"d-003", "drifted"},
+	}
+	for i, w := range want {
+		if deployments[i].ID != w.ID {
+			t.Errorf("deployment %d id = %q, want %q", i, deployments[i].ID, w.ID)
+		}
+		if deployments[i].DriftStatus != w.DriftStatus {
+			t.Errorf("deployment %s drift_status = %q, want %q", w.ID, deployments[i].DriftStatus, w.DriftStatus)
+		}
+	}
+}
+
+// TestCheckDrift_PlanFnDrifted verifies the non-dry-run DriftDetected branch:
+// when the injected planFn returns a plan with changes, check_drift reports
+// status=drifted and persists the changes to drift.json.
+func TestCheckDrift_PlanFnDrifted(t *testing.T) {
+	workDir := t.TempDir()
+	deploymentsDir := filepath.Join(workDir, "deployments")
+	mustMkdirAll(t, deploymentsDir)
+	depDir := filepath.Join(deploymentsDir, "d-001")
+	mustMkdirAll(t, depDir)
+	dagJSON := `{"version":1,"deployment_id":"d-001","status":"applied","nodes":[{"id":"a","type":"t","name":"a"}]}`
+	mustWriteFile(t, filepath.Join(depDir, "dag.json"), []byte(dagJSON))
+	planner := newTestPlanner(t, workDir)
+
+	// Inject a plan that returns one update change — simulates drift.
+	planFn := func(_ context.Context) (*iac.Plan, error) {
+		return &iac.Plan{
+			Summary: iac.Summary{Update: 1, Noop: 2},
+			Changes: []iac.ResourceChange{
+				{Address: "t.a", Type: "t", Action: iac.ActionUpdate},
+			},
+		}, nil
+	}
+
+	tool := &checkDriftTool{
+		cfg: Config{
+			Planner: planner, Cloud: mockCloud{},
+			DeploymentsDir: deploymentsDir, DryRun: false,
+		},
+		planFn: planFn,
+	}
+
+	args, _ := json.Marshal(map[string]string{"deployment_id": "d-001"})
+	result := tool.Execute(context.Background(), args)
+	if result.Error != nil {
+		t.Fatalf("Execute should return job_id, got error: %v", result.Error)
+	}
+	jobID := extractJobID(t, result.Content)
+	job := pollJob(t, planner, jobID)
+	if job.Status != agent.JobDone {
+		t.Fatalf("check_drift should succeed, got status %s (err=%s)", job.Status, job.Error)
+	}
+
+	var driftResult agent.DriftResult
+	if err := json.Unmarshal(job.Result, &driftResult); err != nil {
+		t.Fatalf("parse drift result: %v", err)
+	}
+	if driftResult.Status != agent.DriftDetected {
+		t.Errorf("expected status=drifted, got %q", driftResult.Status)
+	}
+	if driftResult.Summary.Update != 1 {
+		t.Errorf("expected summary.update=1, got %d", driftResult.Summary.Update)
+	}
+	if len(driftResult.Changes) != 1 {
+		t.Fatalf("expected 1 change, got %d", len(driftResult.Changes))
+	}
+	if driftResult.Changes[0].Address != "t.a" {
+		t.Errorf("expected change address=t.a, got %q", driftResult.Changes[0].Address)
+	}
+	if driftResult.Changes[0].Action != "update" {
+		t.Errorf("expected change action=update, got %q", driftResult.Changes[0].Action)
+	}
+
+	// Verify drift.json on disk.
+	driftData, err := os.ReadFile(filepath.Join(depDir, "drift.json"))
+	if err != nil {
+		t.Fatalf("drift.json not written: %v", err)
+	}
+	var onDisk agent.DriftResult
+	if err := json.Unmarshal(driftData, &onDisk); err != nil {
+		t.Fatalf("parse drift.json: %v", err)
+	}
+	if onDisk.Status != agent.DriftDetected {
+		t.Errorf("drift.json status = %q, want drifted", onDisk.Status)
+	}
+}
+
+// TestCheckDrift_PlanFnCheckFailed verifies the non-dry-run DriftCheckFailed
+// branch: when the injected planFn returns an error, check_drift persists
+// check_failed to drift.json and returns the error to the caller.
+func TestCheckDrift_PlanFnCheckFailed(t *testing.T) {
+	workDir := t.TempDir()
+	deploymentsDir := filepath.Join(workDir, "deployments")
+	mustMkdirAll(t, deploymentsDir)
+	depDir := filepath.Join(deploymentsDir, "d-001")
+	mustMkdirAll(t, depDir)
+	dagJSON := `{"version":1,"deployment_id":"d-001","status":"applied","nodes":[{"id":"a","type":"t","name":"a"}]}`
+	mustWriteFile(t, filepath.Join(depDir, "dag.json"), []byte(dagJSON))
+	planner := newTestPlanner(t, workDir)
+
+	planFn := func(_ context.Context) (*iac.Plan, error) {
+		return nil, fmt.Errorf("simulated refresh failure: provider timeout")
+	}
+
+	tool := &checkDriftTool{
+		cfg: Config{
+			Planner: planner, Cloud: mockCloud{},
+			DeploymentsDir: deploymentsDir, DryRun: false,
+		},
+		planFn: planFn,
+	}
+
+	args, _ := json.Marshal(map[string]string{"deployment_id": "d-001"})
+	result := tool.Execute(context.Background(), args)
+	jobID := extractJobID(t, result.Content)
+	job := pollJob(t, planner, jobID)
+	if job.Status != agent.JobFailed {
+		t.Fatalf("check_drift should fail on plan error, got status %s", job.Status)
+	}
+	if !strings.Contains(job.Error, "refresh failure") {
+		t.Fatalf("error should contain the plan error, got: %s", job.Error)
+	}
+
+	// Verify drift.json persisted with check_failed.
+	driftData, err := os.ReadFile(filepath.Join(depDir, "drift.json"))
+	if err != nil {
+		t.Fatalf("drift.json not written: %v", err)
+	}
+	var onDisk agent.DriftResult
+	if err := json.Unmarshal(driftData, &onDisk); err != nil {
+		t.Fatalf("parse drift.json: %v", err)
+	}
+	if onDisk.Status != agent.DriftCheckFailed {
+		t.Errorf("drift.json status = %q, want check_failed", onDisk.Status)
+	}
+	if !strings.Contains(onDisk.Error, "refresh failure") {
+		t.Errorf("drift.json error should contain the plan error, got: %q", onDisk.Error)
 	}
 }
 


### PR DESCRIPTION
## Summary

Add a `check_drift` MCP tool that runs `terraform plan` (refresh + diff) after `apply_deployment` to detect drift between desired state and real cloud resources. The result is persisted to `drift.json` — a read-only side observation that does not advance the state machine or invalidate `cost.json`. `list_deployments` now reports a `drift_status` field per deployment.

## Design

- **Type isolation**: `DriftResult` / `DriftChange` / `DriftSummary` are self-contained in `dag.go`; `Before`/`After` use `json.RawMessage`, no `iac` package dependency — same pattern as `CostEstimate` using `[]any`, avoids import cycles.
- **Atomic write**: `SaveDrift` reuses `atomicWrite` (tmp + rename), consistent with `saveDag` / `saveCost`.
- **State gate**: `check_drift` requires `DagApplied` — drift only makes sense after apply.
- **Read-only invariant**: does not call `SetDagStatus` or `invalidateCost`; enforced by explicit tests.
- **Dry-run semantics**: dry-run returns `clean` (no real cloud state to compare), still persists `drift.json`.
- **Plan failure handling**: on `client.Plan()` failure, persists `check_failed` + error to `drift.json` and returns the error to the caller.

## LLM auto-routing

Tool descriptions updated so the LLM semantically routes to `check_drift` when users ask about cloud health/convergence without naming the tool or deployment ID:

- `check_drift`: added trigger scenarios (deployment healthy / resources changed manually / cloud matches plan / verify convergence after apply)
- `get_deployment_status`: clarifies it reads LOCAL state (may be stale), directs to `check_drift` for real cloud state
- `list_deployments`: mentions `drift_status` field, directs to `check_drift` for unchecked deployments
- `apply_deployment`: directs to `check_drift` to verify convergence after apply succeeds

## Test coverage

- `TestCheckDrift_InvalidID` — path traversal guard
- `TestCheckDrift_StateGateRejectsNonApplied` / `Destroyed` / `MissingDag` — state gate
- `TestCheckDrift_DryRunClean` — dry-run returns clean + persists
- `TestCheckDrift_Drifted` — non-dry-run drifted path (planFn injection)
- `TestCheckDrift_CheckFailed` — non-dry-run plan failure path
- `TestCheckDrift_DoesNotInvalidateCost` — cost.json unaffected
- `TestCheckDrift_DoesNotChangeDagStatus` — dag.Status unaffected
- `TestListDeployments_DriftStatus` — list_deployments reports drift_status
- `TestSaveDrift_DriftStatusOf` — save/load round-trip
- `TestDriftStatusOf_UnreadableReturnsEmpty` — invalid JSON returns empty

E2E verified on real HuaweiCloud: both clean and drifted paths pass; LLM routing verified with natural language phrasing that shares no words with the tool descriptions.

## Files

- `cmd/mcp/iac-server/agent/dag.go` — drift types + SaveDrift/DriftStatusOf
- `cmd/mcp/iac-server/agent/dag_test.go` — drift helper tests
- `cmd/mcp/iac-server/mcp/tools.go` — check_drift tool + description routing
- `cmd/mcp/iac-server/mcp/tools_test.go` — check_drift tool tests