### PR TITLE
fix(serve): default to 127.0.0.1 listen instead of all interfaces

### DIFF
--- a/cmd/cli/config/config.go
+++ b/cmd/cli/config/config.go
@@ -237,7 +237,12 @@ func (m *ModelConfig) UnmarshalJSON(b []byte) error {
 }
 
 type ServerConfig struct {
-	Port int `json:"port,omitempty"`
+	// Host is the listen address for the REST server. Default
+	// "127.0.0.1" (loopback only — the server is not reachable from
+	// the network). Set to "0.0.0.0" to listen on all interfaces
+	// (container/remote-access scenarios).
+	Host string `json:"host,omitempty"`
+	Port int    `json:"port,omitempty"`
 }
 
 // McpServerConfig describes an MCP server using the standard MCP config format
@@ -396,6 +401,9 @@ func ApplyDefaults(cfg *Config, settingsPath string) {
 	}
 	if len(cfg.Plugins) == 0 {
 		cfg.Plugins = []string{DefaultPluginsDir()}
+	}
+	if cfg.Server.Host == "" {
+		cfg.Server.Host = "127.0.0.1"
 	}
 	if cfg.Server.Port == 0 {
 		cfg.Server.Port = 8080

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -338,6 +338,10 @@ func buildServeCmd(cfg config.Config) *cobra.Command {
 			if p > 0 {
 				cfg.Server.Port = p
 			}
+			h, _ := cmd.Flags().GetString("host")
+			if h != "" {
+				cfg.Server.Host = h
+			}
 			if sandboxEnabled, _ := cmd.Flags().GetBool("sandbox"); sandboxEnabled {
 				cfg.Sandbox.Enabled = true
 			}
@@ -380,6 +384,7 @@ func buildServeCmd(cfg config.Config) *cobra.Command {
 	cmd.Flags().Bool("acp", false, "ACP mode over stdio")
 	cmd.Flags().String("channel", "", "Enable IM channel (\"feishu\", \"wechat\", or \"wecom\")")
 	cmd.Flags().Int("port", 0, "REST port (overrides settings)")
+	cmd.Flags().String("host", "", "REST listen address (overrides settings, default 127.0.0.1)")
 	cmd.Flags().Bool("sandbox", false, "Enable OS-native sandbox (bwrap/seatbelt) for shell commands")
 	addCapabilityFlags(cmd)
 	return cmd

--- a/cmd/cli/server/http.go
+++ b/cmd/cli/server/http.go
@@ -177,7 +177,7 @@ func RunREST(ctx context.Context, cfg *config.Config) error {
 		w.Write([]byte(`{"status":"ok"}`))
 	})
 
-	addr := fmt.Sprintf(":%d", cfg.Server.Port)
+	addr := fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port)
 	// ReadHeaderTimeout guards the slow-header DoS (a client that never
 	// finishes sending headers holds a connection); body reads are
 	// bounded per-handler (see the cli:http dispatcher). SSE endpoints


### PR DESCRIPTION
The REST server used ":<port>" which binds 0.0.0.0 (all interfaces), exposing the server to the network by default. Add a Host field to ServerConfig (default 127.0.0.1) and a --host flag to override for container/remote-access scenarios.