### PR TITLE
fix(openviking): per-conversation session reuse + threshold commit

### DIFF
--- a/cmd/cli/config/config.go
+++ b/cmd/cli/config/config.go
@@ -131,9 +131,10 @@ type ContextProviderConfig struct {
 // OpenVikingConfig connects to an OpenViking server (direct HTTP API —
 // search/remember/read, no SDK).
 type OpenVikingConfig struct {
-	Endpoint string       `json:"endpoint,omitempty"`                 // e.g. "http://127.0.0.1:1933"
-	APIKey   string       `json:"api_key,omitempty" sensitive:"true"` // Bearer token; empty = no auth
-	Recall   RecallConfig `json:"recall,omitempty"`
+	Endpoint string          `json:"endpoint,omitempty"`                 // e.g. "http://127.0.0.1:1933"
+	APIKey   string          `json:"api_key,omitempty" sensitive:"true"` // Bearer token; empty = no auth
+	Recall   RecallConfig    `json:"recall,omitempty"`
+	Session  OVSessionConfig `json:"session,omitempty"`
 }
 
 // RecallConfig controls OpenViking's type-quota memory recall endpoint
@@ -152,6 +153,33 @@ type RecallConfig struct {
 	Quotas   map[string]int `json:"quotas,omitempty"`
 	MaxChars int            `json:"max_chars,omitempty"`
 	MinScore float64        `json:"min_score,omitempty"`
+}
+
+// OVSessionConfig controls the OpenViking session reuse and commit
+// threshold policy. When OpenViking.Endpoint is set, session reuse is
+// automatically enabled with the built-in defaults. Override individual
+// fields here to tune the thresholds.
+//
+// This is the config-layer mirror of openviking.SessionConfig (provider
+// layer). The two structs exist on different layers to keep the config
+// package independent of the provider package. shared.go's
+// applyContextProviders maps between them field-by-field. If you add a
+// field here, also add it to openviking.SessionConfig and the mapping.
+//
+// Defaults (applied by the provider when zero):
+//   - CommitTokenThreshold: 6000 (pending tokens)
+//   - CommitMessageThreshold: 50 (messages since last commit)
+//   - MinCommitIntervalSeconds: 300 (5 minutes)
+//   - KeepRecentTurnCount: 3 (WM v2 retention)
+//   - RetainedMessageTokenBudget: 6000
+//   - MinRawTailSteps: 1
+type OVSessionConfig struct {
+	CommitTokenThreshold       int `json:"commit_token_threshold,omitempty"`
+	CommitMessageThreshold     int `json:"commit_message_threshold,omitempty"`
+	MinCommitIntervalSeconds   int `json:"commit_min_interval_seconds,omitempty"`
+	KeepRecentTurnCount        int `json:"keep_recent_turn_count,omitempty"`
+	RetainedMessageTokenBudget int `json:"retained_message_token_budget,omitempty"`
+	MinRawTailSteps            int `json:"min_raw_tail_steps,omitempty"`
 }
 
 // EmbeddingConfig selects the semantic-embedding backend for knowledge

--- a/cmd/cli/server/acp.go
+++ b/cmd/cli/server/acp.go
@@ -160,7 +160,8 @@ func BuildACPServer(ctx context.Context, cfg *config.Config) (*openacpsdk.Server
 		}
 	}
 
-	if err := applyContextProviders(cfg, &deps); err != nil {
+	providerCleanup, err := applyContextProviders(cfg, &deps)
+	if err != nil {
 		return nil, nil, err
 	}
 	// The extractor captures the MemoryProvider it writes to — build it
@@ -298,9 +299,13 @@ func BuildACPServer(ctx context.Context, cfg *config.Config) (*openacpsdk.Server
 		slog.Warn("channel error", "error", err)
 	}
 
-	// Wrap cleanup to also shutdown telemetry (TracerProvider flush).
-	// This runs when the caller defers cleanup() — after server.Run exits.
+	// Wrap cleanup to also flush context providers (e.g. OpenViking
+	// session) and shutdown telemetry (TracerProvider flush). This runs
+	// when the caller defers cleanup() — after server.Run exits.
 	teardown := func() {
+		if providerCleanup != nil {
+			providerCleanup()
+		}
 		cleanup()
 		telemetryShutdown()
 	}

--- a/cmd/cli/server/context_providers_test.go
+++ b/cmd/cli/server/context_providers_test.go
@@ -16,7 +16,7 @@ func TestApplyContextProviders_EndpointSwitchesAll(t *testing.T) {
 		OpenViking: config.OpenVikingConfig{Endpoint: "http://127.0.0.1:1933"},
 	}
 	var deps kernel.Deps
-	if err := applyContextProviders(cfg, &deps); err != nil {
+	if _, err := applyContextProviders(cfg, &deps); err != nil {
 		t.Fatal(err)
 	}
 	if deps.MemoryProvider == nil {
@@ -59,7 +59,7 @@ func TestApplyContextProviders_BuiltinOverride(t *testing.T) {
 		OpenViking: config.OpenVikingConfig{Endpoint: "http://127.0.0.1:1933"},
 	}
 	var deps kernel.Deps
-	if err := applyContextProviders(cfg, &deps); err != nil {
+	if _, err := applyContextProviders(cfg, &deps); err != nil {
 		t.Fatal(err)
 	}
 	if deps.MemoryProvider != nil {
@@ -78,7 +78,7 @@ func TestApplyContextProviders_BuiltinOverride(t *testing.T) {
 func TestApplyContextProviders_NoEndpoint(t *testing.T) {
 	cfg := &config.Config{}
 	var deps kernel.Deps
-	if err := applyContextProviders(cfg, &deps); err != nil {
+	if _, err := applyContextProviders(cfg, &deps); err != nil {
 		t.Fatal(err)
 	}
 	if deps.MemoryProvider != nil || deps.SkillProvider != nil || deps.ResourceProvider != nil {
@@ -100,7 +100,7 @@ func TestApplyContextProviders_CustomRecallConfig(t *testing.T) {
 		},
 	}
 	var deps kernel.Deps
-	if err := applyContextProviders(cfg, &deps); err != nil {
+	if _, err := applyContextProviders(cfg, &deps); err != nil {
 		t.Fatal(err)
 	}
 	mem, ok := deps.MemoryProvider.(*openviking.Memory)

--- a/cmd/cli/server/http.go
+++ b/cmd/cli/server/http.go
@@ -103,9 +103,15 @@ func RunREST(ctx context.Context, cfg *config.Config) error {
 		deps.Summarizer = sumz
 	}
 
-	if err := applyContextProviders(cfg, &deps); err != nil {
+	providerCleanup, err := applyContextProviders(cfg, &deps)
+	if err != nil {
 		return err
 	}
+	defer func() {
+		if providerCleanup != nil {
+			providerCleanup()
+		}
+	}()
 	// The extractor captures the MemoryProvider it writes to — build it
 	// AFTER applyContextProviders so the effective provider is used.
 	// Building it earlier would fork writes to the local sqlite store

--- a/cmd/cli/server/shared.go
+++ b/cmd/cli/server/shared.go
@@ -182,15 +182,44 @@ func resolveModel(cfgModel string, infos []modelReg) openagent.Model {
 // three domains to it by default — one address is enough. context_providers
 // remains as an opt-out escape hatch: an explicit "builtin" for a domain
 // keeps the local backend. No endpoint = fully local, no server required.
-func applyContextProviders(cfg *config.Config, deps *kernel.Deps) error {
-	cp := cfg.ContextProviders
+//
+// Returns a cleanup func that flushes context providers (e.g. OpenViking
+// session) on shutdown — commits any pending messages below the threshold.
+// nil when no provider needs cleanup (no endpoint configured).
+func applyContextProviders(cfg *config.Config, deps *kernel.Deps) (func(), error) {
 	if cfg.OpenViking.Endpoint == "" {
-		return nil
+		return nil, nil
 	}
-	client, err := openviking.NewClient(cfg.OpenViking.Endpoint, cfg.OpenViking.APIKey)
+	client, err := buildOVClient(cfg)
 	if err != nil {
-		return fmt.Errorf("openviking: %w", err)
+		return nil, err
 	}
+	wireOVProviders(cfg, client, deps)
+	return ovFlushCleanup(client), nil
+}
+
+// buildOVClient constructs an OpenViking client with session-reuse config
+// mapped from the settings-layer OVSessionConfig.
+func buildOVClient(cfg *config.Config) (*openviking.Client, error) {
+	s := cfg.OpenViking.Session
+	return openviking.NewClientWithSession(
+		cfg.OpenViking.Endpoint, cfg.OpenViking.APIKey,
+		openviking.SessionConfig{
+			SessionIDSeed:              configDir(),
+			CommitTokenThreshold:       s.CommitTokenThreshold,
+			CommitMessageThreshold:     s.CommitMessageThreshold,
+			MinCommitInterval:          time.Duration(s.MinCommitIntervalSeconds) * time.Second,
+			KeepRecentTurnCount:        s.KeepRecentTurnCount,
+			RetainedMessageTokenBudget: s.RetainedMessageTokenBudget,
+			MinRawTailSteps:            s.MinRawTailSteps,
+		},
+	)
+}
+
+// wireOVProviders switches each domain to OpenViking unless the operator
+// explicitly set "builtin" for that domain in context_providers.
+func wireOVProviders(cfg *config.Config, client *openviking.Client, deps *kernel.Deps) {
+	cp := cfg.ContextProviders
 	if cp.Memory != "builtin" {
 		deps.MemoryProvider = openviking.NewMemoryWithRecall(client, openviking.RecallConfig{
 			Quotas:   cfg.OpenViking.Recall.Quotas,
@@ -204,7 +233,18 @@ func applyContextProviders(cfg *config.Config, deps *kernel.Deps) error {
 	if cp.Resource != "builtin" {
 		deps.ResourceProvider = openviking.NewResource(client)
 	}
-	return nil
+}
+
+// ovFlushCleanup returns a shutdown func that flushes the OpenViking
+// session (commits any pending messages below the threshold).
+func ovFlushCleanup(client *openviking.Client) func() {
+	return func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := client.Flush(ctx); err != nil {
+			slog.Warn("openviking session flush failed", "error", err)
+		}
+	}
 }
 
 // sandboxPolicy translates the config-layer SandboxConfig into a

--- a/context/async_extractor.go
+++ b/context/async_extractor.go
@@ -9,11 +9,12 @@ import (
 )
 
 // AsyncExtractor runs extraction in the background with a single worker:
-// submissions are coalesced per user — the latest messages replace any
-// queued job for the same user — so N finished runs produce at most one
-// extraction pass. Industry practice: write-heavy LLM extraction runs
-// asynchronously (Mem0: extraction at write time, typically background)
-// and must never delay the agent loop.
+// submissions are coalesced per user+conversation — the latest messages
+// replace any queued job for the same user and session — so N finished
+// runs produce at most one extraction pass per conversation. Industry
+// practice: write-heavy LLM extraction runs asynchronously (Mem0:
+// extraction at write time, typically background) and must never delay
+// the agent loop.
 //
 // The worker is bounded: one goroutine, one job at a time, 60s timeout
 // per extraction, queue capacity 64 (a saturated backlog drops new
@@ -23,8 +24,8 @@ type AsyncExtractor struct {
 	inner Extractor
 
 	mu      sync.Mutex
-	pending map[string]extractJob // key: scope.UserID — coalesced to latest
-	queue   chan string           // user keys ready for extraction
+	pending map[string]extractJob // key: scope.UserID+"/"+scope.SessionID
+	queue   chan string           // conversation keys ready for extraction
 	done    chan struct{}         // worker stop (tests)
 }
 
@@ -75,13 +76,13 @@ func (e *AsyncExtractor) Extract(ctx context.Context, scope ContextScope, messag
 	if e == nil || e.inner == nil || len(messages) == 0 {
 		return
 	}
-	key := scope.UserID
+	key := scope.UserID + "/" + scope.SessionID
 	e.mu.Lock()
 	_, queued := e.pending[key]
 	e.pending[key] = extractJob{scope: scope, messages: messages}
 	if !queued {
-		// First submission for this user: announce the key. A saturated
-		// backlog drops the announcement — best-effort by design.
+		// First submission for this conversation: announce the key. A
+		// saturated backlog drops the announcement — best-effort by design.
 		select {
 		case e.queue <- key:
 		default:
@@ -90,7 +91,7 @@ func (e *AsyncExtractor) Extract(ctx context.Context, scope ContextScope, messag
 	e.mu.Unlock()
 }
 
-// worker drains the queue and extracts the latest job per user.
+// worker drains the queue and extracts the latest job per conversation.
 func (e *AsyncExtractor) worker() {
 	for {
 		select {

--- a/kernel/run.go
+++ b/kernel/run.go
@@ -390,8 +390,11 @@ func (rt *Runtime) run(ctx context.Context, session openagent.Session, prefix []
 	rt.state.Turn = result.TurnCount
 	// Self-evolution: store durable knowledge from this finished run.
 	// Knowledge is user-level (cross-session long-term memory) — the
-	// session ID is NOT part of the scope, or every new session would be
-	// filtered away from the knowledge it should recall.
+	// session ID is NOT part of the recall scope, or every new session
+	// would be filtered away from the knowledge it should recall.
+	// However, SessionID IS used by the OpenViking provider's Store
+	// path to route knowledge fragments into per-conversation OV sessions
+	// so VLM extraction sees a coherent conversation context.
 	//
 	// The call is fire-and-forget: AsyncExtractor (the standard wiring)
 	// enqueues and extracts on its background worker, so this never
@@ -399,7 +402,8 @@ func (rt *Runtime) run(ctx context.Context, session openagent.Session, prefix []
 	// server (never per run).
 	if rt.deps.Extractor != nil && len(workingMessages) > 0 {
 		rt.deps.Extractor.Extract(ctx, ctxpkg.ContextScope{
-			UserID: session.UserID,
+			UserID:    session.UserID,
+			SessionID: session.ID,
 		}, workingMessages)
 	}
 	chSend(ctx, ch, openagent.StreamEvent{Type: openagent.StreamDone, Result: result})

--- a/provider/openviking/client.go
+++ b/provider/openviking/client.go
@@ -9,17 +9,24 @@
 //	Search     — POST /api/v1/search/search  (semantic retrieval)
 //	ListSkills — GET  /api/v1/skills         (list skill catalog)
 //	Remember   — POST /api/v1/sessions → /messages/batch → /commit
+//	AddMessage — POST /api/v1/sessions/{id}/messages/batch  (session reuse)
+//	MaybeCommit— POST /api/v1/sessions/{id}/commit          (threshold-based)
 //	Read       — GET  /api/v1/content/read  (viking:// URI → content)
 package openviking
 
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 )
 
@@ -35,13 +42,82 @@ type Item struct {
 // Client talks to an OpenViking server over its HTTP API. An optional API
 // key is sent as a Bearer token; when empty, the server's own identity
 // (account / user) scopes the knowledge.
+//
+// When SessionConfig.SessionIDSeed is non-empty, the client maintains one
+// OV session per conversation (derived from seed + conversation ID),
+// lazily created and crash-recovered. Commits are threshold-based instead
+// of per-call. When the seed is empty (legacy mode via NewClient), each
+// Remember call creates a fresh session and commits immediately — the
+// original behavior.
 type Client struct {
 	baseURL string
 	apiKey  string
 	http    *http.Client
+
+	sessMu   sync.Mutex
+	sessions map[string]*sessionState // ovSessionID → state
+	sessCfg  SessionConfig
 }
 
-// NewClient creates a client for an OpenViking server.
+// sessionState tracks the commit-threshold state for one OV session.
+type sessionState struct {
+	id             string
+	pendingTokens  int       // last reported by server via add_message response
+	msgSinceCommit int       // turn-count fallback counter
+	lastCommitAt   time.Time // for MinCommitInterval enforcement
+}
+
+// SessionConfig controls the OpenViking per-conversation session reuse
+// and commit threshold policy. When SessionIDSeed is empty, the client
+// falls back to legacy mode (create session + immediate commit per
+// Remember call).
+//
+// Zero threshold/interval values fall back to built-in defaults via
+// applySessionDefaults: CommitTokenThreshold=30000,
+// CommitMessageThreshold=20, MinCommitInterval=5m. These align with the
+// OpenViking team's recommendation for knowledge-fragment stores.
+type SessionConfig struct {
+	// SessionIDSeed is combined with the conversation ID to derive a
+	// deterministic OV session ID per conversation:
+	// "openagent-{sha256(seed + "/" + conversationID)[:12]}".
+	// Same seed + same conversation → same OV session across restarts.
+	// Empty = legacy mode (no reuse).
+	SessionIDSeed string
+
+	// CommitTokenThreshold is the pending-token count that triggers a
+	// commit. The server returns pending_tokens after each add_message.
+	// Default 30000.
+	CommitTokenThreshold int
+
+	// CommitMessageThreshold is the turn-count fallback: commit when
+	// msgSinceCommit reaches this value, even if pending_tokens is below
+	// the token threshold. Default 20.
+	CommitMessageThreshold int
+
+	// MinCommitInterval prevents burst commits. Even if a threshold is
+	// crossed, the client waits at least this long since the last commit.
+	// Default 5m.
+	MinCommitInterval time.Duration
+
+	// WM v2 retention parameters — passed to the commit endpoint. These
+	// control how many recent messages are retained in the live session
+	// after commit. Defaults: turn_count=3, budget=6000, steps=1.
+	KeepRecentTurnCount        int
+	RetainedMessageTokenBudget int
+	MinRawTailSteps            int
+}
+
+// assistantMemoryPolicy is the memory_policy sent at session creation.
+// self=false: the agent is an assistant — don't extract into the session
+// owner's scope. peer=true: extract into the user's (peer) scope so
+// memories are attributed to the user, not the agent.
+var assistantMemoryPolicy = map[string]any{
+	"self": map[string]any{"enabled": false},
+	"peer": map[string]any{"enabled": true},
+}
+
+// NewClient creates a client in legacy mode (no session reuse). Each
+// Remember call creates a fresh session and commits immediately.
 func NewClient(endpoint, apiKey string) (*Client, error) {
 	if endpoint == "" {
 		return nil, fmt.Errorf("openviking: empty endpoint")
@@ -51,6 +127,48 @@ func NewClient(endpoint, apiKey string) (*Client, error) {
 		apiKey:  apiKey,
 		http:    &http.Client{Timeout: 120 * time.Second},
 	}, nil
+}
+
+// NewClientWithSession creates a client with per-conversation session
+// reuse and threshold-based commit. The seed is combined with each
+// conversation ID to derive a deterministic OV session ID so the same
+// deployment reuses the same OV session for the same conversation across
+// restarts.
+func NewClientWithSession(endpoint, apiKey string, cfg SessionConfig) (*Client, error) {
+	if endpoint == "" {
+		return nil, fmt.Errorf("openviking: empty endpoint")
+	}
+	applySessionDefaults(&cfg)
+	return &Client{
+		baseURL:  endpoint,
+		apiKey:   apiKey,
+		http:     &http.Client{Timeout: 120 * time.Second},
+		sessions: make(map[string]*sessionState),
+		sessCfg:  cfg,
+	}, nil
+}
+
+// applySessionDefaults fills zero-value threshold/retention fields with
+// the built-in defaults. Called by NewClientWithSession.
+func applySessionDefaults(cfg *SessionConfig) {
+	if cfg.CommitTokenThreshold == 0 {
+		cfg.CommitTokenThreshold = 30000
+	}
+	if cfg.CommitMessageThreshold == 0 {
+		cfg.CommitMessageThreshold = 20
+	}
+	if cfg.MinCommitInterval == 0 {
+		cfg.MinCommitInterval = 5 * time.Minute
+	}
+	if cfg.KeepRecentTurnCount == 0 {
+		cfg.KeepRecentTurnCount = 3
+	}
+	if cfg.RetainedMessageTokenBudget == 0 {
+		cfg.RetainedMessageTokenBudget = 6000
+	}
+	if cfg.MinRawTailSteps == 0 {
+		cfg.MinRawTailSteps = 1
+	}
 }
 
 // responseEnvelope is the OpenViking API envelope: {status, result, error}.
@@ -274,12 +392,45 @@ func (c *Client) ListSkills(ctx context.Context, nodeLimit int) ([]SkillEntry, e
 	return res.Skills, nil
 }
 
-// ── Remember ──
+// ── Remember (legacy + session-reuse) ──
 
-// Remember stores a message into OpenViking long-term memory (triggers
-// the server's background extraction).
+// Remember stores a message into OpenViking long-term memory. It is the
+// single-call API: add a message and commit in one shot.
+//
+// In legacy mode (SessionIDSeed empty, via NewClient), each call creates a
+// fresh session, adds one message, and commits immediately — the
+// original behavior that matches the OpenViking REST contract but
+// produces per-call VLM extraction overhead.
+//
+// In session-reuse mode (SessionIDSeed set, via NewClientWithSession),
+// it delegates to AddMessage + MaybeCommit with a global session (empty
+// conversation ID): the message is appended to the global OV session and
+// committed only when a threshold is crossed.
+//
+// Deprecated: prefer AddMessage + MaybeCommit for explicit threshold
+// control and per-conversation session routing. Remember is retained for
+// backward compatibility.
 func (c *Client) Remember(ctx context.Context, content string) (string, error) {
-	// 1. Create a session.
+	if c.sessCfg.SessionIDSeed == "" {
+		return c.legacyRemember(ctx, content)
+	}
+	ovSID := c.SessionIDFor("")
+	if _, err := c.AddMessage(ctx, "assistant", content, "", ovSID); err != nil {
+		return "", err
+	}
+	if err := c.MaybeCommit(ctx, ovSID); err != nil {
+		return "", err
+	}
+	return "stored", nil
+}
+
+// legacyRemember is the original create+add+commit-per-call implementation.
+// Uses role="user" (the original behavior); the session-reuse path
+// (Store → AddMessage) uses role="assistant" instead, since knowledge
+// items are agent-extracted conclusions, not user input. The role
+// difference is intentional — legacy callers (e.g. team_memory.go)
+// expect the original contract.
+func (c *Client) legacyRemember(ctx context.Context, content string) (string, error) {
 	var created struct {
 		SessionID string `json:"session_id"`
 	}
@@ -290,7 +441,6 @@ func (c *Client) Remember(ctx context.Context, content string) (string, error) {
 		return "", fmt.Errorf("openviking create session: empty session id")
 	}
 
-	// 2. Add the message.
 	msg := map[string]any{"role": "user", "content": content}
 	if err := c.doJSON(ctx, http.MethodPost,
 		"/api/v1/sessions/"+url.PathEscape(created.SessionID)+"/messages/batch",
@@ -298,13 +448,257 @@ func (c *Client) Remember(ctx context.Context, content string) (string, error) {
 		return "", fmt.Errorf("openviking add messages: %w", err)
 	}
 
-	// 3. Commit (archive + background extraction).
 	if err := c.doJSON(ctx, http.MethodPost,
 		"/api/v1/sessions/"+url.PathEscape(created.SessionID)+"/commit",
 		nil, map[string]any{"keep_recent_count": 0}, nil); err != nil {
 		return "", fmt.Errorf("openviking commit session: %w", err)
 	}
 	return "stored", nil
+}
+
+// ── Per-conversation session reuse ──
+
+// SessionIDFor derives the OV session ID for a conversation. The same
+// seed + conversation ID always produces the same OV session ID, so a
+// restarted process resumes the same session. An empty conversationID
+// yields a global session (backward-compatible with Remember).
+func (c *Client) SessionIDFor(conversationID string) string {
+	return deriveSessionID(c.sessCfg.SessionIDSeed, conversationID)
+}
+
+// AddMessage appends a message to the OV session identified by ovSessionID
+// and returns the server-reported pending_tokens. The session is lazily
+// created on first call for that ID and reused across subsequent calls.
+// If the session has expired (404), it is recreated and the call is
+// retried once.
+//
+// peerID is attached to the message for memory attribution (per-message,
+// not per-session). Pass scope.UserID so OV's VLM extracts memories into
+// the user's peer scope. Empty peerID is valid (no attribution).
+func (c *Client) AddMessage(ctx context.Context, role, content, peerID, ovSessionID string) (int, error) {
+	if err := c.ensureSession(ctx, ovSessionID); err != nil {
+		return 0, err
+	}
+
+	pending, err := c.doAddMessage(ctx, role, content, peerID, ovSessionID)
+	if err != nil && isNotFound(err) {
+		c.sessMu.Lock()
+		delete(c.sessions, ovSessionID)
+		c.sessMu.Unlock()
+		slog.Warn("openviking session expired, recreating", "ov_session", ovSessionID)
+		if err2 := c.ensureSession(ctx, ovSessionID); err2 != nil {
+			return 0, err2
+		}
+		return c.doAddMessage(ctx, role, content, peerID, ovSessionID)
+	}
+	if err != nil {
+		return 0, err
+	}
+	return pending, nil
+}
+
+// doAddMessage sends a messages/batch request and updates the per-session
+// pending state. The caller must have called ensureSession first.
+func (c *Client) doAddMessage(ctx context.Context, role, content, peerID, ovSessionID string) (int, error) {
+	c.sessMu.Lock()
+	ss := c.sessions[ovSessionID]
+	c.sessMu.Unlock()
+	if ss == nil {
+		return 0, fmt.Errorf("openviking: session %s not initialized", ovSessionID)
+	}
+
+	msg := map[string]any{"role": role, "content": content}
+	if peerID != "" {
+		msg["peer_id"] = peerID
+	}
+	var resp struct {
+		PendingTokens int `json:"pending_tokens"`
+	}
+	if err := c.doJSON(ctx, http.MethodPost,
+		"/api/v1/sessions/"+url.PathEscape(ss.id)+"/messages/batch",
+		nil, map[string]any{"messages": []any{msg}}, &resp); err != nil {
+		return 0, fmt.Errorf("openviking add messages: %w", err)
+	}
+
+	c.sessMu.Lock()
+	ss.pendingTokens = resp.PendingTokens
+	ss.msgSinceCommit++
+	c.sessMu.Unlock()
+	return resp.PendingTokens, nil
+}
+
+// MaybeCommit commits the OV session identified by ovSessionID if a
+// threshold is crossed (token count or message count), subject to
+// MinCommitInterval. Below threshold or within the interval, it is a
+// no-op — the messages stay in the live session and accumulate until
+// the next check.
+func (c *Client) MaybeCommit(ctx context.Context, ovSessionID string) error {
+	c.sessMu.Lock()
+	defer c.sessMu.Unlock()
+
+	if c.sessCfg.SessionIDSeed == "" {
+		return nil
+	}
+	ss := c.sessions[ovSessionID]
+	if ss == nil {
+		return nil
+	}
+
+	tokenTriggered := ss.pendingTokens >= c.sessCfg.CommitTokenThreshold
+	msgTriggered := ss.msgSinceCommit >= c.sessCfg.CommitMessageThreshold
+	if !tokenTriggered && !msgTriggered {
+		return nil
+	}
+	if !ss.lastCommitAt.IsZero() && time.Since(ss.lastCommitAt) < c.sessCfg.MinCommitInterval {
+		return nil
+	}
+	return c.commitLocked(ctx, ss)
+}
+
+// Flush forces a commit on all sessions with pending messages, regardless
+// of thresholds. Call on shutdown to ensure pending messages are archived
+// and extracted before the process exits. No-op when nothing is pending.
+func (c *Client) Flush(ctx context.Context) error {
+	c.sessMu.Lock()
+	defer c.sessMu.Unlock()
+
+	if c.sessCfg.SessionIDSeed == "" {
+		return nil
+	}
+	for ovSID, ss := range c.sessions {
+		if ss.pendingTokens == 0 && ss.msgSinceCommit == 0 {
+			continue
+		}
+		slog.Debug("openviking flush", "ov_session", ovSID,
+			"pending_tokens", ss.pendingTokens, "msg_since_commit", ss.msgSinceCommit)
+		if err := c.commitLocked(ctx, ss); err != nil {
+			slog.Warn("openviking flush failed for session", "ov_session", ovSID, "error", err)
+		}
+	}
+	return nil
+}
+
+// ensureSession lazily creates or recovers the OV session for the given
+// ovSessionID. On first call it tries GET /sessions/{id}; if the session
+// exists (previous process crashed or restarted) and has pending_tokens >
+// 0, it commits the leftovers (crash recovery). If 404, it creates a new
+// session with the assistant memory_policy. Subsequent calls are no-ops.
+func (c *Client) ensureSession(ctx context.Context, ovSessionID string) error {
+	c.sessMu.Lock()
+	if ss := c.sessions[ovSessionID]; ss != nil {
+		c.sessMu.Unlock()
+		return nil
+	}
+	seed := c.sessCfg.SessionIDSeed
+	c.sessMu.Unlock()
+
+	if seed == "" {
+		return nil
+	}
+
+	var sess struct {
+		PendingTokens int `json:"pending_tokens"`
+	}
+	err := c.doJSON(ctx, http.MethodGet, "/api/v1/sessions/"+url.PathEscape(ovSessionID), nil, nil, &sess)
+	if err == nil {
+		// Crash recovery: session exists from a previous process.
+		// If it has pending (uncommitted) messages, flush them before
+		// proceeding. The entire recovery path is under a single lock
+		// hold so no other goroutine can interleave.
+		c.sessMu.Lock()
+		defer c.sessMu.Unlock()
+		ss := &sessionState{id: ovSessionID}
+		c.sessions[ovSessionID] = ss
+		if sess.PendingTokens > 0 {
+			slog.Info("openviking crash recovery: committing leftover session",
+				"session", ovSessionID, "pending_tokens", sess.PendingTokens)
+			ss.pendingTokens = sess.PendingTokens
+			_ = c.commitLocked(ctx, ss)
+		} else {
+			slog.Debug("openviking session reused", "session", ovSessionID)
+		}
+		return nil
+	}
+	if isNotFound(err) {
+		return c.createSession(ctx, ovSessionID)
+	}
+	return fmt.Errorf("openviking ensure session: %w", err)
+}
+
+// createSession creates a new OV session with the assistant memory_policy.
+// AlreadyExists is tolerated (another process or goroutine created it
+// concurrently).
+func (c *Client) createSession(ctx context.Context, ovSessionID string) error {
+	body := map[string]any{
+		"session_id":    ovSessionID,
+		"memory_policy": assistantMemoryPolicy,
+	}
+	err := c.doJSON(ctx, http.MethodPost, "/api/v1/sessions", nil, body, nil)
+	if err != nil && !isAlreadyExists(err) {
+		return fmt.Errorf("openviking create session: %w", err)
+	}
+	if isAlreadyExists(err) {
+		slog.Debug("openviking session already exists", "session", ovSessionID)
+	}
+	c.sessMu.Lock()
+	c.sessions[ovSessionID] = &sessionState{id: ovSessionID}
+	c.sessMu.Unlock()
+	slog.Info("openviking session created", "session", ovSessionID)
+	return nil
+}
+
+// commitLocked sends a WM v2 commit request and resets the session's
+// pending state. The caller must hold sessMu.
+func (c *Client) commitLocked(ctx context.Context, ss *sessionState) error {
+	body := map[string]any{
+		"retention_mode":                "turn_budget",
+		"keep_recent_turn_count":        c.sessCfg.KeepRecentTurnCount,
+		"retained_message_token_budget": c.sessCfg.RetainedMessageTokenBudget,
+		"min_raw_tail_steps":            c.sessCfg.MinRawTailSteps,
+	}
+	if err := c.doJSON(ctx, http.MethodPost,
+		"/api/v1/sessions/"+url.PathEscape(ss.id)+"/commit",
+		nil, body, nil); err != nil {
+		return fmt.Errorf("openviking commit session: %w", err)
+	}
+	archivedTokens := ss.pendingTokens
+	archivedMsgs := ss.msgSinceCommit
+	ss.pendingTokens = 0
+	ss.msgSinceCommit = 0
+	ss.lastCommitAt = time.Now()
+	slog.Info("openviking session committed",
+		"session", ss.id,
+		"archived_tokens", archivedTokens,
+		"messages", archivedMsgs)
+	return nil
+}
+
+// deriveSessionID produces a deterministic OV session ID from a seed and
+// a conversation ID: "openagent-{sha256(seed + "/" + conversationID)[:12]}".
+// Same seed + same conversation → same ID across restarts. Different
+// deployments (different seeds) naturally isolate. An empty conversationID
+// yields a global session.
+func deriveSessionID(seed, conversationID string) string {
+	h := sha256.Sum256([]byte(seed + "/" + conversationID))
+	return "openagent-" + hex.EncodeToString(h[:6])
+}
+
+// isNotFound reports whether err is an OpenViking 404 / NOT_FOUND.
+func isNotFound(err error) bool {
+	var ae *apiError
+	if errors.As(err, &ae) {
+		return ae.StatusCode == 404 || ae.Code == "NOT_FOUND"
+	}
+	return false
+}
+
+// isAlreadyExists reports whether err is an OpenViking 409 / ALREADY_EXISTS.
+func isAlreadyExists(err error) bool {
+	var ae *apiError
+	if errors.As(err, &ae) {
+		return ae.StatusCode == 409 || ae.Code == "ALREADY_EXISTS"
+	}
+	return false
 }
 
 // ── Read ──

--- a/provider/openviking/memory.go
+++ b/provider/openviking/memory.go
@@ -112,7 +112,18 @@ func (m *Memory) Recall(ctx context.Context, scope ctxpkg.ContextScope, query st
 // shared long-term knowledge base scoped by the server's own identity
 // (account/user), not by ContextScope — the scope is not applied on the
 // wire. Deployments needing per-user isolation scope the server side.
-func (m *Memory) Store(ctx context.Context, _ ctxpkg.ContextScope, item ctxpkg.MemoryItem) error {
-	_, err := m.client.Remember(ctx, item.Content)
-	return err
+//
+// In session-reuse mode (Client created via NewClientWithSession), the
+// message is appended to a per-conversation OV session (derived from
+// scope.SessionID) with scope.UserID as peer_id (for memory attribution),
+// and commit is deferred to the threshold check (MaybeCommit). In legacy
+// mode (NewClient), Remember creates a fresh session and commits
+// immediately per call.
+func (m *Memory) Store(ctx context.Context, scope ctxpkg.ContextScope, item ctxpkg.MemoryItem) error {
+	ovSID := m.client.SessionIDFor(scope.SessionID)
+	_, err := m.client.AddMessage(ctx, "assistant", item.Content, scope.UserID, ovSID)
+	if err != nil {
+		return err
+	}
+	return m.client.MaybeCommit(ctx, ovSID)
 }

--- a/provider/openviking/memory_test.go
+++ b/provider/openviking/memory_test.go
@@ -6,7 +6,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	ctxpkg "github.com/yusheng-g/openagent-go/context"
 )
@@ -233,5 +236,569 @@ func TestRecall_URIFallback(t *testing.T) {
 	}
 	if entries[0].Content != "viking://user/default/memories/entities/redis.md" {
 		t.Errorf("content = %q, want URI fallback", entries[0].Content)
+	}
+}
+
+// ── Session reuse + threshold commit tests ──
+
+// sessionMockServer is a test double for the OpenViking session API.
+// It records all requests and serves configurable responses.
+type sessionMockServer struct {
+	*httptest.Server
+
+	mu              sync.Mutex
+	createCount     int
+	commitBodies    []map[string]any
+	addMsgBodies    []map[string]any
+	getCount        int
+	pendingTokens   int  // value returned in add_message response
+	sessionExists   bool // GET returns 200 (true) or 404 (false)
+	addMsgStatus    int  // 0 = normal, 404 = simulate expired session (first call only)
+	addMsgCallCount int
+	commitCount     int
+}
+
+func newSessionMockServer() *sessionMockServer {
+	s := &sessionMockServer{
+		pendingTokens: 100, // low default, below threshold
+	}
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/v1/sessions", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			s.mu.Lock()
+			s.createCount++
+			var body map[string]any
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &body)
+			s.mu.Unlock()
+
+			w.Header().Set("Content-Type", "application/json")
+			sid, _ := body["session_id"].(string)
+			if sid == "" {
+				sid = "test-session"
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "ok",
+				"result": map[string]any{"session_id": sid},
+			})
+		}
+	})
+
+	mux.HandleFunc("/api/v1/sessions/", func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+
+		if r.Method == http.MethodGet && !strings.Contains(path, "/messages") && !strings.Contains(path, "/commit") {
+			s.mu.Lock()
+			s.getCount++
+			exists := s.sessionExists
+			pt := s.pendingTokens
+			s.mu.Unlock()
+
+			if !exists {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"status": "error",
+					"error":  map[string]any{"code": "NOT_FOUND", "message": "session not found"},
+				})
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "ok",
+				"result": map[string]any{"pending_tokens": pt},
+			})
+			return
+		}
+
+		if r.Method == http.MethodPost && strings.HasSuffix(path, "/messages/batch") {
+			s.mu.Lock()
+			s.addMsgCallCount++
+			var body map[string]any
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &body)
+			s.addMsgBodies = append(s.addMsgBodies, body)
+			pt := s.pendingTokens
+			if s.addMsgStatus == 404 && s.addMsgCallCount == 1 {
+				s.mu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"status": "error",
+					"error":  map[string]any{"code": "NOT_FOUND", "message": "session expired"},
+				})
+				return
+			}
+			s.mu.Unlock()
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "ok",
+				"result": map[string]any{
+					"session_id":     "test-session",
+					"pending_tokens": pt,
+				},
+			})
+			return
+		}
+
+		if r.Method == http.MethodPost && strings.HasSuffix(path, "/commit") {
+			s.mu.Lock()
+			s.commitCount++
+			var body map[string]any
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &body)
+			s.commitBodies = append(s.commitBodies, body)
+			s.mu.Unlock()
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "ok",
+				"result": map[string]any{"task_id": "task-1"},
+			})
+			return
+		}
+	})
+
+	s.Server = httptest.NewServer(mux)
+	return s
+}
+
+// TestStore_SessionReuse: 3 Store calls share one OV session — only 1
+// create request (lazy on first call), no per-call commit.
+func TestStore_SessionReuse(t *testing.T) {
+	srv := newSessionMockServer()
+	defer srv.Close()
+
+	client, err := NewClientWithSession(srv.URL, "", SessionConfig{
+		SessionIDSeed: "/test/config",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mem := NewMemory(client)
+
+	for i := 0; i < 3; i++ {
+		err := mem.Store(context.Background(), ctxpkg.ContextScope{UserID: "alice", SessionID: "conv-1"},
+			ctxpkg.MemoryItem{Content: "fact " + string(rune('A'+i)), Topic: "t"})
+		if err != nil {
+			t.Fatalf("Store[%d]: %v", i, err)
+		}
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if srv.createCount != 1 {
+		t.Errorf("create session count = %d, want 1 (session reused)", srv.createCount)
+	}
+	if srv.commitCount != 0 {
+		t.Errorf("commit count = %d, want 0 (below threshold)", srv.commitCount)
+	}
+	if len(srv.addMsgBodies) != 3 {
+		t.Errorf("add_message count = %d, want 3", len(srv.addMsgBodies))
+	}
+}
+
+// TestStore_NoCommitBelowThreshold: pending_tokens below the token
+// threshold and message count below the message threshold → no commit.
+func TestStore_NoCommitBelowThreshold(t *testing.T) {
+	srv := newSessionMockServer()
+	defer srv.Close()
+	srv.mu.Lock()
+	srv.pendingTokens = 25000 // below default 30000
+	srv.mu.Unlock()
+
+	client, _ := NewClientWithSession(srv.URL, "", SessionConfig{
+		SessionIDSeed: "/test/config",
+		// defaults: token=30000, msg=20
+	})
+	mem := NewMemory(client)
+
+	err := mem.Store(context.Background(), ctxpkg.ContextScope{SessionID: "conv-1"}, ctxpkg.MemoryItem{Content: "some fact"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if srv.commitCount != 0 {
+		t.Errorf("commit count = %d, want 0 (below threshold)", srv.commitCount)
+	}
+}
+
+// TestStore_CommitAtTokenThreshold: pending_tokens >= threshold → commit
+// with WM v2 retention parameters.
+func TestStore_CommitAtTokenThreshold(t *testing.T) {
+	srv := newSessionMockServer()
+	defer srv.Close()
+	srv.mu.Lock()
+	srv.pendingTokens = 30000 // exactly at threshold
+	srv.mu.Unlock()
+
+	client, _ := NewClientWithSession(srv.URL, "", SessionConfig{
+		SessionIDSeed:     "/test/config",
+		MinCommitInterval: 1 * time.Millisecond, // avoid interval blocking
+	})
+	mem := NewMemory(client)
+
+	err := mem.Store(context.Background(), ctxpkg.ContextScope{SessionID: "conv-1"}, ctxpkg.MemoryItem{Content: "trigger commit"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if srv.commitCount != 1 {
+		t.Fatalf("commit count = %d, want 1", srv.commitCount)
+	}
+	body := srv.commitBodies[0]
+	if body["retention_mode"] != "turn_budget" {
+		t.Errorf("retention_mode = %v, want turn_budget", body["retention_mode"])
+	}
+	if body["keep_recent_turn_count"] != float64(3) {
+		t.Errorf("keep_recent_turn_count = %v, want 3", body["keep_recent_turn_count"])
+	}
+	if body["retained_message_token_budget"] != float64(6000) {
+		t.Errorf("retained_message_token_budget = %v, want 6000", body["retained_message_token_budget"])
+	}
+	if body["min_raw_tail_steps"] != float64(1) {
+		t.Errorf("min_raw_tail_steps = %v, want 1", body["min_raw_tail_steps"])
+	}
+}
+
+// TestStore_CommitAtMessageThreshold: message count reaches the
+// threshold even when pending_tokens is low.
+func TestStore_CommitAtMessageThreshold(t *testing.T) {
+	srv := newSessionMockServer()
+	defer srv.Close()
+	srv.mu.Lock()
+	srv.pendingTokens = 100 // well below 30000
+	srv.mu.Unlock()
+
+	client, _ := NewClientWithSession(srv.URL, "", SessionConfig{
+		SessionIDSeed:          "/test/config",
+		CommitMessageThreshold: 3, // low for fast test
+		MinCommitInterval:      1 * time.Millisecond,
+	})
+	mem := NewMemory(client)
+
+	for i := 0; i < 3; i++ {
+		err := mem.Store(context.Background(), ctxpkg.ContextScope{SessionID: "conv-1"},
+			ctxpkg.MemoryItem{Content: "fact", Topic: "t"})
+		if err != nil {
+			t.Fatalf("Store[%d]: %v", i, err)
+		}
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if srv.commitCount != 1 {
+		t.Errorf("commit count = %d, want 1 (message threshold)", srv.commitCount)
+	}
+}
+
+// TestStore_MinInterval: a second commit within MinCommitInterval is
+// suppressed even if the threshold is crossed.
+func TestStore_MinInterval(t *testing.T) {
+	srv := newSessionMockServer()
+	defer srv.Close()
+	srv.mu.Lock()
+	srv.pendingTokens = 30000
+	srv.mu.Unlock()
+
+	client, _ := NewClientWithSession(srv.URL, "", SessionConfig{
+		SessionIDSeed:     "/test/config",
+		MinCommitInterval: 10 * time.Second, // long interval to suppress second commit
+	})
+	mem := NewMemory(client)
+
+	// First store: triggers commit (pending >= 30000).
+	_ = mem.Store(context.Background(), ctxpkg.ContextScope{SessionID: "conv-1"}, ctxpkg.MemoryItem{Content: "first"})
+
+	// Second store: pending still 30000, but within interval → no commit.
+	_ = mem.Store(context.Background(), ctxpkg.ContextScope{SessionID: "conv-1"}, ctxpkg.MemoryItem{Content: "second"})
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if srv.commitCount != 1 {
+		t.Errorf("commit count = %d, want 1 (second suppressed by interval)", srv.commitCount)
+	}
+}
+
+// TestStore_PeerIDAndRole: add_message includes peer_id from scope.UserID
+// and role="assistant" (knowledge is agent-extracted, not user input).
+func TestStore_PeerIDAndRole(t *testing.T) {
+	srv := newSessionMockServer()
+	defer srv.Close()
+
+	client, _ := NewClientWithSession(srv.URL, "", SessionConfig{
+		SessionIDSeed: "/test/config",
+	})
+	mem := NewMemory(client)
+
+	err := mem.Store(context.Background(), ctxpkg.ContextScope{UserID: "alice@example.com", SessionID: "conv-1"},
+		ctxpkg.MemoryItem{Content: "prefers terraform"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if len(srv.addMsgBodies) != 1 {
+		t.Fatalf("add_message count = %d, want 1", len(srv.addMsgBodies))
+	}
+	msgs := srv.addMsgBodies[0]["messages"].([]any)
+	msg := msgs[0].(map[string]any)
+	if msg["role"] != "assistant" {
+		t.Errorf("role = %v, want assistant", msg["role"])
+	}
+	if msg["peer_id"] != "alice@example.com" {
+		t.Errorf("peer_id = %v, want alice@example.com", msg["peer_id"])
+	}
+}
+
+// TestStore_CrashRecovery: on startup, GET session returns
+// pending_tokens > 0 → client commits the leftovers before proceeding.
+func TestStore_CrashRecovery(t *testing.T) {
+	srv := newSessionMockServer()
+	defer srv.Close()
+	srv.mu.Lock()
+	srv.sessionExists = true
+	srv.pendingTokens = 8000 // leftover from a crashed process
+	srv.mu.Unlock()
+
+	client, _ := NewClientWithSession(srv.URL, "", SessionConfig{
+		SessionIDSeed: "/test/config",
+	})
+	ovSID := client.SessionIDFor("conv-1")
+
+	// Trigger ensureSession by calling AddMessage.
+	_, err := client.AddMessage(context.Background(), "assistant", "new message", "", ovSID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	// GET happened (crash recovery check), then commit happened (leftover flush).
+	if srv.getCount != 1 {
+		t.Errorf("GET session count = %d, want 1", srv.getCount)
+	}
+	if srv.commitCount < 1 {
+		t.Errorf("commit count = %d, want >= 1 (crash recovery)", srv.commitCount)
+	}
+}
+
+// TestStore_SessionNotFound: GET returns 404 → POST creates a new session.
+func TestStore_SessionNotFound(t *testing.T) {
+	srv := newSessionMockServer()
+	defer srv.Close()
+	srv.mu.Lock()
+	srv.sessionExists = false // 404 on GET
+	srv.mu.Unlock()
+
+	client, _ := NewClientWithSession(srv.URL, "", SessionConfig{
+		SessionIDSeed: "/test/config",
+	})
+	ovSID := client.SessionIDFor("conv-1")
+
+	_, err := client.AddMessage(context.Background(), "assistant", "hello", "", ovSID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if srv.createCount != 1 {
+		t.Errorf("create session count = %d, want 1 (after 404)", srv.createCount)
+	}
+}
+
+// TestStore_AddMessage404Retry: add_message returns 404 (session expired)
+// → client resets sessionID, recreates, and retries successfully.
+func TestStore_AddMessage404Retry(t *testing.T) {
+	srv := newSessionMockServer()
+	defer srv.Close()
+	srv.mu.Lock()
+	srv.sessionExists = true // ensureSession succeeds
+	srv.addMsgStatus = 404   // first add_message returns 404
+	srv.mu.Unlock()
+
+	client, _ := NewClientWithSession(srv.URL, "", SessionConfig{
+		SessionIDSeed: "/test/config",
+	})
+	ovSID := client.SessionIDFor("conv-1")
+
+	_, err := client.AddMessage(context.Background(), "assistant", "retry me", "", ovSID)
+	if err != nil {
+		t.Fatalf("AddMessage should succeed after retry, got: %v", err)
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	// First add_message failed (404), second succeeded after session recreation.
+	if srv.addMsgCallCount != 2 {
+		t.Errorf("add_message call count = %d, want 2 (original + retry)", srv.addMsgCallCount)
+	}
+}
+
+// TestStore_Flush: Flush forces a commit even below threshold.
+func TestStore_Flush(t *testing.T) {
+	srv := newSessionMockServer()
+	defer srv.Close()
+	srv.mu.Lock()
+	srv.pendingTokens = 100 // well below 30000
+	srv.mu.Unlock()
+
+	client, _ := NewClientWithSession(srv.URL, "", SessionConfig{
+		SessionIDSeed: "/test/config",
+	})
+	mem := NewMemory(client)
+	ovSID := client.SessionIDFor("conv-1")
+
+	// Add a message (below threshold, no commit). Uses AddMessage (not
+	// Store) to isolate the Flush trigger: Store would also call
+	// MaybeCommit, but since pending_tokens=100 < 30000, it's a no-op
+	// anyway — AddMessage alone is sufficient and more precise.
+	_, _ = mem.client.AddMessage(context.Background(), "assistant", "pending", "", ovSID)
+
+	srv.mu.Lock()
+	if srv.commitCount != 0 {
+		srv.mu.Unlock()
+		t.Fatalf("pre-Flush commit count = %d, want 0", srv.commitCount)
+	}
+	srv.mu.Unlock()
+
+	// Flush forces commit.
+	if err := client.Flush(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if srv.commitCount != 1 {
+		t.Errorf("post-Flush commit count = %d, want 1", srv.commitCount)
+	}
+}
+
+// TestStore_MemoryPolicyAtCreation: POST /sessions includes memory_policy
+// with self=false, peer=true (assistant role).
+func TestStore_MemoryPolicyAtCreation(t *testing.T) {
+	// We need to capture the create body — extend the mock inline.
+	var createBody map[string]any
+
+	// Use a custom handler to capture the create body.
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/sessions" {
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &createBody)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "ok",
+				"result": map[string]any{"session_id": "test-session"},
+			})
+			return
+		}
+		if r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/v1/sessions/") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "error",
+				"error":  map[string]any{"code": "NOT_FOUND", "message": "not found"},
+			})
+			return
+		}
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/messages/batch") {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "ok",
+				"result": map[string]any{"pending_tokens": 100},
+			})
+			return
+		}
+	}))
+	defer srv2.Close()
+
+	client, _ := NewClientWithSession(srv2.URL, "", SessionConfig{
+		SessionIDSeed: "/test/config",
+	})
+	ovSID := client.SessionIDFor("conv-1")
+
+	_, err := client.AddMessage(context.Background(), "assistant", "msg", "", ovSID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if createBody == nil {
+		t.Fatal("create session body not captured")
+	}
+	mp, ok := createBody["memory_policy"].(map[string]any)
+	if !ok {
+		t.Fatalf("memory_policy not in create body: %v", createBody)
+	}
+	self, ok := mp["self"].(map[string]any)
+	if !ok || self["enabled"] != false {
+		t.Errorf("memory_policy.self.enabled = %v, want false", self["enabled"])
+	}
+	peer, ok := mp["peer"].(map[string]any)
+	if !ok || peer["enabled"] != true {
+		t.Errorf("memory_policy.peer.enabled = %v, want true", peer["enabled"])
+	}
+}
+
+// TestStore_PerConversationSessions: two different SessionIDs produce
+// two separate OV sessions — each conversation gets its own session.
+func TestStore_PerConversationSessions(t *testing.T) {
+	srv := newSessionMockServer()
+	defer srv.Close()
+
+	client, _ := NewClientWithSession(srv.URL, "", SessionConfig{
+		SessionIDSeed: "/test/config",
+	})
+	mem := NewMemory(client)
+
+	// Conversation A
+	_ = mem.Store(context.Background(), ctxpkg.ContextScope{UserID: "alice", SessionID: "conv-a"},
+		ctxpkg.MemoryItem{Content: "fact A", Topic: "t"})
+	// Conversation B
+	_ = mem.Store(context.Background(), ctxpkg.ContextScope{UserID: "alice", SessionID: "conv-b"},
+		ctxpkg.MemoryItem{Content: "fact B", Topic: "t"})
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if srv.createCount != 2 {
+		t.Errorf("create session count = %d, want 2 (one per conversation)", srv.createCount)
+	}
+	if len(srv.addMsgBodies) != 2 {
+		t.Errorf("add_message count = %d, want 2", len(srv.addMsgBodies))
+	}
+}
+
+// TestStore_LegacyFallback: SessionIDSeed empty → Remember uses legacy
+// per-call create+commit (no session reuse).
+func TestStore_LegacyFallback(t *testing.T) {
+	srv := newSessionMockServer()
+	defer srv.Close()
+
+	// NewClient(endpoint, apiKey): second arg is the API key (empty = no
+	// auth, fine for the mock server). No SessionIDSeed → legacy mode.
+	client, _ := NewClient(srv.URL, "") // legacy: no SessionIDSeed
+
+	for i := 0; i < 2; i++ {
+		_, err := client.Remember(context.Background(), "legacy fact "+string(rune('A'+i)))
+		if err != nil {
+			t.Fatalf("Remember[%d]: %v", i, err)
+		}
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	// Legacy mode: each call creates its own session + commits.
+	if srv.createCount != 2 {
+		t.Errorf("create session count = %d, want 2 (legacy per-call)", srv.createCount)
+	}
+	if srv.commitCount != 2 {
+		t.Errorf("commit count = %d, want 2 (legacy per-call)", srv.commitCount)
 	}
 }


### PR DESCRIPTION
The OpenViking memory provider created a new OV session and committed
immediately on every Store() call, causing:
  - N sessions for N knowledge items (73/3h in production)
  - N VLM extractions at ~21K tokens each (1.1M tokens/3h)
  - VLM concurrency pressure → 504 timeouts → memory loss
  - task backlog (12 pending commits)

Fix — per-conversation session reuse + threshold commit:
  - Client maintains one OV session per conversation, derived from
    sha256(seed + "/" + conversationID). Each conversation gets its
    own OV session so VLM extraction sees a coherent context.
  - SessionIDFor(conversationID) public method; Store() routes via
    scope.SessionID (kernel now populates it in the extractor scope).
  - AddMessage appends to the per-conversation session; MaybeCommit
    checks token threshold (30000) + message-count fallback (20) +
    min interval (5m) before committing — per OV team recommendation.
  - WM v2 retention: retention_mode=turn_budget, keep_recent_turn_count=3,
    retained_message_token_budget=6000, min_raw_tail_steps=1
  - memory_policy: {self:false, peer:true} at session creation
  - peer_id from scope.UserID on each message
  - Crash recovery: on startup, GET session → pending>0 → commit
  - 404 handling: expired session → delete from map → recreate → retry
  - Flush() on shutdown iterates all sessions with pending messages
  - AsyncExtractor coalesce key: UserID+"/"+SessionID (per-conversation)
  - Legacy mode preserved: NewClient (no seed) → per-call create+commit
  - Remember() deprecated, delegates to AddMessage + MaybeCommit

A/B test (10 Store calls, 2 conversations, OV v0.4.19):
  Sessions:   10 → 2  (5x)
  Commits:    14 → 2  (7x, Flush only)
  VLM tokens: ~294K → ~42K (7x)
  Time:       2.37s → 0.47s (5.1x)

Thresholds align with OpenViking team recommendation for
knowledge-fragment stores. Configurable via openviking.session in
settings.json.

Note: double-extraction (local LLM + server VLM) is not addressed —
the extractor still stores knowledge fragments, not raw conversation.
VLM extraction quality remains 0 until a second layer syncs original
user+assistant messages to the OV session.