### PR TITLE
fix(iac-server): terraform install path, state attributes, SSRF internal bypass, prompt types

### DIFF
--- a/cmd/mcp/iac-server/agent/planner.go
+++ b/cmd/mcp/iac-server/agent/planner.go
@@ -381,7 +381,9 @@ or, when you need more input:
 	msg := openagent.UserMessage(userMsg)
 	var result *openagent.RunResult
 	for attempt := 0; attempt < 3; attempt++ {
+		stop := heartbeatProgress(progress, fmt.Sprintf("Determining resource specs (attempt %d/3)...", attempt+1), 1, 3)
 		result, err = rt.Run(ctx, session, msg)
+		stop()
 		if err != nil {
 			return "", fmt.Errorf("specify_resources: LLM run (attempt %d): %w", attempt+1, err)
 		}
@@ -566,7 +568,9 @@ Return JSON:
 	var reasoning string
 	for attempt := 0; attempt < 3; attempt++ {
 		progress(fmt.Sprintf("Generating .tf files (attempt %d/3)...", attempt+1), float64(attempt), 3)
+		stop := heartbeatProgress(progress, fmt.Sprintf("Generating .tf files (attempt %d/3)...", attempt+1), float64(attempt), 3)
 		result, err := rt.Run(ctx, session, msg)
+		stop()
 		if err != nil {
 			return "", fmt.Errorf("generate_terraform_plan: LLM run (attempt %d): %w", attempt+1, err)
 		}
@@ -582,7 +586,9 @@ Return JSON:
 			continue
 		}
 		if err := json.Unmarshal([]byte(raw), &llmOutput); err != nil {
-			return "", fmt.Errorf("generate_terraform_plan: parse (attempt %d): %w (raw=%q)", attempt+1, err, raw)
+			// JSON parse failure — retry with a nudge before giving up.
+			msg = nudgeMessage(fmt.Sprintf("Your previous response was not valid JSON: %s. Output the JSON result with .tf files as specified in the system prompt, without any markdown fences or extra text.", err))
+			continue
 		}
 
 		if len(llmOutput.Files) == 0 {
@@ -816,7 +822,9 @@ Return JSON:
 
 	session := openagent.Session{ID: sessionID(deploymentID)}
 	progress("Querying cloud pricing...", 1, 3)
+	stop := heartbeatProgress(progress, "Querying cloud pricing...", 1, 3)
 	result, err := rt.Run(ctx, session, openagent.UserMessage(userMsg))
+	stop()
 	if err != nil {
 		return "", fmt.Errorf("estimate_cost: LLM run: %w", err)
 	}
@@ -1081,8 +1089,14 @@ func readTFFiles(dir string) (string, error) {
 	return b.String(), nil
 }
 
-// extractJSON finds the first JSON object in a string (LLM output may have
-// surrounding text or markdown fences).
+// extractJSON finds the first balanced JSON object in a string (LLM output
+// may have surrounding text or markdown fences).
+//
+// It uses brace-depth counting instead of LastIndex("}") to find the true
+// end of the JSON object. This handles the case where the LLM appends extra
+// text after the closing fence — e.g. ```json\n{...}\n```\n} — where
+// LastIndex("}") would match the trailing "}" and leave the fence inside
+// the extracted substring, causing json.Unmarshal to fail.
 func extractJSON(s string) string {
 	s = strings.TrimSpace(s)
 	s = strings.TrimPrefix(s, "```json")
@@ -1090,12 +1104,43 @@ func extractJSON(s string) string {
 	s = strings.TrimSuffix(s, "```")
 	s = strings.TrimSpace(s)
 
-	start := strings.Index(s, "{")
-	end := strings.LastIndex(s, "}")
-	if start == -1 || end == -1 || end <= start {
+	start := strings.IndexByte(s, '{')
+	if start == -1 {
 		return s
 	}
-	return s[start : end+1]
+
+	// Walk from start, counting brace depth. Skip strings to avoid
+	// counting braces inside JSON string values.
+	depth := 0
+	inString := false
+	escaped := false
+	for i := start; i < len(s); i++ {
+		c := s[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if c == '\\' && inString {
+			escaped = true
+			continue
+		}
+		if c == '"' {
+			inString = !inString
+			continue
+		}
+		if inString {
+			continue
+		}
+		if c == '{' {
+			depth++
+		} else if c == '}' {
+			depth--
+			if depth == 0 {
+				return s[start : i+1]
+			}
+		}
+	}
+	return s // unbalanced — return whole string so Unmarshal gives a clear error
 }
 
 // hasJSONObject reports whether s contains an extractable JSON object.
@@ -1105,6 +1150,38 @@ func extractJSON(s string) string {
 func hasJSONObject(s string) bool {
 	extracted := extractJSON(s)
 	return strings.HasPrefix(extracted, "{") && strings.HasSuffix(extracted, "}")
+}
+
+// heartbeatProgress periodically updates the progress message with elapsed
+// time while a long-running LLM call is in progress. It returns a stop
+// function that must be called when the LLM call completes. The caller's
+// progress cur/tot are preserved — only the message is enriched with a
+// running elapsed counter so the client can tell the task is alive.
+//
+// Usage:
+//
+//	stop := heartbeatProgress(progress, "Determining resource specs...", 1, 3)
+//	result, err := rt.Run(ctx, session, msg)
+//	stop()
+func heartbeatProgress(progress openagent.ProgressFunc, msg string, cur, tot float64) func() {
+	start := time.Now()
+	ticker := time.NewTicker(10 * time.Second)
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-done:
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				progress(fmt.Sprintf("%s (%ds elapsed)", msg, int(time.Since(start).Seconds())), cur, tot)
+			}
+		}
+	}()
+	return func() {
+		close(done)
+		progress(msg, cur, tot) // final update without elapsed
+	}
 }
 
 // nudgeMessage returns a transient user message that prompts the LLM to retry

--- a/cmd/mcp/iac-server/mcp/tools.go
+++ b/cmd/mcp/iac-server/mcp/tools.go
@@ -621,9 +621,12 @@ func (t *getDeploymentStatusTool) Execute(ctx context.Context, args json.RawMess
 	// the client gets a usable identifier for each resource.
 	var state struct {
 		Resources []struct {
-			Address string `json:"address"` // absent in state v4; kept for forward-compat
-			Type    string `json:"type"`
-			Name    string `json:"name"`
+			Address   string `json:"address"` // absent in state v4; kept for forward-compat
+			Type      string `json:"type"`
+			Name      string `json:"name"`
+			Instances []struct {
+				Attributes map[string]any `json:"attributes,omitempty"`
+			} `json:"instances,omitempty"`
 		} `json:"resources"`
 		Outputs map[string]struct {
 			Value any `json:"value"`
@@ -635,18 +638,24 @@ func (t *getDeploymentStatusTool) Execute(ctx context.Context, args json.RawMess
 	}
 
 	// Build resource summaries with a non-empty address (type.name when the
-	// state file omits it).
-	resources := make([]map[string]string, 0, len(state.Resources))
+	// state file omits it). Include the first instance's attributes so callers
+	// can read key values (e.g. EIP address, ECS id/flavor/public_ip) without
+	// a separate query_cloud round-trip.
+	resources := make([]map[string]any, 0, len(state.Resources))
 	for _, r := range state.Resources {
 		addr := r.Address
 		if addr == "" && r.Type != "" && r.Name != "" {
 			addr = r.Type + "." + r.Name
 		}
-		resources = append(resources, map[string]string{
+		entry := map[string]any{
 			"address": addr,
 			"type":    r.Type,
 			"name":    r.Name,
-		})
+		}
+		if len(r.Instances) > 0 && r.Instances[0].Attributes != nil {
+			entry["attributes"] = r.Instances[0].Attributes
+		}
+		resources = append(resources, entry)
 	}
 
 	summary := map[string]any{

--- a/cmd/mcp/iac-server/provider/huaweicloud/httpclient.go
+++ b/cmd/mcp/iac-server/provider/huaweicloud/httpclient.go
@@ -77,6 +77,14 @@ func NewHTTPRequest(ak, sk, securityToken string) *HTTPRequest {
 					if err != nil {
 						host = addr
 					}
+					// HuaweiCloud API endpoints resolve to 100.125.x.x inside
+					// VPCs (RFC 6598 CGNAT), which ResolveAndCheck rejects.
+					// isHuaweiCloudHost already verified the domain at the
+					// Execute layer, so this bypass only applies to legitimate
+					// HuaweiCloud API domains — not attacker-controlled hosts.
+					if isHuaweiCloudInternal(host) {
+						return dialer.DialContext(ctx, network, addr)
+					}
 					if err := utils.ResolveAndCheck(host); err != nil {
 						return nil, err
 					}
@@ -146,8 +154,13 @@ func (t *HTTPRequest) Execute(ctx context.Context, args json.RawMessage) *openag
 
 	// Parse the URL into endpoint, path, and query for signing.
 	// (parsed already validated above; reuse it.)
-	if err := utils.ResolveAndCheck(parsed.Hostname()); err != nil {
-		return openagent.ErrorResult(fmt.Errorf("http_request: %w", err), false, "")
+	// Same HuaweiCloud internal bypass as DialContext — by this point
+	// isHuaweiCloudHost has confirmed the domain, so a 100.125.x.x resolve
+	// is a legitimate VPC-internal API endpoint, not an SSRF target.
+	if !isHuaweiCloudInternal(parsed.Hostname()) {
+		if err := utils.ResolveAndCheck(parsed.Hostname()); err != nil {
+			return openagent.ErrorResult(fmt.Errorf("http_request: %w", err), false, "")
+		}
 	}
 
 	// Query params for signing — pass url.Values directly so repeated keys
@@ -348,6 +361,33 @@ func isHuaweiCloudHost(host string) bool {
 	}
 	for _, sfx := range suffixes {
 		if strings.HasSuffix(host, sfx) {
+			return true
+		}
+	}
+	return false
+}
+
+// isHuaweiCloudInternal reports whether host resolves to a HuaweiCloud
+// VPC-internal address (100.125.0.0/16). Inside a VPC, HuaweiCloud API
+// endpoints (iam/ims/ecs/rms.{region}.myhuaweicloud.com) resolve to
+// 100.125.x.x — part of RFC 6598 CGNAT (100.64.0.0/10), which the generic
+// SSRF defense (utils.IsPublicIP) rejects. This bypass lets those legitimate
+// internal endpoints through.
+//
+// Security: this is only reached after isHuaweiCloudHost has verified the
+// domain is a real HuaweiCloud API endpoint (*.myhuaweicloud.com/.cn/.eu),
+// so an attacker-controlled URL never reaches this check.
+func isHuaweiCloudInternal(host string) bool {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	ips, err := net.DefaultResolver.LookupIPAddr(context.Background(), host)
+	if err != nil || len(ips) == 0 {
+		return false
+	}
+	for _, ip := range ips {
+		ip4 := ip.IP.To4()
+		if ip4 != nil && ip4[0] == 100 && ip4[1] == 125 {
 			return true
 		}
 	}

--- a/cmd/mcp/iac-server/provider/huaweicloud/prompts.go
+++ b/cmd/mcp/iac-server/provider/huaweicloud/prompts.go
@@ -32,7 +32,7 @@ func (h *HuaweiCloud) agents() map[provider.PromptRole]provider.AgentConfig {
 - Do NOT generate .tf configuration
 
 ## Notes
-- Resource types are huaweicloud terraform resource types (e.g. huaweicloud_vpc, huaweicloud_compute_instance, huaweicloud_vpc_subnet, huaweicloud_vpc_eip, huaweicloud_rds_instance, huaweicloud_elb_loadbalancer)`,
+- Resource types are huaweicloud terraform resource types (e.g. huaweicloud_vpc, huaweicloud_vpc_subnet, huaweicloud_vpc_eip, huaweicloud_vpc_eip_associate, huaweicloud_networking_secgroup, huaweicloud_networking_secgroup_rule, huaweicloud_compute_instance, huaweicloud_compute_eip_associate, huaweicloud_rds_instance, huaweicloud_elb_loadbalancer, huaweicloud_dcs_instance, huaweicloud_cce_cluster, huaweicloud_obs_bucket, huaweicloud_cdn_domain)`,
 		},
 		provider.RoleSpecifier: {
 			SkillName: "huaweicloud-deploy",

--- a/iac/binary.go
+++ b/iac/binary.go
@@ -76,15 +76,19 @@ func Install(ctx context.Context, ver string, mirrors []string, destDir string) 
 		return "", fmt.Errorf("create install dir: %w", err)
 	}
 
-	// Empty version: skip cache + mirrors, go straight to hc-install latest.
+	// Empty version: check cache first, then fetch latest via hc-install.
 	if ver == "" {
+		binPath := filepath.Join(destDir, binaryName(""))
+		if info, err := os.Stat(binPath); err == nil && !info.IsDir() {
+			return binPath, nil
+		}
 		return installViaHCInstall(ctx, ver, destDir)
 	}
 
 	// Check if already installed.
 	binName := binaryName(ver)
 	binPath := filepath.Join(destDir, binName)
-	if _, err := os.Stat(binPath); err == nil {
+	if info, err := os.Stat(binPath); err == nil && !info.IsDir() {
 		return binPath, nil
 	}
 
@@ -129,7 +133,7 @@ func downloadFromMirror(ctx context.Context, mirror, ver, destDir string) (strin
 func installViaHCInstall(ctx context.Context, ver, destDir string) (string, error) {
 	i := install.NewInstaller()
 
-	var dir string
+	var binPath string
 	var err error
 
 	if ver == "" {
@@ -138,7 +142,7 @@ func installViaHCInstall(ctx context.Context, ver, destDir string) (string, erro
 			Product:    product.Terraform,
 			InstallDir: destDir,
 		}
-		dir, err = i.Ensure(ctx, []src.Source{lv})
+		binPath, err = i.Ensure(ctx, []src.Source{lv})
 		if err != nil {
 			return "", fmt.Errorf("hc-install latest: %w", err)
 		}
@@ -153,29 +157,30 @@ func installViaHCInstall(ctx context.Context, ver, destDir string) (string, erro
 			Version:    v,
 			InstallDir: destDir,
 		}
-		dir, err = i.Ensure(ctx, []src.Source{ev})
+		binPath, err = i.Ensure(ctx, []src.Source{ev})
 		if err != nil {
 			return "", fmt.Errorf("hc-install %s: %w", ver, err)
 		}
 	}
 
-	// hc-install names the binary "terraform"; rename to include version
-	// for our caching scheme.
-	srcPath := filepath.Join(dir, "terraform")
-	if runtime.GOOS == "windows" {
-		srcPath = filepath.Join(dir, "terraform.exe")
-	}
-
+	// hc-install's Ensure returns the full path to the installed executable
+	// (filepath.Join(destDir, Product.BinaryName())), not a directory.
+	// Product.BinaryName() is platform-aware — "terraform.exe" on Windows,
+	// "terraform" elsewhere — so no GOOS switch is needed here. The previous
+	// code treated the return value as a directory and re-joined "terraform"
+	// onto it, producing a double-nested path (destDir/terraform/terraform).
+	// For the "latest" case the binary is already at the right path; for a
+	// pinned version, rename it to include the version suffix for caching.
 	if ver == "" {
-		return srcPath, nil
+		return binPath, nil
 	}
 
 	dstPath := filepath.Join(destDir, binaryName(ver))
-	if err := os.Rename(srcPath, dstPath); err != nil {
-		if err := copyFile(srcPath, dstPath); err != nil {
+	if err := os.Rename(binPath, dstPath); err != nil {
+		if err := copyFile(binPath, dstPath); err != nil {
 			return "", fmt.Errorf("rename binary: %w", err)
 		}
-		os.Remove(srcPath)
+		os.Remove(binPath)
 	}
 	return dstPath, nil
 }


### PR DESCRIPTION
## Fixes

### 1. terraform install path double-nesting bug (Blocker)
`iac/binary.go` `installViaHCInstall` — hc-install's `Ensure` returns the full executable path, but the old code treated it as a directory and joined another `terraform` onto it, producing `destDir/terraform/terraform` -> ENOTDIR.

### 2. terraform cache check does not distinguish file from directory
`iac/binary.go` `Install` — both the `ver == ""` and `ver != ""` branches used `os.Stat` to check the cache but did not verify the path is a regular file. A stale directory left by the old bug could be returned as a binary path. Added `!info.IsDir()`. Also added a cache check for the `ver == ""` branch (previously it always re-downloaded).

### 3. get_deployment_status does not return resource attributes
`cmd/mcp/iac-server/mcp/tools.go` — the state parser only read `address`/`type`/`name`, not `instances[].attributes`. Added `Instances` and `Attributes` fields and included them in the output.

### 4. SSRF blocks Huawei Cloud internal 100.125.x.x
`cmd/mcp/iac-server/provider/huaweicloud/httpclient.go` — Huawei Cloud API endpoints resolve to `100.125.0.0/16` (RFC 6598 CGNAT) and are blocked by SSRF protection. Added `isHuaweiCloudInternal` allowlist function and bypass in `DialContext`.

### 5. architect prompt resource types incomplete
`cmd/mcp/iac-server/provider/huaweicloud/prompts.go` — expanded example types from 6 to 14, covering all SKILL.md pattern table entries to prevent the LLM from inferring non-existent types.

### 6. LLM JSON output parsing + retry + progress heartbeat
`cmd/mcp/iac-server/agent/planner.go`:
- `extractJSON` uses bracket-depth counting instead of `LastIndex("}")` to avoid greedy matching
- `json.Unmarshal` failure now triggers a nudge retry instead of returning an error immediately
- Added `heartbeatProgress` helper that updates the progress message every 10s during long-running LLM calls