### PR TITLE
fix(channel): cardTooLarge infinite fold loop — progressive trim until card fits

### DIFF
--- a/cmd/cli/server/channel.go
+++ b/cmd/cli/server/channel.go
@@ -349,7 +349,9 @@ func streamReply(reply channel.ReplyFunc, stream <-chan openagent.StreamEvent, s
 
 		// When the card exceeds the platform's size limit, fold the
 		// old card to a collapsed "done" state, then start a fresh
-		// one keeping only the last few blocks.
+		// one. Progressively trim blocks (last 1 → 0) until the
+		// rebuilt card fits; runCard's internal thought cap guarantees
+		// the card fits once blocks are empty.
 		if runCardID != "" && cardTooLarge(sizer, card) {
 			slog.Info("cardTooLarge triggered",
 				"cardSize", cardSize,
@@ -363,10 +365,16 @@ func streamReply(reply channel.ReplyFunc, stream <-chan openagent.StreamEvent, s
 				Fold:   channel.FoldCollapsed,
 			})
 			runCardID = ""
-			if len(blocks) > 3 {
-				blocks = blocks[len(blocks)-3:]
+			for cardTooLarge(sizer, card) {
+				if len(blocks) > 1 {
+					blocks = blocks[len(blocks)-1:]
+				} else if len(blocks) == 1 {
+					blocks = nil
+				} else {
+					break
+				}
+				card = runCard(stage, thoughtBuf.String(), blocks, lastErr)
 			}
-			card = runCard(stage, thoughtBuf.String(), blocks, lastErr)
 			approvalMu.Lock()
 			card.Approval = pendingApproval
 			approvalMu.Unlock()


### PR DESCRIPTION
The cardTooLarge branch in flushRunCard trimmed blocks to the last 3 and never re-checked whether the rebuilt card was still oversized. When len(blocks) <= 3 (e.g. two websearch results at ~20KB each), the trim was skipped entirely, rebuilding an identical oversized card on every flush — causing an infinite cascade of '✅ 已完成' cards in Feishu.

Replace the single trim with a loop that progressively reduces blocks (last 1 → 0) until the card fits under maxCardBytes. Once blocks are empty, runCard's internal thought cap (maxCardBytes/3) guarantees the loop terminates.

Reproduced: two websearch calls (24KB + 19KB results) triggered 15+ duplicate '已完成' cards during PPT generation at 15:06.