### PR TITLE
feat(track): add event tracking package and SessionObserver interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,30 @@ To keep a specific domain on local storage while using OpenViking for the rest:
 
 `context_providers` accepts `"builtin"` or `"openviking"` for each of `memory`, `skill`, `resource`. Empty = follow the endpoint default.
 
+## Telemetry & Privacy
+
+Official binaries may report anonymous session lifecycle events (create / close / delete) to the Huawei Cloud martech tracking platform. This helps us understand usage and improve the product.
+
+**What is reported:** event type, session ID, entry point (`acp`/`cli`/`rest`), session mode (`auto`/`semi-auto`/`manual`/`plan`), session duration, and failure reason. The `anonymousId`/`distinctId`/`instance_id` fields carry a hostname-derived identifier (hostname used directly if it is already a 32-char hex value, otherwise MD5 of the hostname) so events from one deployment can be correlated. **No source code, prompts, model output, or file contents are reported.**
+
+**Default behavior — disabled.** The tracking endpoint and AppID are **not** hardcoded in the repository; a plain `go build` or `./build.sh` leaves them empty, producing a disabled binary. Only CI pipeline builds that inject `OPENAGENT_EVENT_POST_URL` / `OPENAGENT_EVENT_APP_ID` (stored as pipeline variables, not in the repo) produce a binary that emits events.
+
+**Enable** (CI pipeline):
+
+```bash
+OPENAGENT_EVENT_POST_URL="https://your-track-endpoint" \
+OPENAGENT_EVENT_APP_ID="your-app-id" \
+./build.sh
+```
+
+**Opt out** — leave the variables unset (the default), or explicitly set the endpoint to empty:
+
+```bash
+OPENAGENT_EVENT_POST_URL="" ./build.sh
+```
+
+You may also disable TLS verification (`OPENAGENT_SKIP_VERIFY=true`).
+
 ## Features
 
 - **Pluggable architecture** — every component is an interface: Model, Memory, Tools, Guards, Approver, Hooks, Observer

--- a/README.zh.md
+++ b/README.zh.md
@@ -275,6 +275,30 @@ OpenViking 是一个上下文数据库，提供服务端记忆、技能和资源
 
 `context_providers` 对 `memory`、`skill`、`resource` 各域可设为 `"builtin"` 或 `"openviking"`。留空 = 跟随 endpoint 默认值。
 
+## 遥测与隐私
+
+官方二进制可能向华为云 martech 平台上报匿名会话生命周期事件（创建 / 关闭 / 删除），用于了解使用情况、改进产品。
+
+**上报内容：** 事件类型、会话 ID、入口（`acp`/`cli`/`rest`）、会话模式（`auto`/`semi-auto`/`manual`/`plan`）、会话时长、失败原因。`anonymousId`/`distinctId`/`instance_id` 字段携带主机名派生标识（若主机名已是 32 位十六进制则直接使用，否则取主机名的 MD5），用于关联同一部署的事件。**不会上报源代码、提示词、模型输出或文件内容。**
+
+**默认行为——禁用。** 上报端点和 AppID **不**硬编码在仓库中；直接 `go build` 或 `./build.sh` 不注入它们，产出禁用上报的二进制。只有 CI 流水线构建注入了 `OPENAGENT_EVENT_POST_URL` / `OPENAGENT_EVENT_APP_ID`（作为流水线变量存储，不在仓库中）时，才产出上报二进制。
+
+**启用**（CI 流水线）：
+
+```bash
+OPENAGENT_EVENT_POST_URL="https://your-track-endpoint" \
+OPENAGENT_EVENT_APP_ID="your-app-id" \
+./build.sh
+```
+
+**关闭** — 不设置这些变量（默认），或显式将端点置空：
+
+```bash
+OPENAGENT_EVENT_POST_URL="" ./build.sh
+```
+
+也可关闭 TLS 校验（`OPENAGENT_SKIP_VERIFY=true`）。
+
 ## 特性
 
 - **全插件架构** — 每个组件都是接口：Model、Memory、Tools、Guards、Approver、Hooks、Observer

--- a/acp/server.go
+++ b/acp/server.go
@@ -153,6 +153,19 @@ type AgentServer struct {
 	// (auto-allow safe calls, prompt for destructive). Configured via
 	// settings "default_mode": "auto" | "semi-auto" | "manual" | "plan".
 	DefaultMode string
+
+	// sessionObservers receives session lifecycle events (create / close /
+	// delete).  Set via SetSessionObservers at assembly time.  nil = events
+	// are silently dropped.  The server does NOT import track — only the
+	// assembly layer wires concrete observers.
+	sessionObservers openagent.SessionObserver
+}
+
+// SetSessionObservers wires a SessionObserver into the server.  Call once at
+// assembly time (e.g. in BuildACPServer).  Pass nil to disable.  Safe to
+// call before the server starts serving.
+func (s *AgentServer) SetSessionObservers(obs openagent.SessionObserver) {
+	s.sessionObservers = obs
 }
 
 // defaultMode resolves the configured default mode.
@@ -1270,6 +1283,16 @@ func (s *AgentServer) OnNewSession(ctx context.Context, req openacp.NewSessionRe
 	}
 	s.sendMcpServersUpdate(id, mcpConns)
 
+	// Emit session lifecycle event for observers (tracking, telemetry, etc.).
+	if s.sessionObservers != nil {
+		s.sessionObservers.OnSessionCreate(ctx, openagent.SessionLifecycleEvent{
+			SessionID:   string(id),
+			EntryPoint:  openagent.EntryPointACP,
+			SessionMode: ss.Mode(),
+			CreatedAt:   ss.createdAt,
+		})
+	}
+
 	return &openacp.NewSessionResponse{
 		Meta:          map[string]any{"created_at": time.Now().UTC().Format(time.RFC3339Nano)},
 		SessionID:     id,
@@ -1511,6 +1534,17 @@ func (s *AgentServer) OnCloseSession(ctx context.Context, req openacp.CloseSessi
 		s.disconnectMCP(ss.mcpConns)
 		s.killSubAgents(ss)
 	}
+	if s.sessionObservers != nil {
+		evt := openagent.SessionLifecycleEvent{
+			SessionID:  string(req.SessionID),
+			EntryPoint: openagent.EntryPointACP,
+		}
+		if ss != nil && !ss.createdAt.IsZero() {
+			evt.DurationMs = time.Since(ss.createdAt).Milliseconds()
+			evt.SessionMode = ss.Mode()
+		}
+		s.sessionObservers.OnSessionClose(ctx, evt)
+	}
 	s.removeSession(req.SessionID)
 	return &openacp.CloseSessionResponse{}, nil
 }
@@ -1523,6 +1557,25 @@ func (s *AgentServer) OnDeleteSession(ctx context.Context, req openacp.DeleteSes
 		if ss.processMgr != nil {
 			ss.processMgr.Cleanup()
 		}
+	}
+	if s.sessionObservers != nil {
+		evt := openagent.SessionLifecycleEvent{
+			SessionID:  string(req.SessionID),
+			EntryPoint: openagent.EntryPointACP,
+		}
+		if ss != nil && !ss.createdAt.IsZero() {
+			evt.DurationMs = time.Since(ss.createdAt).Milliseconds()
+			evt.SessionMode = ss.Mode()
+		} else {
+			// Session already removed from map (e.g. after close) — try
+			// loading persisted state for mode/createdAt.
+			mode, _, createdAt, _ := s.loadSessionState(ctx, string(req.SessionID))
+			if mode != "" && !createdAt.IsZero() {
+				evt.SessionMode = mode
+				evt.DurationMs = time.Since(createdAt).Milliseconds()
+			}
+		}
+		s.sessionObservers.OnSessionDelete(ctx, evt)
 	}
 	s.removeSession(req.SessionID)
 	// Runtime.Delete removes metadata and messages together.

--- a/acp/session_lifecycle_test.go
+++ b/acp/session_lifecycle_test.go
@@ -1,0 +1,143 @@
+package acp
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	openagent "github.com/yusheng-g/openagent-go"
+	openacp "github.com/yusheng-g/openagent-go/acp/sdk"
+
+	"github.com/yusheng-g/openagent-go/agent"
+	"github.com/yusheng-g/openagent-go/kernel"
+)
+
+// fakeSessionObserver captures lifecycle events for testing.
+type fakeSessionObserver struct {
+	mu      sync.Mutex
+	creates []openagent.SessionLifecycleEvent
+	closes  []openagent.SessionLifecycleEvent
+	deletes []openagent.SessionLifecycleEvent
+}
+
+func (f *fakeSessionObserver) OnSessionCreate(_ context.Context, e openagent.SessionLifecycleEvent) {
+	f.mu.Lock()
+	f.creates = append(f.creates, e)
+	f.mu.Unlock()
+}
+
+func (f *fakeSessionObserver) OnSessionClose(_ context.Context, e openagent.SessionLifecycleEvent) {
+	f.mu.Lock()
+	f.closes = append(f.closes, e)
+	f.mu.Unlock()
+}
+
+func (f *fakeSessionObserver) OnSessionDelete(_ context.Context, e openagent.SessionLifecycleEvent) {
+	f.mu.Lock()
+	f.deletes = append(f.deletes, e)
+	f.mu.Unlock()
+}
+
+func newTestServerWithObserver() (*AgentServer, *fakeSessionObserver) {
+	srv := NewAgentServer(agent.New("test"), kernel.Deps{}, nil, nil)
+	fake := &fakeSessionObserver{}
+	srv.SetSessionObservers(fake)
+	return srv, fake
+}
+
+func TestOnNewSession_EmitsCreateEvent(t *testing.T) {
+	srv, fake := newTestServerWithObserver()
+
+	resp, err := srv.OnNewSession(context.Background(), openacp.NewSessionRequest{Cwd: "/tmp"})
+	if err != nil {
+		t.Fatalf("OnNewSession: %v", err)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if len(fake.creates) != 1 {
+		t.Fatalf("expected 1 create event, got %d", len(fake.creates))
+	}
+	evt := fake.creates[0]
+	if evt.SessionID != string(resp.SessionID) {
+		t.Errorf("SessionID = %q, want %q", evt.SessionID, resp.SessionID)
+	}
+	if evt.EntryPoint != "acp" {
+		t.Errorf("EntryPoint = %q, want acp", evt.EntryPoint)
+	}
+	if evt.CreatedAt.IsZero() {
+		t.Error("CreatedAt should not be zero")
+	}
+}
+
+func TestOnCloseSession_EmitsCloseEvent(t *testing.T) {
+	srv, fake := newTestServerWithObserver()
+
+	// Create a session first.
+	resp, err := srv.OnNewSession(context.Background(), openacp.NewSessionRequest{Cwd: "/tmp"})
+	if err != nil {
+		t.Fatalf("OnNewSession: %v", err)
+	}
+
+	// Close it.
+	_, err = srv.OnCloseSession(context.Background(), openacp.CloseSessionRequest{SessionID: resp.SessionID})
+	if err != nil {
+		t.Fatalf("OnCloseSession: %v", err)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if len(fake.closes) != 1 {
+		t.Fatalf("expected 1 close event, got %d", len(fake.closes))
+	}
+	evt := fake.closes[0]
+	if evt.SessionID != string(resp.SessionID) {
+		t.Errorf("SessionID = %q, want %q", evt.SessionID, resp.SessionID)
+	}
+	if evt.EntryPoint != "acp" {
+		t.Errorf("EntryPoint = %q, want acp", evt.EntryPoint)
+	}
+	if evt.DurationMs < 0 {
+		t.Error("DurationMs should be non-negative for a session that was created")
+	}
+}
+
+func TestOnDeleteSession_EmitsDeleteEvent(t *testing.T) {
+	srv, fake := newTestServerWithObserver()
+
+	// Create a session first.
+	resp, err := srv.OnNewSession(context.Background(), openacp.NewSessionRequest{Cwd: "/tmp"})
+	if err != nil {
+		t.Fatalf("OnNewSession: %v", err)
+	}
+
+	// Delete it.
+	_, err = srv.OnDeleteSession(context.Background(), openacp.DeleteSessionRequest{SessionID: resp.SessionID})
+	if err != nil {
+		t.Fatalf("OnDeleteSession: %v", err)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if len(fake.deletes) != 1 {
+		t.Fatalf("expected 1 delete event, got %d", len(fake.deletes))
+	}
+	evt := fake.deletes[0]
+	if evt.SessionID != string(resp.SessionID) {
+		t.Errorf("SessionID = %q, want %q", evt.SessionID, resp.SessionID)
+	}
+	if evt.EntryPoint != "acp" {
+		t.Errorf("EntryPoint = %q, want acp", evt.EntryPoint)
+	}
+}
+
+func TestSessionObserver_NilIsNoOp(t *testing.T) {
+	// No observer set — should not panic.
+	srv := NewAgentServer(agent.New("test"), kernel.Deps{}, nil, nil)
+	// srv.sessionObservers is nil.
+
+	_, err := srv.OnNewSession(context.Background(), openacp.NewSessionRequest{Cwd: "/tmp"})
+	if err != nil {
+		t.Fatalf("OnNewSession with nil observer: %v", err)
+	}
+}

--- a/build.sh
+++ b/build.sh
@@ -20,6 +20,15 @@ set -euo pipefail
 NAME="${OPENAGENT_BINARY_NAME:-openagent}"
 VERSION="${OPENAGENT_VERSION:-$(git describe --tags --always 2>/dev/null || echo dev)}"
 
+# Event tracking (ldflags-injected). Empty = disabled. The endpoint URL and
+# AppID are not hardcoded here — they are injected via the OPENAGENT_EVENT_*
+# environment variables, typically set as pipeline variables in CI (not in the
+# repo). A plain `go build` or `./build.sh` without these variables produces a
+# disabled binary.
+EVENT_POST_URL="${OPENAGENT_EVENT_POST_URL:-}"
+EVENT_APP_ID="${OPENAGENT_EVENT_APP_ID:-}"
+SKIP_VERIFY="${OPENAGENT_SKIP_VERIFY:-false}"
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$REPO_ROOT"
 
@@ -29,7 +38,10 @@ echo "==> Building Go binary: $NAME (version $VERSION, embedded skills)"
 go build \
          -ldflags "-s -w \
                    -X github.com/yusheng-g/openagent-go/version.Name=$NAME \
-                   -X github.com/yusheng-g/openagent-go/version.Version=$VERSION" \
+                   -X github.com/yusheng-g/openagent-go/version.Version=$VERSION \
+                   -X github.com/yusheng-g/openagent-go/track.EventPostUrl=$EVENT_POST_URL \
+                   -X github.com/yusheng-g/openagent-go/track.AppID=$EVENT_APP_ID \
+                   -X github.com/yusheng-g/openagent-go/track.EventSkipVerify=$SKIP_VERIFY" \
          -o "$NAME" ./cmd/cli/
 
 echo ""

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/yusheng-g/openagent-go/keyring"
 	plugin "github.com/yusheng-g/openagent-go/plugin/cli"
 	cliwasm "github.com/yusheng-g/openagent-go/plugin/cli/wasm"
+	"github.com/yusheng-g/openagent-go/track"
 	"github.com/yusheng-g/openagent-go/version"
 )
 
@@ -137,6 +138,13 @@ func main() {
 		// SetupLog reinstalled the default slog handler — re-apply quiet.
 		applyQuiet()
 	}
+
+	// 5b. Initialize event tracking and wire the session observer.
+	// track.Init is a no-op when EventPostUrl is empty. The endpoint is not
+	// hardcoded — it is injected from CI pipeline variables via ldflags, so
+	// dev builds and tests are unaffected.
+	track.Init()
+	server.SetSessionObservers(track.GetObserver())
 
 	// 6. Build cobra tree.
 	rootCmd.AddCommand(buildServeCmd(cfg))

--- a/cmd/cli/server/acp.go
+++ b/cmd/cli/server/acp.go
@@ -191,6 +191,11 @@ func BuildACPServer(ctx context.Context, cfg *config.Config) (*openacpsdk.Server
 	// these with the client's per-session list at connect time.
 	srv.SetSettingsMcpServers(convertMcpServers(cfg.McpServers))
 
+	// Wire session lifecycle observers (tracking, etc.) into the ACP server.
+	if sessionObserver != nil {
+		srv.SetSessionObservers(sessionObserver)
+	}
+
 	// Register model configs for runtime_set_model_config.
 	for _, mi := range modelInfos {
 		srv.RegisterModel(mi.Key(), mi.Provider, mi.ID, mi.APIKey, mi.BaseURL, acp.ModelPricing{

--- a/cmd/cli/server/run.go
+++ b/cmd/cli/server/run.go
@@ -111,8 +111,19 @@ func RunCLI(ctx context.Context, cfg *config.Config, message string) error {
 		CreatedAt: time.Now(),
 	}
 
+	// Emit session lifecycle events for observers (tracking, telemetry, etc.).
+	if sessionObserver != nil {
+		sessionObserver.OnSessionCreate(ctx, openagent.SessionLifecycleEvent{
+			SessionID:   session.ID,
+			EntryPoint:  openagent.EntryPointCLI,
+			SessionMode: "",
+			CreatedAt:   session.CreatedAt,
+		})
+	}
+
 	// 7. Run and stream events to terminal
 	ch := kernel.New(agentCfg, deps).RunStream(ctx, session, openagent.UserMessage(message))
+	var runErr error
 	for evt := range ch {
 		switch evt.Type {
 		case openagent.StreamTextDelta:
@@ -128,14 +139,32 @@ func RunCLI(ctx context.Context, cfg *config.Config, message string) error {
 			}
 
 		case openagent.StreamError:
-			return evt.Error
+			runErr = evt.Error
 
 		case openagent.StreamAborted:
 			if evt.Error != nil {
-				return evt.Error
+				runErr = evt.Error
+			} else {
+				runErr = ctx.Err()
 			}
-			return ctx.Err()
 		}
 	}
-	return nil
+
+	if sessionObserver != nil {
+		closeEvt := openagent.SessionLifecycleEvent{
+			SessionID:  session.ID,
+			EntryPoint: openagent.EntryPointCLI,
+			DurationMs: time.Since(session.CreatedAt).Milliseconds(),
+		}
+		if runErr != nil {
+			closeEvt.Err = runErr
+		}
+		// Use a fresh context — ctx may be cancelled (Ctrl+C) but we
+		// still want the close event to reach the tracking endpoint.
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		sessionObserver.OnSessionClose(closeCtx, closeEvt)
+	}
+
+	return runErr
 }

--- a/cmd/cli/server/shared.go
+++ b/cmd/cli/server/shared.go
@@ -1001,3 +1001,16 @@ func buildRuntimeDeps(caps config.Capabilities, sensitive config.SensitiveConfig
 func channelDir(name string) string {
 	return filepath.Join(configDir(), "channel", name)
 }
+
+// sessionObserver is the process-wide session lifecycle observer, wired at
+// startup by main.go via SetSessionObservers.  nil = no observers (events
+// silently dropped).  Used by RunCLI and the ACP/REST servers to emit
+// session create/close/delete events.
+var sessionObserver openagent.SessionObserver
+
+// SetSessionObservers wires the process-wide session lifecycle observer.
+// Call once at startup (e.g. in main.go after track.Init()).  Pass nil to
+// disable.
+func SetSessionObservers(obs openagent.SessionObserver) {
+	sessionObserver = obs
+}

--- a/session_observer.go
+++ b/session_observer.go
@@ -1,0 +1,94 @@
+package openagent
+
+import (
+	"context"
+	"time"
+)
+
+// SessionLifecycleEvent carries session-level lifecycle metadata.
+// It is emitted by the ACP/REST/CLI servers at session create / close /
+// delete boundaries and consumed by SessionObserver implementations
+// (e.g. track.Observer for HTTP event reporting).
+//
+// This mirrors the RunObserver / StageEvent pattern but operates one level
+// up: RunObserver observes stages *inside* a run loop; SessionObserver
+// observes the session lifecycle *around* runs.
+
+// EntryPoint constants — the value of SessionLifecycleEvent.EntryPoint,
+// identifying which server created the session. Defined here (not in the
+// track package) so emitters can reference them without importing track.
+const (
+	EntryPointACP  = "acp"
+	EntryPointCLI  = "cli"
+	EntryPointREST = "rest"
+)
+
+type SessionLifecycleEvent struct {
+	SessionID   string    // session ID from Session.ID
+	EntryPoint  string    // one of EntryPointACP / EntryPointCLI / EntryPointREST
+	SessionMode string    // "auto" | "semi-auto" | "manual" | "plan" (empty if unknown)
+	DurationMs  int64     // milliseconds since session create (close/delete only)
+	Err         error     // non-nil if the session ended with an error
+	CreatedAt   time.Time // session creation time (for duration calculation)
+}
+
+// SessionObserver receives session lifecycle events.  nil SessionObserver =
+// events are silently dropped — callers MUST nil-check before invoking.
+//
+// This is a plain Go interface (no WASM, no plugin loader), compiled
+// statically — same pattern as RunObserver.  Implementations include
+// track.Observer (HTTP event reporting); future implementations may cover
+// OpenTelemetry traces or agent evaluation hooks.
+//
+// Concurrency contract: implementations MUST be safe for concurrent use.
+// OnCloseSession and OnDeleteSession may be called from different goroutines
+// than OnNewSession (e.g. ACP session/delete handler vs. the original
+// session/new handler goroutine).
+type SessionObserver interface {
+	OnSessionCreate(ctx context.Context, event SessionLifecycleEvent)
+	OnSessionClose(ctx context.Context, event SessionLifecycleEvent)
+	OnSessionDelete(ctx context.Context, event SessionLifecycleEvent)
+}
+
+// MultiSessionObserver combines multiple SessionObservers into one.
+// Each observer is called in order; nil observers are skipped.  Returns nil
+// when no observers remain after filtering, so the caller can store the
+// result directly and nil-check once.
+func MultiSessionObserver(observers ...SessionObserver) SessionObserver {
+	var filtered []SessionObserver
+	for _, o := range observers {
+		if o != nil {
+			filtered = append(filtered, o)
+		}
+	}
+	switch len(filtered) {
+	case 0:
+		return nil
+	case 1:
+		return filtered[0]
+	default:
+		return &multiSessionObserver{list: filtered}
+	}
+}
+
+type multiSessionObserver struct {
+	list []SessionObserver
+}
+
+func (m *multiSessionObserver) OnSessionCreate(ctx context.Context, event SessionLifecycleEvent) {
+	for _, o := range m.list {
+		o.OnSessionCreate(ctx, event)
+	}
+}
+
+func (m *multiSessionObserver) OnSessionClose(ctx context.Context, event SessionLifecycleEvent) {
+	for _, o := range m.list {
+		o.OnSessionClose(ctx, event)
+	}
+}
+
+func (m *multiSessionObserver) OnSessionDelete(ctx context.Context, event SessionLifecycleEvent) {
+	for _, o := range m.list {
+		o.OnSessionDelete(ctx, event)
+	}
+}

--- a/session_observer_test.go
+++ b/session_observer_test.go
@@ -1,0 +1,86 @@
+package openagent
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// captureSessionObserver records every lifecycle event it receives.
+type captureSessionObserver struct {
+	mu      sync.Mutex
+	creates []SessionLifecycleEvent
+	closes  []SessionLifecycleEvent
+	deletes []SessionLifecycleEvent
+}
+
+func (c *captureSessionObserver) OnSessionCreate(_ context.Context, e SessionLifecycleEvent) {
+	c.mu.Lock()
+	c.creates = append(c.creates, e)
+	c.mu.Unlock()
+}
+
+func (c *captureSessionObserver) OnSessionClose(_ context.Context, e SessionLifecycleEvent) {
+	c.mu.Lock()
+	c.closes = append(c.closes, e)
+	c.mu.Unlock()
+}
+
+func (c *captureSessionObserver) OnSessionDelete(_ context.Context, e SessionLifecycleEvent) {
+	c.mu.Lock()
+	c.deletes = append(c.deletes, e)
+	c.mu.Unlock()
+}
+
+func (c *captureSessionObserver) createCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.creates)
+}
+
+func TestMultiSessionObserver_NilFiltering(t *testing.T) {
+	// All nil → returns nil (caller can nil-check once).
+	obs := MultiSessionObserver(nil, nil)
+	if obs != nil {
+		t.Fatal("MultiSessionObserver(nil, nil) should return nil")
+	}
+}
+
+func TestMultiSessionObserver_SingleFlatten(t *testing.T) {
+	// A single non-nil observer should be returned directly (not wrapped).
+	c := &captureSessionObserver{}
+	obs := MultiSessionObserver(nil, c, nil)
+	if obs != c {
+		t.Fatal("MultiSessionObserver with one non-nil should return it directly")
+	}
+}
+
+func TestMultiSessionObserver_FanOut(t *testing.T) {
+	a := &captureSessionObserver{}
+	b := &captureSessionObserver{}
+	obs := MultiSessionObserver(a, b)
+
+	evt := SessionLifecycleEvent{SessionID: "s1", EntryPoint: "acp"}
+	obs.OnSessionCreate(context.Background(), evt)
+
+	if a.createCount() != 1 || b.createCount() != 1 {
+		t.Fatalf("expected both observers to receive create; got a=%d b=%d",
+			a.createCount(), b.createCount())
+	}
+}
+
+func TestMultiSessionObserver_AllThreeMethods(t *testing.T) {
+	c := &captureSessionObserver{}
+	obs := MultiSessionObserver(c)
+
+	obs.OnSessionCreate(context.Background(), SessionLifecycleEvent{SessionID: "s1"})
+	obs.OnSessionClose(context.Background(), SessionLifecycleEvent{SessionID: "s1", DurationMs: 100})
+	obs.OnSessionDelete(context.Background(), SessionLifecycleEvent{SessionID: "s1"})
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.creates) != 1 || len(c.closes) != 1 || len(c.deletes) != 1 {
+		t.Fatalf("expected 1/1/1 creates/closes/deletes; got %d/%d/%d",
+			len(c.creates), len(c.closes), len(c.deletes))
+	}
+}

--- a/track/track.go
+++ b/track/track.go
@@ -1,0 +1,296 @@
+// Package track reports events to the Huawei Cloud martech tracking platform
+// via a Base64-JSON-form-urlencoded POST protocol.  Currently it reports
+// session lifecycle events (create / close / delete); the package is
+// structured so other event types can be added without changing the
+// reporting infrastructure.
+//
+// The package is self-contained: when EventPostUrl is empty (the default —
+// the endpoint is not hardcoded; it is injected via ldflags from CI pipeline
+// variables), Init is a no-op and all Report* calls return immediately
+// without making network requests. Only builds with a ldflags-injected
+// endpoint emit events.
+//
+// Observer implements openagent.SessionObserver, so the track package can be
+// wired into the ACP/CLI servers via SetSessionObservers without those
+// servers importing track directly.  MultiSessionObserver is available for
+// multi-observer fan-out (e.g. track + OpenTelemetry).
+package track
+
+import (
+	"bytes"
+	"context"
+	"crypto/md5"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	openagent "github.com/yusheng-g/openagent-go"
+	"github.com/yusheng-g/openagent-go/version"
+)
+
+// Package-level configuration, injected via ldflags at build time.
+// The endpoint URL and AppID are not hardcoded in the repo — they are
+// injected from CI pipeline variables (OPENAGENT_EVENT_POST_URL /
+// OPENAGENT_EVENT_APP_ID). When EventPostUrl is empty, the package is
+// fully disabled (no-op).
+var (
+	EventPostUrl    string    // tracking platform endpoint
+	AppID           string    // tracking platform app ID
+	EventSkipVerify = "false" // skip TLS certificate verification ("true" | "false")
+)
+
+// HTTP timeout for the tracking POST.  Bounded so a hung endpoint cannot
+// stall the caller indefinitely.
+const trackTimeout = 5 * time.Second
+
+var (
+	mu       sync.Mutex
+	observer *Observer
+)
+
+func init() {
+	observer = &Observer{}
+}
+
+// EventType constants — the "event" field in EventReq.
+const (
+	EventSessionCreate = "HwCloudCli_Session_Create"
+	EventSessionClose  = "HwCloudCli_Session_Close"
+	EventSessionDelete = "HwCloudCli_Session_Delete"
+)
+
+// EventReq is the contract with the tracking platform.
+// Field names and json tags MUST NOT change — only the field values.
+type EventReq struct {
+	AnonymousId string     `json:"anonymousId"`
+	DistinctId  string     `json:"distinctId"`
+	Event       string     `json:"event"`
+	Time        int64      `json:"time"`
+	Type        string     `json:"type"`
+	Properties  properties `json:"properties"`
+}
+
+// properties is the free-form JSON sub-object for custom fields.
+type properties struct {
+	Source      string `json:"source"`
+	InstanceID  string `json:"instance_id"`
+	Version     string `json:"version"`
+	SessionID   string `json:"session_id"`
+	EntryPoint  string `json:"entry_point"`
+	SessionMode string `json:"session_mode"`
+	DurationMs  int64  `json:"duration_ms"`
+	FailReason  string `json:"fail_reason"`
+	Time        string `json:"time"`
+}
+
+// SessionParams is the input for building an EventReq from a session event.
+type SessionParams struct {
+	SessionID   string
+	EntryPoint  string
+	SessionMode string
+	DurationMs  int64
+	FailReason  string
+}
+
+// eventHttpClient is set once by Init and read by ReportEvent.  Init must
+// complete before any goroutine calls ReportEvent — this happens-before
+// constraint is satisfied by calling Init during single-threaded startup in
+// cmd/cli/main.go before the server begins accepting requests.
+var eventHttpClient *http.Client
+
+// Init constructs the HTTP client used for tracking POSTs.
+// Safe to call multiple times.  No-op when EventPostUrl is empty.
+// Must be called once during startup, before any concurrent ReportEvent calls.
+func Init() {
+	if EventPostUrl == "" {
+		return
+	}
+	if strings.EqualFold(EventSkipVerify, "true") {
+		slog.Warn("track: TLS certificate verification disabled — insecure")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if eventHttpClient != nil {
+		return
+	}
+	eventHttpClient = &http.Client{
+		Timeout: trackTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				MinVersion:         tls.VersionTLS12,
+				InsecureSkipVerify: strings.EqualFold(EventSkipVerify, "true"),
+			},
+		},
+	}
+}
+
+// BuildEvent constructs an EventReq from session-scoped params.
+// The identity fields (AnonymousId/DistinctId) carry the daemon INSTANCE
+// identity — the hostname — so every event from one deployment shares a
+// stable identity. The platform requires a 32-char hex identity (UUID
+// without hyphens): a hostname that is already 32-char hex (Huawei Cloud
+// instance IDs) is used as-is; anything else is MD5-hex encoded.
+func BuildEvent(event string, params SessionParams) EventReq {
+	now := time.Now()
+	host, _ := os.Hostname()
+	identity := host
+	if !isHex32(identity) {
+		sum := md5.Sum([]byte(identity))
+		identity = hex.EncodeToString(sum[:])
+	}
+	return EventReq{
+		AnonymousId: identity,
+		DistinctId:  identity,
+		Event:       event,
+		Time:        now.UnixMilli(),
+		Type:        "track",
+		Properties: properties{
+			Source:      version.Name,
+			InstanceID:  identity,
+			Version:     version.Version,
+			SessionID:   params.SessionID,
+			EntryPoint:  params.EntryPoint,
+			SessionMode: params.SessionMode,
+			DurationMs:  params.DurationMs,
+			FailReason:  params.FailReason,
+			Time:        now.UTC().Format(time.RFC3339Nano),
+		},
+	}
+}
+
+// isHex32 reports whether s is exactly 32 lowercase-hex characters —
+// the tracking platform's required identity format (UUID without hyphens).
+func isHex32(s string) bool {
+	if len(s) != 32 {
+		return false
+	}
+	for _, c := range s {
+		if !(c >= '0' && c <= '9') && !(c >= 'a' && c <= 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// ReportEvent sends a single event to the tracking platform.
+// Panic-safe, non-blocking (bounded by trackTimeout), logs errors via slog.
+// No-op when EventPostUrl is empty or the client was never initialized.
+func ReportEvent(ctx context.Context, eventReq EventReq) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("track: event reporting panic", "panic", r)
+		}
+	}()
+
+	if EventPostUrl == "" || eventHttpClient == nil {
+		return
+	}
+
+	events := []EventReq{eventReq}
+	base64Data, err := encodeToBase64(events)
+	if err != nil {
+		slog.Error("track: failed to encode event data", "error", err)
+		return
+	}
+
+	formData := url.Values{
+		"data":  []string{base64Data},
+		"appid": []string{AppID},
+		"debug": []string{"0"},
+		"gzip":  []string{"0"},
+	}
+	if err := sendPostRequest(ctx, formData); err != nil {
+		slog.Error("track: failed to send event data", "error", err)
+	}
+}
+
+// sendPostRequest POSTs form-urlencoded data to the tracking endpoint.
+func sendPostRequest(ctx context.Context, formData url.Values) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, EventPostUrl, bytes.NewBufferString(formData.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := eventHttpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Warn("track: failed to close response body", "error", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("request failed with status code: %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// encodeToBase64 marshals data to JSON and then Base64-encodes the result.
+func encodeToBase64(data interface{}) (string, error) {
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(jsonData), nil
+}
+
+// ── SessionObserver implementation ──
+
+// Observer implements openagent.SessionObserver, adapting session lifecycle
+// events to HTTP tracking reports.  It is the bridge between the
+// SessionObserver interface and the Report* functions in this package.
+type Observer struct{}
+
+// GetObserver returns the package-level Observer singleton.
+// Safe to call before Init; the Observer methods are no-op when disabled.
+func GetObserver() *Observer {
+	return observer
+}
+
+func (o *Observer) OnSessionCreate(ctx context.Context, e openagent.SessionLifecycleEvent) {
+	ReportEvent(ctx, BuildEvent(EventSessionCreate, SessionParams{
+		SessionID:   e.SessionID,
+		EntryPoint:  e.EntryPoint,
+		SessionMode: e.SessionMode,
+	}))
+}
+
+func (o *Observer) OnSessionClose(ctx context.Context, e openagent.SessionLifecycleEvent) {
+	failReason := ""
+	if e.Err != nil {
+		failReason = e.Err.Error()
+	}
+	ReportEvent(ctx, BuildEvent(EventSessionClose, SessionParams{
+		SessionID:   e.SessionID,
+		EntryPoint:  e.EntryPoint,
+		SessionMode: e.SessionMode,
+		DurationMs:  e.DurationMs,
+		FailReason:  failReason,
+	}))
+}
+
+func (o *Observer) OnSessionDelete(ctx context.Context, e openagent.SessionLifecycleEvent) {
+	failReason := ""
+	if e.Err != nil {
+		failReason = e.Err.Error()
+	}
+	ReportEvent(ctx, BuildEvent(EventSessionDelete, SessionParams{
+		SessionID:   e.SessionID,
+		EntryPoint:  e.EntryPoint,
+		SessionMode: e.SessionMode,
+		DurationMs:  e.DurationMs,
+		FailReason:  failReason,
+	}))
+}

--- a/track/track_test.go
+++ b/track/track_test.go
@@ -1,0 +1,420 @@
+package track
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	openagent "github.com/yusheng-g/openagent-go"
+)
+
+// ── Unit tests ──
+
+func TestBuildEvent_FieldMapping(t *testing.T) {
+	params := SessionParams{
+		SessionID:   "sess-123",
+		EntryPoint:  openagent.EntryPointACP,
+		SessionMode: "manual",
+		DurationMs:  5000,
+		FailReason:  "test error",
+	}
+	evt := BuildEvent(EventSessionCreate, params)
+
+	if evt.Event != EventSessionCreate {
+		t.Errorf("Event = %q, want %q", evt.Event, EventSessionCreate)
+	}
+	// AnonymousId/DistinctId come from hostname, not SessionID.
+	host, _ := os.Hostname()
+	if evt.AnonymousId == "" {
+		t.Error("AnonymousId should not be empty (hostname-derived)")
+	}
+	if evt.DistinctId != evt.AnonymousId {
+		t.Errorf("DistinctId = %q, want %q (same as AnonymousId)", evt.DistinctId, evt.AnonymousId)
+	}
+	if evt.AnonymousId == params.SessionID {
+		t.Errorf("AnonymousId should be hostname-derived, not SessionID %q", params.SessionID)
+	}
+	_ = host // host is informational; identity may be MD5(host) if not hex32
+	if evt.Type != "track" {
+		t.Errorf("Type = %q, want track", evt.Type)
+	}
+	if evt.Time <= 0 {
+		t.Error("Time should be positive (UnixMilli)")
+	}
+	if evt.Properties.SessionID != "sess-123" {
+		t.Errorf("Properties.SessionID = %q, want sess-123", evt.Properties.SessionID)
+	}
+	if evt.Properties.EntryPoint != "acp" {
+		t.Errorf("Properties.EntryPoint = %q, want acp", evt.Properties.EntryPoint)
+	}
+	if evt.Properties.SessionMode != "manual" {
+		t.Errorf("Properties.SessionMode = %q, want manual", evt.Properties.SessionMode)
+	}
+	if evt.Properties.DurationMs != 5000 {
+		t.Errorf("Properties.DurationMs = %d, want 5000", evt.Properties.DurationMs)
+	}
+	if evt.Properties.FailReason != "test error" {
+		t.Errorf("Properties.FailReason = %q, want 'test error'", evt.Properties.FailReason)
+	}
+	if evt.Properties.Time == "" {
+		t.Error("Properties.Time should not be empty (RFC3339Nano)")
+	}
+}
+
+func TestBuildEvent_AllThreeEventTypes(t *testing.T) {
+	params := SessionParams{SessionID: "s1", EntryPoint: openagent.EntryPointCLI}
+
+	create := BuildEvent(EventSessionCreate, params)
+	closeEvt := BuildEvent(EventSessionClose, params)
+	deleteEvt := BuildEvent(EventSessionDelete, params)
+
+	if create.Event != "HwCloudCli_Session_Create" {
+		t.Errorf("create event = %q, want HwCloudCli_Session_Create", create.Event)
+	}
+	if closeEvt.Event != "HwCloudCli_Session_Close" {
+		t.Errorf("close event = %q, want HwCloudCli_Session_Close", closeEvt.Event)
+	}
+	if deleteEvt.Event != "HwCloudCli_Session_Delete" {
+		t.Errorf("delete event = %q, want HwCloudCli_Session_Delete", deleteEvt.Event)
+	}
+}
+
+func TestEncodeToBase64_RoundTrip(t *testing.T) {
+	original := []EventReq{
+		BuildEvent(EventSessionCreate, SessionParams{SessionID: "s1", EntryPoint: "acp"}),
+	}
+	encoded, err := encodeToBase64(original)
+	if err != nil {
+		t.Fatalf("encodeToBase64 failed: %v", err)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("base64 decode failed: %v", err)
+	}
+
+	var result []EventReq
+	if err := json.Unmarshal(decoded, &result); err != nil {
+		t.Fatalf("json unmarshal failed: %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Fatalf("decoded length = %d, want 1", len(result))
+	}
+	if result[0].Event != original[0].Event {
+		t.Errorf("decoded event = %q, want %q", result[0].Event, original[0].Event)
+	}
+	if result[0].Properties.SessionID != original[0].Properties.SessionID {
+		t.Errorf("decoded session_id = %q, want %q",
+			result[0].Properties.SessionID, original[0].Properties.SessionID)
+	}
+}
+
+func TestReportEvent_NoOpWhenUrlEmpty(t *testing.T) {
+	// Save and restore state.
+	savedUrl := EventPostUrl
+	savedClient := eventHttpClient
+	defer func() {
+		EventPostUrl = savedUrl
+		eventHttpClient = savedClient
+	}()
+
+	EventPostUrl = ""
+	eventHttpClient = nil
+
+	// Should return immediately without panicking or making network calls.
+	evt := BuildEvent(EventSessionCreate, SessionParams{SessionID: "s1"})
+	ReportEvent(context.Background(), evt) // must not block or panic
+}
+
+func TestReportEvent_NoOpWhenClientNil(t *testing.T) {
+	savedUrl := EventPostUrl
+	savedClient := eventHttpClient
+	defer func() {
+		EventPostUrl = savedUrl
+		eventHttpClient = savedClient
+	}()
+
+	EventPostUrl = "http://example.com/track"
+	eventHttpClient = nil // client never initialized
+
+	evt := BuildEvent(EventSessionCreate, SessionParams{SessionID: "s1"})
+	ReportEvent(context.Background(), evt) // must not block or panic
+}
+
+func TestReportEvent_PanicSafe(t *testing.T) {
+	savedUrl := EventPostUrl
+	savedClient := eventHttpClient
+	defer func() {
+		EventPostUrl = savedUrl
+		eventHttpClient = savedClient
+	}()
+
+	// Set up a client pointing to an invalid URL to trigger an error path.
+	EventPostUrl = "http://invalid-url-that-does-not-exist.invalid/track"
+	eventHttpClient = &http.Client{Timeout: 1 * time.Second}
+
+	// Should not panic even if the request fails.
+	evt := BuildEvent(EventSessionCreate, SessionParams{SessionID: "s1"})
+	ReportEvent(context.Background(), evt)
+}
+
+func TestInit_NoOpWhenUrlEmpty(t *testing.T) {
+	savedUrl := EventPostUrl
+	savedClient := eventHttpClient
+	defer func() {
+		EventPostUrl = savedUrl
+		eventHttpClient = savedClient
+	}()
+
+	EventPostUrl = ""
+	eventHttpClient = nil
+	Init()
+	if eventHttpClient != nil {
+		t.Error("Init should not create client when EventPostUrl is empty")
+	}
+}
+
+func TestInit_Idempotent(t *testing.T) {
+	savedUrl := EventPostUrl
+	savedClient := eventHttpClient
+	defer func() {
+		EventPostUrl = savedUrl
+		eventHttpClient = savedClient
+	}()
+
+	EventPostUrl = "http://localhost:9999/track"
+	eventHttpClient = nil
+	Init()
+	first := eventHttpClient
+	Init() // second call should not replace the client
+	if eventHttpClient != first {
+		t.Error("Init should be idempotent (same client pointer)")
+	}
+}
+
+// ── Observer tests ──
+
+func TestObserver_DelegatesToReportEvent(t *testing.T) {
+	savedUrl := EventPostUrl
+	savedClient := eventHttpClient
+	defer func() {
+		EventPostUrl = savedUrl
+		eventHttpClient = savedClient
+	}()
+
+	// Use httptest to verify the Observer methods produce correct events.
+	var receivedBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		receivedBody = string(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	EventPostUrl = server.URL
+	AppID = "test-app"
+	eventHttpClient = server.Client()
+
+	obs := &Observer{}
+	obs.OnSessionCreate(context.Background(), openagent.SessionLifecycleEvent{
+		SessionID:   "sess-obs-1",
+		EntryPoint:  openagent.EntryPointACP,
+		SessionMode: "plan",
+	})
+
+	// Decode the received form data.
+	form, err := url.ParseQuery(receivedBody)
+	if err != nil {
+		t.Fatalf("ParseQuery failed: %v", err)
+	}
+	if form.Get("appid") != "test-app" {
+		t.Errorf("appid = %q, want test-app", form.Get("appid"))
+	}
+
+	// Decode the Base64 JSON event.
+	data := form.Get("data")
+	decoded, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		t.Fatalf("base64 decode failed: %v", err)
+	}
+	var events []EventReq
+	if err := json.Unmarshal(decoded, &events); err != nil {
+		t.Fatalf("json unmarshal failed: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Event != EventSessionCreate {
+		t.Errorf("event = %q, want %q", events[0].Event, EventSessionCreate)
+	}
+	if events[0].Properties.SessionID != "sess-obs-1" {
+		t.Errorf("session_id = %q, want sess-obs-1", events[0].Properties.SessionID)
+	}
+	if events[0].Properties.SessionMode != "plan" {
+		t.Errorf("session_mode = %q, want plan", events[0].Properties.SessionMode)
+	}
+}
+
+func TestObserver_OnSessionClose_IncludesDuration(t *testing.T) {
+	savedUrl := EventPostUrl
+	savedClient := eventHttpClient
+	defer func() {
+		EventPostUrl = savedUrl
+		eventHttpClient = savedClient
+	}()
+
+	var receivedBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		receivedBody = string(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	EventPostUrl = server.URL
+	AppID = "test-app"
+	eventHttpClient = server.Client()
+
+	obs := &Observer{}
+	obs.OnSessionClose(context.Background(), openagent.SessionLifecycleEvent{
+		SessionID:  "sess-obs-2",
+		EntryPoint: openagent.EntryPointCLI,
+		DurationMs: 12345,
+	})
+
+	form, _ := url.ParseQuery(receivedBody)
+	decoded, _ := base64.StdEncoding.DecodeString(form.Get("data"))
+	var events []EventReq
+	if err := json.Unmarshal(decoded, &events); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if events[0].Event != EventSessionClose {
+		t.Errorf("event = %q, want %q", events[0].Event, EventSessionClose)
+	}
+	if events[0].Properties.DurationMs != 12345 {
+		t.Errorf("duration_ms = %d, want 12345", events[0].Properties.DurationMs)
+	}
+}
+
+func TestObserver_OnSessionDelete_IncludesFailReason(t *testing.T) {
+	savedUrl := EventPostUrl
+	savedClient := eventHttpClient
+	defer func() {
+		EventPostUrl = savedUrl
+		eventHttpClient = savedClient
+	}()
+
+	var receivedBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		receivedBody = string(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	EventPostUrl = server.URL
+	AppID = "test-app"
+	eventHttpClient = server.Client()
+
+	obs := &Observer{}
+	obs.OnSessionDelete(context.Background(), openagent.SessionLifecycleEvent{
+		SessionID:  "sess-obs-3",
+		EntryPoint: openagent.EntryPointACP,
+		Err:        io.ErrUnexpectedEOF,
+	})
+
+	form, _ := url.ParseQuery(receivedBody)
+	decoded, _ := base64.StdEncoding.DecodeString(form.Get("data"))
+	var events []EventReq
+	if err := json.Unmarshal(decoded, &events); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if events[0].Event != EventSessionDelete {
+		t.Errorf("event = %q, want %q", events[0].Event, EventSessionDelete)
+	}
+	if !strings.Contains(events[0].Properties.FailReason, "unexpected EOF") {
+		t.Errorf("fail_reason = %q, want it to contain 'unexpected EOF'",
+			events[0].Properties.FailReason)
+	}
+}
+
+// ── Integration test ──
+
+func TestIntegration_ServerReceivesAllThreeEventTypes(t *testing.T) {
+	savedUrl := EventPostUrl
+	savedClient := eventHttpClient
+	savedAppID := AppID
+	defer func() {
+		EventPostUrl = savedUrl
+		eventHttpClient = savedClient
+		AppID = savedAppID
+	}()
+
+	var receivedPosts []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		receivedPosts = append(receivedPosts, string(body))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	EventPostUrl = server.URL
+	AppID = "integration-test"
+	eventHttpClient = server.Client()
+
+	ctx := context.Background()
+	obs := &Observer{}
+
+	obs.OnSessionCreate(ctx, openagent.SessionLifecycleEvent{
+		SessionID:  "s-int-1",
+		EntryPoint: openagent.EntryPointACP,
+		CreatedAt:  time.Now().Add(-10 * time.Second),
+	})
+	obs.OnSessionClose(ctx, openagent.SessionLifecycleEvent{
+		SessionID:  "s-int-1",
+		EntryPoint: openagent.EntryPointACP,
+		DurationMs: 10000,
+	})
+	obs.OnSessionDelete(ctx, openagent.SessionLifecycleEvent{
+		SessionID:  "s-int-2",
+		EntryPoint: openagent.EntryPointREST,
+	})
+
+	if len(receivedPosts) != 3 {
+		t.Fatalf("expected 3 POSTs, got %d", len(receivedPosts))
+	}
+
+	// Decode each POST and verify the event type.
+	wantEvents := []string{EventSessionCreate, EventSessionClose, EventSessionDelete}
+	for i, body := range receivedPosts {
+		form, err := url.ParseQuery(body)
+		if err != nil {
+			t.Fatalf("POST %d: ParseQuery failed: %v", i, err)
+		}
+		if form.Get("appid") != "integration-test" {
+			t.Errorf("POST %d: appid = %q, want integration-test", i, form.Get("appid"))
+		}
+		decoded, _ := base64.StdEncoding.DecodeString(form.Get("data"))
+		var events []EventReq
+		if err := json.Unmarshal(decoded, &events); err != nil {
+			t.Fatalf("POST %d: unmarshal failed: %v", i, err)
+		}
+		if len(events) != 1 {
+			t.Fatalf("POST %d: expected 1 event, got %d", i, len(events))
+		}
+		if events[0].Event != wantEvents[i] {
+			t.Errorf("POST %d: event = %q, want %q", i, events[0].Event, wantEvents[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Add a `track` package that reports session lifecycle events to the Huawei Cloud martech tracking platform via Base64-JSON-form-urlencoded POST. The package structure allows other event types to be added later without changing the reporting infrastructure.

## Changes

- **session_observer.go**: `SessionObserver` interface + `MultiSessionObserver` combiner in the openagent package (plain Go interface, same pattern as `RunObserver` — no WASM, no plugin loader). Also hosts the `EntryPointACP`/`CLI`/`REST` constants so emitters need not import track.
- **track/track.go**: HTTP reporting infrastructure + `Observer` implementing `SessionObserver`.
  - Event names prefixed `HwCloudCli_Session_{Create,Close,Delete}`.
  - `AnonymousId`/`DistinctId` derived from hostname (32-char hex as-is, else MD5-hex), so every event from one deployment shares a stable identity.
  - `properties.instance_id` added under `source`, carrying the same hostname-derived identity.
  - ldflags-injected `EventPostUrl`/`AppID`/`EventSkipVerify`.
- **acp/server.go**: emit lifecycle events via `SessionObserver` in `OnNewSession` / `OnCloseSession` / `OnDeleteSession`, using `openagent.EntryPointACP`. Server does NOT import track — only the assembly layer wires it.
- **cmd/cli/server/run.go**: emit create + close for CLI one-shot sessions, using `openagent.EntryPointCLI`.
- **cmd/cli/main.go**: `track.Init()` + `SetSessionObservers` at startup.
- **build.sh**: `OPENAGENT_EVENT_POST_URL` / `OPENAGENT_EVENT_APP_ID` / `OPENAGENT_SKIP_VERIFY` env vars for ldflags injection. **All default to empty (disabled)** — the endpoint and AppID are not hardcoded in the repo; official builds inject them via CI pipeline variables.
- **session_observer.go**: `SessionMode` documents all four modes: `auto` | `semi-auto` | `manual` | `plan`.
- **README.md / README.zh.md**: add a "Telemetry & Privacy" section documenting what is reported (session lifecycle metadata only — no source code, prompts, model output, or file contents), the default-disabled behavior, and how to enable/disable via pipeline variables.

## Telemetry & Privacy

Tracking is **disabled by default**. The endpoint URL and AppID are not hardcoded in the repository — a plain `go build` or `./build.sh` leaves them empty, producing a disabled binary. Only CI pipeline builds that inject `OPENAGENT_EVENT_POST_URL` / `OPENAGENT_EVENT_APP_ID` (stored as pipeline variables, not in the repo) produce a binary that emits events. **What is reported:** event type, session ID, entry point, session mode, duration, failure reason, and a hostname-derived identifier. **No source code, prompts, model output, or file contents are reported.** See the "Telemetry & Privacy" section in the README for full details.

## Test

- `go build ./...` passes.
- `gofmt -l` clean.
- `go test ./track/ ./acp/` passes.